### PR TITLE
Update from_timm from feature_extractor of DeepSORT

### DIFF
--- a/trackers/core/deepsort/feature_extractor.py
+++ b/trackers/core/deepsort/feature_extractor.py
@@ -99,7 +99,7 @@ class DeepSORTFeatureExtractor:
             )
         if not get_pooled_features:
             kwargs["global_pool"] = ""
-        model = timm.create_model(model_name, num_classes=0, **kwargs)
+        model = timm.create_model(model_name, pretrained = pretrained, num_classes=0, **kwargs)
         backbone_model = FeatureExtractionBackbone(model)
         return cls(backbone_model, device, input_size)
 

--- a/trackers/core/deepsort/feature_extractor.py
+++ b/trackers/core/deepsort/feature_extractor.py
@@ -99,7 +99,9 @@ class DeepSORTFeatureExtractor:
             )
         if not get_pooled_features:
             kwargs["global_pool"] = ""
-        model = timm.create_model(model_name, pretrained = pretrained, num_classes=0, **kwargs)
+        model = timm.create_model(
+            model_name, pretrained=pretrained, num_classes=0, **kwargs
+        )
         backbone_model = FeatureExtractionBackbone(model)
         return cls(backbone_model, device, input_size)
 


### PR DESCRIPTION
# Description

The argumented pretrained was not read when it was passed by **kwargs, I had to specify pretrained = pretrained in order to get a pretrained model.

List any dependencies that are required for this change.


-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

By printing the distance matrix between features, it has some meaningful values only when calling it like I propose. I invite you to print out the appearance distance matrix in _get_associated_indices

