### PR TITLE
fix(trackers): optional import bug for deepsort

### DIFF
--- a/trackers/core/deepsort/feature_extractor.py
+++ b/trackers/core/deepsort/feature_extractor.py
@@ -6,7 +6,6 @@ import timm
 import torch
 import torch.nn as nn
 import torchvision.transforms as transforms
-import validators
 from firerequests import FireRequests
 
 from trackers.utils.torch_utils import parse_device_spec
@@ -106,6 +105,8 @@ class DeepSORTFeatureExtractor:
         self, model_or_checkpoint_path: Union[str, torch.nn.Module, None]
     ):
         if isinstance(model_or_checkpoint_path, str):
+            import validators
+
             if validators.url(model_or_checkpoint_path):
                 checkpoint_path = FireRequests().download(model_or_checkpoint_path)[0]
                 self._load_model_from_path(checkpoint_path)


### PR DESCRIPTION
# Description

If we have tracker-specific dependencies in corresponding extras, we won't be able to simplify imports like this
In the existing way, if the extra `deepsort` has some exclusive dependencies, then when I import `SORTTracker` , we'll get an import error.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

TBD