### PR TITLE
fix(trackers): Fix tracker-id asignment logic

### DIFF
--- a/trackers/core/sort/kalman_box_tracker.py
+++ b/trackers/core/sort/kalman_box_tracker.py
@@ -27,12 +27,17 @@ class SORTKalmanBoxTracker:
     """
 
     count = 0
+    
+    @classmethod
+    def get_next_id(cls) -> int:
+        next_id = cls.count
+        cls.count += 1
+        return next_id
 
     def __init__(self, bbox: np.ndarray) -> None:
         # Initialize with a temporary ID of -1
         # Will be assigned a real ID when the track is considered mature
         self.id = -1
-        self.real_id = None
 
         # Number of hits indicates how many times the object has been
         # updated successfully

--- a/trackers/core/sort/kalman_box_tracker.py
+++ b/trackers/core/sort/kalman_box_tracker.py
@@ -32,8 +32,7 @@ class SORTKalmanBoxTracker:
         # Initialize with a temporary ID of -1
         # Will be assigned a real ID when the track is considered mature
         self.id = -1
-        self.real_id = SORTKalmanBoxTracker.count
-        SORTKalmanBoxTracker.count += 1
+        self.real_id = None
 
         # Number of hits indicates how many times the object has been
         # updated successfully

--- a/trackers/core/sort/kalman_box_tracker.py
+++ b/trackers/core/sort/kalman_box_tracker.py
@@ -27,7 +27,7 @@ class SORTKalmanBoxTracker:
     """
 
     count = 0
-    
+
     @classmethod
     def get_next_id(cls) -> int:
         next_id = cls.count

--- a/trackers/core/sort/kalman_box_tracker.py
+++ b/trackers/core/sort/kalman_box_tracker.py
@@ -29,8 +29,10 @@ class SORTKalmanBoxTracker:
     count = 0
 
     def __init__(self, bbox: np.ndarray) -> None:
-        # Each track gets a unique ID
-        self.id = SORTKalmanBoxTracker.count
+        # Initialize with a temporary ID of -1
+        # Will be assigned a real ID when the track is considered mature
+        self.id = -1
+        self.real_id = SORTKalmanBoxTracker.count
         SORTKalmanBoxTracker.count += 1
 
         # Number of hits indicates how many times the object has been

--- a/trackers/utils/sort_utils.py
+++ b/trackers/utils/sort_utils.py
@@ -123,14 +123,9 @@ def update_detections_with_track_ids(
             # Only assign if the track is "mature" or is new but has enough hits
             if (row not in used_rows) and (col not in used_cols):
                 if tracker_obj.hits >= minimum_consecutive_frames:
-                    # If tracker is mature but still has ID -1, assign its real ID
+                    # If tracker is mature but still has ID -1, assign a new ID
                     if tracker_obj.id == -1:
-                        # Assign a new ID only when the track matures
-                        if tracker_obj.real_id is None:
-                            tracker_obj.real_id = SORTKalmanBoxTracker.count
-                            SORTKalmanBoxTracker.count += 1
-                        tracker_obj.id = tracker_obj.real_id
-                    # Assign the tracker ID to the detection
+                        tracker_obj.id = SORTKalmanBoxTracker.get_next_id()
                     final_tracker_ids[col] = tracker_obj.id
                 used_rows.add(row)
                 used_cols.add(col)

--- a/trackers/utils/sort_utils.py
+++ b/trackers/utils/sort_utils.py
@@ -125,6 +125,10 @@ def update_detections_with_track_ids(
                 if tracker_obj.hits >= minimum_consecutive_frames:
                     # If tracker is mature but still has ID -1, assign its real ID
                     if tracker_obj.id == -1:
+                        # Assign a new ID only when the track matures
+                        if tracker_obj.real_id is None:
+                            tracker_obj.real_id = SORTKalmanBoxTracker.count
+                            SORTKalmanBoxTracker.count += 1
                         tracker_obj.id = tracker_obj.real_id
                     # Assign the tracker ID to the detection
                     final_tracker_ids[col] = tracker_obj.id

--- a/trackers/utils/sort_utils.py
+++ b/trackers/utils/sort_utils.py
@@ -123,6 +123,10 @@ def update_detections_with_track_ids(
             # Only assign if the track is "mature" or is new but has enough hits
             if (row not in used_rows) and (col not in used_cols):
                 if tracker_obj.hits >= minimum_consecutive_frames:
+                    # If tracker is mature but still has ID -1, assign its real ID
+                    if tracker_obj.id == -1:
+                        tracker_obj.id = tracker_obj.real_id
+                    # Assign the tracker ID to the detection
                     final_tracker_ids[col] = tracker_obj.id
                 used_rows.add(row)
                 used_cols.add(col)


### PR DESCRIPTION
# Description

Fix the logic of assignment of tracker ID at the time of maturity as per https://github.com/roboflow/trackers/pull/6#discussion_r2038768232

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update