### PR TITLE
chore(dependabot): update configuration for GitHub Actions and Python package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: ⬆️
-    target-branch: "develop"
+    target-branch: "main"
   # Python
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: ⬆️
-    target-branch: "develop"
+    target-branch: "main"


### PR DESCRIPTION
Dependabot support landed for uv lock file. Finally uv lock file now update automatically. 
Example pull requests : https://github.com/onuralpszr/trackers/pulls.


