### PR TITLE
Adding OC-Sort Tracker

### DIFF
--- a/trackers/__init__.py
+++ b/trackers/__init__.py
@@ -1,8 +1,8 @@
-from trackers.core.sort.tracker import SORTTracker
 from trackers.core.ocsort.tracker import OCSORTTracker
+from trackers.core.sort.tracker import SORTTracker
 from trackers.log import get_logger
 
-__all__ = ["SORTTracker", "OCSORTTracker"]
+__all__ = ["OCSORTTracker", "SORTTracker"]
 
 logger = get_logger(__name__)
 
@@ -11,7 +11,7 @@ try:
     from trackers.core.ocsort.tracker import OCSORTTracker
     from trackers.core.reid.model import ReIDModel
 
-    __all__.extend(["DeepSORTTracker", "ReIDModel", "OCSORTTracker"])
+    __all__.extend(["DeepSORTTracker", "OCSORTTracker", "ReIDModel"])
 except ImportError:
     logger.warning(
         "ReIDModel dependencies not installed. ReIDModel will not be available. "

--- a/trackers/__init__.py
+++ b/trackers/__init__.py
@@ -1,15 +1,17 @@
 from trackers.core.sort.tracker import SORTTracker
+from trackers.core.ocsort.tracker import OCSORTTracker
 from trackers.log import get_logger
 
-__all__ = ["SORTTracker"]
+__all__ = ["SORTTracker", "OCSORTTracker"]
 
 logger = get_logger(__name__)
 
 try:
     from trackers.core.deepsort.tracker import DeepSORTTracker
+    from trackers.core.ocsort.tracker import OCSORTTracker
     from trackers.core.reid.model import ReIDModel
 
-    __all__.extend(["DeepSORTTracker", "ReIDModel"])
+    __all__.extend(["DeepSORTTracker", "ReIDModel", "OCSORTTracker"])
 except ImportError:
     logger.warning(
         "ReIDModel dependencies not installed. ReIDModel will not be available. "

--- a/trackers/core/ocsort/association.py
+++ b/trackers/core/ocsort/association.py
@@ -1,0 +1,515 @@
+"""
+Reference Link : https://github.com/noahcao/OC_SORT/blob/master/trackers/ocsort_tracker/association.py
+"""
+
+import os
+from typing import Tuple
+import numpy as np
+
+
+def iou_batch(bboxes1 : np.ndarray, bboxes2 : np.ndarray) -> np.ndarray:
+    """
+    Computes the Intersection over Union (IoU) between two batches of bounding boxes.
+
+    Each bounding box should be in the format [x1, y1, x2, y2], where:
+        - (x1, y1): Top-left corner
+        - (x2, y2): Bottom-right corner
+
+    Args:
+        bboxes1 (np.ndarray): An array of shape (N, 4) representing N bounding boxes.
+        bboxes2 (np.ndarray): An array of shape (M, 4) representing M bounding boxes.
+
+    Returns:
+        np.ndarray: A matrix of shape (N, M) where the element at [i, j] is the IoU 
+                    between `bboxes1[i]` and `bboxes2[j]`.
+    """
+    bboxes2 = np.expand_dims(bboxes2, 0)
+    bboxes1 = np.expand_dims(bboxes1, 1)
+    
+    xx1 = np.maximum(bboxes1[..., 0], bboxes2[..., 0])
+    yy1 = np.maximum(bboxes1[..., 1], bboxes2[..., 1])
+    xx2 = np.minimum(bboxes1[..., 2], bboxes2[..., 2])
+    yy2 = np.minimum(bboxes1[..., 3], bboxes2[..., 3])
+    w = np.maximum(0., xx2 - xx1)
+    h = np.maximum(0., yy2 - yy1)
+    wh = w * h
+    o = wh / ((bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])                                      
+        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1]) - wh)                                              
+    return(o)  
+
+
+def giou_batch(
+    bboxes1 : np.ndarray, 
+    bboxes2 : np.ndarray
+) -> np.ndarray:
+    """
+    Computes the Generalized Intersection over Union (GIoU) between two batches of bounding boxes.
+
+    GIoU extends the traditional IoU metric by accounting for non-overlapping areas,
+    improving gradient behavior when boxes do not intersect.
+
+    Args:
+        bboxes1 (np.ndarray): Predicted bounding boxes of shape (N, 4), where each box is in 
+                              [x1, y1, x2, y2] format.
+        bboxes2 (np.ndarray): Ground truth bounding boxes of shape (N, 4), same format as `bboxes1`.
+
+    Returns:
+        np.ndarray: A 1D array of shape (N,) where each element is the GIoU between 
+                    the corresponding pair of boxes from `bboxes1` and `bboxes2`.
+    """
+    # for details should go to https://arxiv.org/pdf/1902.09630.pdf
+    # ensure predict's bbox form
+    bboxes2 = np.expand_dims(bboxes2, 0)
+    bboxes1 = np.expand_dims(bboxes1, 1)
+
+    xx1 = np.maximum(bboxes1[..., 0], bboxes2[..., 0])
+    yy1 = np.maximum(bboxes1[..., 1], bboxes2[..., 1])
+    xx2 = np.minimum(bboxes1[..., 2], bboxes2[..., 2])
+    yy2 = np.minimum(bboxes1[..., 3], bboxes2[..., 3])
+    w = np.maximum(0., xx2 - xx1)
+    h = np.maximum(0., yy2 - yy1)
+    wh = w * h
+    union = ((bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])                                      
+        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1]) - wh)  
+    iou = wh / union
+
+    xxc1 = np.minimum(bboxes1[..., 0], bboxes2[..., 0])
+    yyc1 = np.minimum(bboxes1[..., 1], bboxes2[..., 1])
+    xxc2 = np.maximum(bboxes1[..., 2], bboxes2[..., 2])
+    yyc2 = np.maximum(bboxes1[..., 3], bboxes2[..., 3])
+    wc = xxc2 - xxc1 
+    hc = yyc2 - yyc1 
+    assert((wc > 0).all() and (hc > 0).all())
+    area_enclose = wc * hc 
+    giou = iou - (area_enclose - union) / area_enclose
+    giou = (giou + 1.)/2.0 # resize from (-1,1) to (0,1)
+    return giou
+
+
+def diou_batch(
+    bboxes1 : np.ndarray, 
+    bboxes2 : np.ndarray
+) -> np.ndarray:
+    """
+    Computes the Distance-IoU (DIoU) between two batches of bounding boxes.
+
+    DIoU improves IoU-based loss by incorporating the normalized distance between 
+    the centers of the predicted and ground truth boxes, encouraging faster convergence.
+
+    Args:
+        bboxes1 (np.ndarray): Predicted bounding boxes of shape (N, 4), 
+                              each in [x1, y1, x2, y2] format.
+        bboxes2 (np.ndarray): Ground truth bounding boxes of shape (N, 4), 
+                              each in [x1, y1, x2, y2] format.
+
+    Returns:
+        np.ndarray: A 1D array of shape (N,) containing the DIoU value for each 
+                    pair of predicted and ground truth boxes.
+    """
+    # for details should go to https://arxiv.org/pdf/1902.09630.pdf
+    # ensure predict's bbox form
+    bboxes2 = np.expand_dims(bboxes2, 0)
+    bboxes1 = np.expand_dims(bboxes1, 1)
+
+    # calculate the intersection box
+    xx1 = np.maximum(bboxes1[..., 0], bboxes2[..., 0])
+    yy1 = np.maximum(bboxes1[..., 1], bboxes2[..., 1])
+    xx2 = np.minimum(bboxes1[..., 2], bboxes2[..., 2])
+    yy2 = np.minimum(bboxes1[..., 3], bboxes2[..., 3])
+    w = np.maximum(0., xx2 - xx1)
+    h = np.maximum(0., yy2 - yy1)
+    wh = w * h
+    union = ((bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])                                      
+        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1]) - wh) 
+    iou = wh / union
+    centerx1 = (bboxes1[..., 0] + bboxes1[..., 2]) / 2.0
+    centery1 = (bboxes1[..., 1] + bboxes1[..., 3]) / 2.0
+    centerx2 = (bboxes2[..., 0] + bboxes2[..., 2]) / 2.0
+    centery2 = (bboxes2[..., 1] + bboxes2[..., 3]) / 2.0
+
+    inner_diag = (centerx1 - centerx2) ** 2 + (centery1 - centery2) ** 2
+
+    xxc1 = np.minimum(bboxes1[..., 0], bboxes2[..., 0])
+    yyc1 = np.minimum(bboxes1[..., 1], bboxes2[..., 1])
+    xxc2 = np.maximum(bboxes1[..., 2], bboxes2[..., 2])
+    yyc2 = np.maximum(bboxes1[..., 3], bboxes2[..., 3])
+
+    outer_diag = (xxc2 - xxc1) ** 2 + (yyc2 - yyc1) ** 2
+    diou = iou - inner_diag / outer_diag
+
+    return (diou + 1) / 2.0 # resize from (-1,1) to (0,1)
+
+def ciou_batch(
+    bboxes1 : np.ndarray, 
+    bboxes2 : np.ndarray
+) -> np.ndarray:
+    """
+    Computes the Complete IoU (CIoU) between two batches of bounding boxes.
+
+    CIoU builds upon DIoU by incorporating aspect ratio consistency along with 
+    overlap area and center distance, making it more robust for bounding box regression.
+
+    Args:
+        bboxes1 (np.ndarray): Predicted bounding boxes of shape (N, 4), 
+                              where each box is in [x1, y1, x2, y2] format.
+        bboxes2 (np.ndarray): Ground truth bounding boxes of shape (N, 4), 
+                              where each box is in [x1, y1, x2, y2] format.
+
+    Returns:
+        np.ndarray: A 1D array of shape (N,) containing the CIoU values for each 
+                    corresponding pair of predicted and ground truth boxes.
+    """
+    # for details should go to https://arxiv.org/pdf/1902.09630.pdf
+    # ensure predict's bbox form
+    bboxes2 = np.expand_dims(bboxes2, 0)
+    bboxes1 = np.expand_dims(bboxes1, 1)
+
+    # calculate the intersection box
+    xx1 = np.maximum(bboxes1[..., 0], bboxes2[..., 0])
+    yy1 = np.maximum(bboxes1[..., 1], bboxes2[..., 1])
+    xx2 = np.minimum(bboxes1[..., 2], bboxes2[..., 2])
+    yy2 = np.minimum(bboxes1[..., 3], bboxes2[..., 3])
+    w = np.maximum(0., xx2 - xx1)
+    h = np.maximum(0., yy2 - yy1)
+    wh = w * h
+    union = ((bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])                                      
+        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1]) - wh) 
+    iou = wh / union
+
+    centerx1 = (bboxes1[..., 0] + bboxes1[..., 2]) / 2.0
+    centery1 = (bboxes1[..., 1] + bboxes1[..., 3]) / 2.0
+    centerx2 = (bboxes2[..., 0] + bboxes2[..., 2]) / 2.0
+    centery2 = (bboxes2[..., 1] + bboxes2[..., 3]) / 2.0
+
+    inner_diag = (centerx1 - centerx2) ** 2 + (centery1 - centery2) ** 2
+
+    xxc1 = np.minimum(bboxes1[..., 0], bboxes2[..., 0])
+    yyc1 = np.minimum(bboxes1[..., 1], bboxes2[..., 1])
+    xxc2 = np.maximum(bboxes1[..., 2], bboxes2[..., 2])
+    yyc2 = np.maximum(bboxes1[..., 3], bboxes2[..., 3])
+
+    outer_diag = (xxc2 - xxc1) ** 2 + (yyc2 - yyc1) ** 2
+    
+    w1 = bboxes1[..., 2] - bboxes1[..., 0]
+    h1 = bboxes1[..., 3] - bboxes1[..., 1]
+    w2 = bboxes2[..., 2] - bboxes2[..., 0]
+    h2 = bboxes2[..., 3] - bboxes2[..., 1]
+
+    # prevent dividing over zero. add one pixel shift
+    h2 = h2 + 1.
+    h1 = h1 + 1.
+    arctan = np.arctan(w2/h2) - np.arctan(w1/h1)
+    v = (4 / (np.pi ** 2)) * (arctan ** 2)
+    S = 1 - iou 
+    alpha = v / (S+v)
+    ciou = iou - inner_diag / outer_diag - alpha * v
+    
+    return (ciou + 1) / 2.0 # resize from (-1,1) to (0,1)
+
+
+def ct_dist(
+    bboxes1: np.ndarray, 
+    bboxes2: np.ndarray
+) -> np.ndarray:
+    """
+    Computes a normalized similarity matrix based on center-point distances 
+    between two sets of bounding boxes.
+
+    This function calculates the Euclidean distance between the centers of each 
+    bounding box in `bboxes1` and `bboxes2`, then linearly rescales the values to [0, 1],
+    where 1 represents the closest match (smallest distance) and 0 the farthest.
+
+    Note:
+        This is a coarse metric and may be unstable as a standalone association 
+        criterion, especially under varying frame rates or fast-moving objects.
+
+    Args:
+        bboxes1 (np.ndarray): An array of shape (N, 4), with bounding boxes in 
+                              [x1, y1, x2, y2] format.
+        bboxes2 (np.ndarray): An array of shape (M, 4), with bounding boxes in 
+                              [x1, y1, x2, y2] format.
+
+    Returns:
+        np.ndarray: A (N, M) matrix of normalized center-distance similarity scores 
+                    in the range [0, 1], where higher values indicate closer proximity.
+    """
+
+    bboxes2 = np.expand_dims(bboxes2, 0)
+    bboxes1 = np.expand_dims(bboxes1, 1)
+
+    centerx1 = (bboxes1[..., 0] + bboxes1[..., 2]) / 2.0
+    centery1 = (bboxes1[..., 1] + bboxes1[..., 3]) / 2.0
+    centerx2 = (bboxes2[..., 0] + bboxes2[..., 2]) / 2.0
+    centery2 = (bboxes2[..., 1] + bboxes2[..., 3]) / 2.0
+
+    ct_dist2 = (centerx1 - centerx2) ** 2 + (centery1 - centery2) ** 2
+
+    ct_dist = np.sqrt(ct_dist2)
+
+    # The linear rescaling is a naive version and needs more study
+    ct_dist = ct_dist / ct_dist.max()
+    return ct_dist.max() - ct_dist # resize to (0,1)
+
+
+def speed_direction_batch(
+    dets : np.ndarray, 
+    tracks : np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Computes normalized direction vectors (dy, dx) from tracks to detections.
+
+    For each pair of detection and track, this function computes the direction vector 
+    from the center of the track bounding box to the center of the detection bounding box,
+    and normalizes it to unit length.
+
+    Args:
+        dets (np.ndarray): Array of detection bounding boxes with shape (N, 4), 
+                           in [x1, y1, x2, y2] format.
+        tracks (np.ndarray): Array of track bounding boxes with shape (M, 4), 
+                             in [x1, y1, x2, y2] format.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: Two arrays of shape (M, N) representing:
+            - dy: Normalized vertical component of the direction vector.
+            - dx: Normalized horizontal component of the direction vector.
+    """
+    tracks = tracks[..., np.newaxis]
+    CX1, CY1 = (dets[:,0] + dets[:,2])/2.0, (dets[:,1]+dets[:,3])/2.0
+    CX2, CY2 = (tracks[:,0] + tracks[:,2]) /2.0, (tracks[:,1]+tracks[:,3])/2.0
+    dx = CX1 - CX2 
+    dy = CY1 - CY2 
+    norm = np.sqrt(dx**2 + dy**2) + 1e-6
+    dx = dx / norm 
+    dy = dy / norm
+    return dy, dx # size: num_track x num_det
+
+
+def linear_assignment(cost_matrix : np.ndarray) -> np.ndarray:
+    """
+    Solves the linear assignment problem (also known as the Hungarian algorithm)
+    to find the optimal one-to-one assignment with minimum total cost.
+
+    This function attempts to use the `lap` library (LAPJV algorithm) for efficient 
+    computation. If unavailable, it falls back to `scipy.optimize.linear_sum_assignment`.
+
+    Args:
+        cost_matrix (np.ndarray): A 2D array of shape (N, M) representing the cost 
+                                  of assigning each row to each column.
+
+    Returns:
+        np.ndarray: An array of shape (K, 2), where each row is a pair [row_index, col_index] 
+                    indicating an optimal assignment. K ≤ min(N, M).
+    """
+    try:
+        import lap
+        _, x, y = lap.lapjv(cost_matrix, extend_cost=True)
+        return np.array([[y[i],i] for i in x if i >= 0]) #
+    except ImportError:
+        from scipy.optimize import linear_sum_assignment
+        x, y = linear_sum_assignment(cost_matrix)
+        return np.array(list(zip(x, y)))
+
+
+def associate_detections_to_trackers(
+    detections : np.ndarray,
+    trackers : np.ndarray,
+    iou_threshold : float = 0.3
+) -> np.ndarray:
+    """
+    Assigns detections to existing trackers using Intersection over Union (IoU).
+
+    This function computes the IoU between each detection and each tracker, 
+    then solves the assignment problem to match detections to trackers based 
+    on the highest IoU values. Matches with IoU below the threshold are 
+    considered invalid and treated as unmatched.
+
+    Args:
+        detections (np.ndarray): Array of shape (N, 4), representing N detected bounding boxes 
+                                 in [x1, y1, x2, y2] format.
+        trackers (np.ndarray): Array of shape (M, 4), representing M tracker bounding boxes 
+                               in [x1, y1, x2, y2] format.
+        iou_threshold (float, optional): Minimum IoU required to consider a detection-tracker 
+                                         pair as a valid match. Defaults to 0.3.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray, np.ndarray]:
+            - matches: Array of shape (K, 2), each row is a pair [detection_idx, tracker_idx].
+            - unmatched_detections: Array of detection indices that did not match any tracker.
+            - unmatched_trackers: Array of tracker indices that did not match any detection.
+    """
+
+    if(len(trackers)==0):
+        return np.empty((0,2),dtype=int), np.arange(len(detections)), np.empty((0,5),dtype=int)
+
+    iou_matrix = iou_batch(detections, trackers)
+
+    if min(iou_matrix.shape) > 0:
+        a = (iou_matrix > iou_threshold).astype(np.int32)
+        if a.sum(1).max() == 1 and a.sum(0).max() == 1:
+            matched_indices = np.stack(np.where(a), axis=1)
+        else:
+            matched_indices = linear_assignment(-iou_matrix)
+    else:
+        matched_indices = np.empty(shape=(0,2))
+
+    unmatched_detections = []
+    for d, det in enumerate(detections):
+        if(d not in matched_indices[:,0]):
+            unmatched_detections.append(d)
+    unmatched_trackers = []
+    for t, trk in enumerate(trackers):
+        if(t not in matched_indices[:,1]):
+            unmatched_trackers.append(t)
+
+    #filter out matched with low IOU
+    matches = []
+    for m in matched_indices:
+        if(iou_matrix[m[0], m[1]]<iou_threshold):
+            unmatched_detections.append(m[0])
+            unmatched_trackers.append(m[1])
+        else:
+            matches.append(m.reshape(1,2))
+    if(len(matches)==0):
+        matches = np.empty((0,2),dtype=int)
+    else:
+        matches = np.concatenate(matches,axis=0)
+
+    return matches, np.array(unmatched_detections), np.array(unmatched_trackers)
+
+
+def associate(detections, trackers, iou_threshold, velocities, previous_obs, vdc_weight):    
+    if(len(trackers)==0):
+        return np.empty((0,2),dtype=int), np.arange(len(detections)), np.empty((0,5),dtype=int)
+
+    Y, X = speed_direction_batch(detections, previous_obs)
+    inertia_Y, inertia_X = velocities[:,0], velocities[:,1]
+    inertia_Y = np.repeat(inertia_Y[:, np.newaxis], Y.shape[1], axis=1)
+    inertia_X = np.repeat(inertia_X[:, np.newaxis], X.shape[1], axis=1)
+    diff_angle_cos = inertia_X * X + inertia_Y * Y
+    diff_angle_cos = np.clip(diff_angle_cos, a_min=-1, a_max=1)
+    diff_angle = np.arccos(diff_angle_cos)
+    diff_angle = (np.pi /2.0 - np.abs(diff_angle)) / np.pi
+
+    valid_mask = np.ones(previous_obs.shape[0])
+    valid_mask[np.where(previous_obs[:,4]<0)] = 0
+    
+    iou_matrix = iou_batch(detections, trackers)
+    scores = np.repeat(detections[:,-1][:, np.newaxis], trackers.shape[0], axis=1)
+    # iou_matrix = iou_matrix * scores # a trick sometiems works, we don't encourage this
+    valid_mask = np.repeat(valid_mask[:, np.newaxis], X.shape[1], axis=1)
+
+    angle_diff_cost = (valid_mask * diff_angle) * vdc_weight
+    angle_diff_cost = angle_diff_cost.T
+    angle_diff_cost = angle_diff_cost * scores
+
+    if min(iou_matrix.shape) > 0:
+        a = (iou_matrix > iou_threshold).astype(np.int32)
+        if a.sum(1).max() == 1 and a.sum(0).max() == 1:
+            matched_indices = np.stack(np.where(a), axis=1)
+        else:
+            matched_indices = linear_assignment(-(iou_matrix+angle_diff_cost))
+    else:
+        matched_indices = np.empty(shape=(0,2))
+
+    unmatched_detections = []
+    for d, det in enumerate(detections):
+        if(d not in matched_indices[:,0]):
+            unmatched_detections.append(d)
+    unmatched_trackers = []
+    for t, trk in enumerate(trackers):
+        if(t not in matched_indices[:,1]):
+            unmatched_trackers.append(t)
+
+    # filter out matched with low IOU
+    matches = []
+    for m in matched_indices:
+        if(iou_matrix[m[0], m[1]]<iou_threshold):
+            unmatched_detections.append(m[0])
+            unmatched_trackers.append(m[1])
+        else:
+            matches.append(m.reshape(1,2))
+    if(len(matches)==0):
+        matches = np.empty((0,2),dtype=int)
+    else:
+        matches = np.concatenate(matches,axis=0)
+
+    return matches, np.array(unmatched_detections), np.array(unmatched_trackers)
+
+
+def associate_kitti(detections, trackers, det_cates, iou_threshold, 
+        velocities, previous_obs, vdc_weight):
+    if(len(trackers)==0):
+        return np.empty((0,2),dtype=int), np.arange(len(detections)), np.empty((0,5),dtype=int)
+
+    """
+        Cost from the velocity direction consistency
+    """
+    Y, X = speed_direction_batch(detections, previous_obs)
+    inertia_Y, inertia_X = velocities[:,0], velocities[:,1]
+    inertia_Y = np.repeat(inertia_Y[:, np.newaxis], Y.shape[1], axis=1)
+    inertia_X = np.repeat(inertia_X[:, np.newaxis], X.shape[1], axis=1)
+    diff_angle_cos = inertia_X * X + inertia_Y * Y
+    diff_angle_cos = np.clip(diff_angle_cos, a_min=-1, a_max=1)
+    diff_angle = np.arccos(diff_angle_cos)
+    diff_angle = (np.pi /2.0 - np.abs(diff_angle)) / np.pi
+
+    valid_mask = np.ones(previous_obs.shape[0])
+    valid_mask[np.where(previous_obs[:,4]<0)]=0  
+    valid_mask = np.repeat(valid_mask[:, np.newaxis], X.shape[1], axis=1)
+
+    scores = np.repeat(detections[:,-1][:, np.newaxis], trackers.shape[0], axis=1)
+    angle_diff_cost = (valid_mask * diff_angle) * vdc_weight
+    angle_diff_cost = angle_diff_cost.T
+    angle_diff_cost = angle_diff_cost * scores
+
+    """
+        Cost from IoU
+    """
+    iou_matrix = iou_batch(detections, trackers)
+    
+
+    """
+        With multiple categories, generate the cost for catgory mismatch
+    """
+    num_dets = detections.shape[0]
+    num_trk = trackers.shape[0]
+    cate_matrix = np.zeros((num_dets, num_trk))
+    for i in range(num_dets):
+            for j in range(num_trk):
+                if det_cates[i] != trackers[j, 4]:
+                        cate_matrix[i][j] = -1e6
+    
+    cost_matrix = - iou_matrix -angle_diff_cost - cate_matrix
+
+    if min(iou_matrix.shape) > 0:
+        a = (iou_matrix > iou_threshold).astype(np.int32)
+        if a.sum(1).max() == 1 and a.sum(0).max() == 1:
+            matched_indices = np.stack(np.where(a), axis=1)
+        else:
+            matched_indices = linear_assignment(cost_matrix)
+    else:
+        matched_indices = np.empty(shape=(0,2))
+
+    unmatched_detections = []
+    for d, det in enumerate(detections):
+        if(d not in matched_indices[:,0]):
+            unmatched_detections.append(d)
+    unmatched_trackers = []
+    for t, trk in enumerate(trackers):
+        if(t not in matched_indices[:,1]):
+            unmatched_trackers.append(t)
+
+    #filter out matched with low IOU
+    matches = []
+    for m in matched_indices:
+        if(iou_matrix[m[0], m[1]]<iou_threshold):
+            unmatched_detections.append(m[0])
+            unmatched_trackers.append(m[1])
+        else:
+            matches.append(m.reshape(1,2))
+    if(len(matches)==0):
+        matches = np.empty((0,2),dtype=int)
+    else:
+        matches = np.concatenate(matches,axis=0)
+
+    return matches, np.array(unmatched_detections), np.array(unmatched_trackers)

--- a/trackers/core/ocsort/association.py
+++ b/trackers/core/ocsort/association.py
@@ -2,12 +2,12 @@
 Reference Link : https://github.com/noahcao/OC_SORT/blob/master/trackers/ocsort_tracker/association.py
 """
 
-import os
 from typing import Tuple
+
 import numpy as np
 
 
-def iou_batch(bboxes1 : np.ndarray, bboxes2 : np.ndarray) -> np.ndarray:
+def iou_batch(bboxes1: np.ndarray, bboxes2: np.ndarray) -> np.ndarray:
     """
     Computes the Intersection over Union (IoU) between two batches of bounding boxes.
 
@@ -20,28 +20,28 @@ def iou_batch(bboxes1 : np.ndarray, bboxes2 : np.ndarray) -> np.ndarray:
         bboxes2 (np.ndarray): An array of shape (M, 4) representing M bounding boxes.
 
     Returns:
-        np.ndarray: A matrix of shape (N, M) where the element at [i, j] is the IoU 
+        np.ndarray: A matrix of shape (N, M) where the element at [i, j] is the IoU
                     between `bboxes1[i]` and `bboxes2[j]`.
     """
     bboxes2 = np.expand_dims(bboxes2, 0)
     bboxes1 = np.expand_dims(bboxes1, 1)
-    
+
     xx1 = np.maximum(bboxes1[..., 0], bboxes2[..., 0])
     yy1 = np.maximum(bboxes1[..., 1], bboxes2[..., 1])
     xx2 = np.minimum(bboxes1[..., 2], bboxes2[..., 2])
     yy2 = np.minimum(bboxes1[..., 3], bboxes2[..., 3])
-    w = np.maximum(0., xx2 - xx1)
-    h = np.maximum(0., yy2 - yy1)
+    w = np.maximum(0.0, xx2 - xx1)
+    h = np.maximum(0.0, yy2 - yy1)
     wh = w * h
-    o = wh / ((bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])                                      
-        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1]) - wh)                                              
-    return(o)  
+    o = wh / (
+        (bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])
+        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1])
+        - wh
+    )
+    return o
 
 
-def giou_batch(
-    bboxes1 : np.ndarray, 
-    bboxes2 : np.ndarray
-) -> np.ndarray:
+def giou_batch(bboxes1: np.ndarray, bboxes2: np.ndarray) -> np.ndarray:
     """
     Computes the Generalized Intersection over Union (GIoU) between two batches of bounding boxes.
 
@@ -49,12 +49,12 @@ def giou_batch(
     improving gradient behavior when boxes do not intersect.
 
     Args:
-        bboxes1 (np.ndarray): Predicted bounding boxes of shape (N, 4), where each box is in 
+        bboxes1 (np.ndarray): Predicted bounding boxes of shape (N, 4), where each box is in
                               [x1, y1, x2, y2] format.
         bboxes2 (np.ndarray): Ground truth bounding boxes of shape (N, 4), same format as `bboxes1`.
 
     Returns:
-        np.ndarray: A 1D array of shape (N,) where each element is the GIoU between 
+        np.ndarray: A 1D array of shape (N,) where each element is the GIoU between
                     the corresponding pair of boxes from `bboxes1` and `bboxes2`.
     """
     # for details should go to https://arxiv.org/pdf/1902.09630.pdf
@@ -66,44 +66,44 @@ def giou_batch(
     yy1 = np.maximum(bboxes1[..., 1], bboxes2[..., 1])
     xx2 = np.minimum(bboxes1[..., 2], bboxes2[..., 2])
     yy2 = np.minimum(bboxes1[..., 3], bboxes2[..., 3])
-    w = np.maximum(0., xx2 - xx1)
-    h = np.maximum(0., yy2 - yy1)
+    w = np.maximum(0.0, xx2 - xx1)
+    h = np.maximum(0.0, yy2 - yy1)
     wh = w * h
-    union = ((bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])                                      
-        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1]) - wh)  
+    union = (
+        (bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])
+        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1])
+        - wh
+    )
     iou = wh / union
 
     xxc1 = np.minimum(bboxes1[..., 0], bboxes2[..., 0])
     yyc1 = np.minimum(bboxes1[..., 1], bboxes2[..., 1])
     xxc2 = np.maximum(bboxes1[..., 2], bboxes2[..., 2])
     yyc2 = np.maximum(bboxes1[..., 3], bboxes2[..., 3])
-    wc = xxc2 - xxc1 
-    hc = yyc2 - yyc1 
-    assert((wc > 0).all() and (hc > 0).all())
-    area_enclose = wc * hc 
+    wc = xxc2 - xxc1
+    hc = yyc2 - yyc1
+    assert (wc > 0).all() and (hc > 0).all()
+    area_enclose = wc * hc
     giou = iou - (area_enclose - union) / area_enclose
-    giou = (giou + 1.)/2.0 # resize from (-1,1) to (0,1)
+    giou = (giou + 1.0) / 2.0  # resize from (-1,1) to (0,1)
     return giou
 
 
-def diou_batch(
-    bboxes1 : np.ndarray, 
-    bboxes2 : np.ndarray
-) -> np.ndarray:
+def diou_batch(bboxes1: np.ndarray, bboxes2: np.ndarray) -> np.ndarray:
     """
     Computes the Distance-IoU (DIoU) between two batches of bounding boxes.
 
-    DIoU improves IoU-based loss by incorporating the normalized distance between 
+    DIoU improves IoU-based loss by incorporating the normalized distance between
     the centers of the predicted and ground truth boxes, encouraging faster convergence.
 
     Args:
-        bboxes1 (np.ndarray): Predicted bounding boxes of shape (N, 4), 
+        bboxes1 (np.ndarray): Predicted bounding boxes of shape (N, 4),
                               each in [x1, y1, x2, y2] format.
-        bboxes2 (np.ndarray): Ground truth bounding boxes of shape (N, 4), 
+        bboxes2 (np.ndarray): Ground truth bounding boxes of shape (N, 4),
                               each in [x1, y1, x2, y2] format.
 
     Returns:
-        np.ndarray: A 1D array of shape (N,) containing the DIoU value for each 
+        np.ndarray: A 1D array of shape (N,) containing the DIoU value for each
                     pair of predicted and ground truth boxes.
     """
     # for details should go to https://arxiv.org/pdf/1902.09630.pdf
@@ -116,11 +116,14 @@ def diou_batch(
     yy1 = np.maximum(bboxes1[..., 1], bboxes2[..., 1])
     xx2 = np.minimum(bboxes1[..., 2], bboxes2[..., 2])
     yy2 = np.minimum(bboxes1[..., 3], bboxes2[..., 3])
-    w = np.maximum(0., xx2 - xx1)
-    h = np.maximum(0., yy2 - yy1)
+    w = np.maximum(0.0, xx2 - xx1)
+    h = np.maximum(0.0, yy2 - yy1)
     wh = w * h
-    union = ((bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])                                      
-        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1]) - wh) 
+    union = (
+        (bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])
+        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1])
+        - wh
+    )
     iou = wh / union
     centerx1 = (bboxes1[..., 0] + bboxes1[..., 2]) / 2.0
     centery1 = (bboxes1[..., 1] + bboxes1[..., 3]) / 2.0
@@ -137,26 +140,24 @@ def diou_batch(
     outer_diag = (xxc2 - xxc1) ** 2 + (yyc2 - yyc1) ** 2
     diou = iou - inner_diag / outer_diag
 
-    return (diou + 1) / 2.0 # resize from (-1,1) to (0,1)
+    return (diou + 1) / 2.0  # resize from (-1,1) to (0,1)
 
-def ciou_batch(
-    bboxes1 : np.ndarray, 
-    bboxes2 : np.ndarray
-) -> np.ndarray:
+
+def ciou_batch(bboxes1: np.ndarray, bboxes2: np.ndarray) -> np.ndarray:
     """
     Computes the Complete IoU (CIoU) between two batches of bounding boxes.
 
-    CIoU builds upon DIoU by incorporating aspect ratio consistency along with 
+    CIoU builds upon DIoU by incorporating aspect ratio consistency along with
     overlap area and center distance, making it more robust for bounding box regression.
 
     Args:
-        bboxes1 (np.ndarray): Predicted bounding boxes of shape (N, 4), 
+        bboxes1 (np.ndarray): Predicted bounding boxes of shape (N, 4),
                               where each box is in [x1, y1, x2, y2] format.
-        bboxes2 (np.ndarray): Ground truth bounding boxes of shape (N, 4), 
+        bboxes2 (np.ndarray): Ground truth bounding boxes of shape (N, 4),
                               where each box is in [x1, y1, x2, y2] format.
 
     Returns:
-        np.ndarray: A 1D array of shape (N,) containing the CIoU values for each 
+        np.ndarray: A 1D array of shape (N,) containing the CIoU values for each
                     corresponding pair of predicted and ground truth boxes.
     """
     # for details should go to https://arxiv.org/pdf/1902.09630.pdf
@@ -169,11 +170,14 @@ def ciou_batch(
     yy1 = np.maximum(bboxes1[..., 1], bboxes2[..., 1])
     xx2 = np.minimum(bboxes1[..., 2], bboxes2[..., 2])
     yy2 = np.minimum(bboxes1[..., 3], bboxes2[..., 3])
-    w = np.maximum(0., xx2 - xx1)
-    h = np.maximum(0., yy2 - yy1)
+    w = np.maximum(0.0, xx2 - xx1)
+    h = np.maximum(0.0, yy2 - yy1)
     wh = w * h
-    union = ((bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])                                      
-        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1]) - wh) 
+    union = (
+        (bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])
+        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1])
+        - wh
+    )
     iou = wh / union
 
     centerx1 = (bboxes1[..., 0] + bboxes1[..., 2]) / 2.0
@@ -189,48 +193,45 @@ def ciou_batch(
     yyc2 = np.maximum(bboxes1[..., 3], bboxes2[..., 3])
 
     outer_diag = (xxc2 - xxc1) ** 2 + (yyc2 - yyc1) ** 2
-    
+
     w1 = bboxes1[..., 2] - bboxes1[..., 0]
     h1 = bboxes1[..., 3] - bboxes1[..., 1]
     w2 = bboxes2[..., 2] - bboxes2[..., 0]
     h2 = bboxes2[..., 3] - bboxes2[..., 1]
 
     # prevent dividing over zero. add one pixel shift
-    h2 = h2 + 1.
-    h1 = h1 + 1.
-    arctan = np.arctan(w2/h2) - np.arctan(w1/h1)
-    v = (4 / (np.pi ** 2)) * (arctan ** 2)
-    S = 1 - iou 
-    alpha = v / (S+v)
+    h2 = h2 + 1.0
+    h1 = h1 + 1.0
+    arctan = np.arctan(w2 / h2) - np.arctan(w1 / h1)
+    v = (4 / (np.pi**2)) * (arctan**2)
+    S = 1 - iou
+    alpha = v / (S + v)
     ciou = iou - inner_diag / outer_diag - alpha * v
-    
-    return (ciou + 1) / 2.0 # resize from (-1,1) to (0,1)
+
+    return (ciou + 1) / 2.0  # resize from (-1,1) to (0,1)
 
 
-def ct_dist(
-    bboxes1: np.ndarray, 
-    bboxes2: np.ndarray
-) -> np.ndarray:
+def ct_dist(bboxes1: np.ndarray, bboxes2: np.ndarray) -> np.ndarray:
     """
-    Computes a normalized similarity matrix based on center-point distances 
+    Computes a normalized similarity matrix based on center-point distances
     between two sets of bounding boxes.
 
-    This function calculates the Euclidean distance between the centers of each 
+    This function calculates the Euclidean distance between the centers of each
     bounding box in `bboxes1` and `bboxes2`, then linearly rescales the values to [0, 1],
     where 1 represents the closest match (smallest distance) and 0 the farthest.
 
     Note:
-        This is a coarse metric and may be unstable as a standalone association 
+        This is a coarse metric and may be unstable as a standalone association
         criterion, especially under varying frame rates or fast-moving objects.
 
     Args:
-        bboxes1 (np.ndarray): An array of shape (N, 4), with bounding boxes in 
+        bboxes1 (np.ndarray): An array of shape (N, 4), with bounding boxes in
                               [x1, y1, x2, y2] format.
-        bboxes2 (np.ndarray): An array of shape (M, 4), with bounding boxes in 
+        bboxes2 (np.ndarray): An array of shape (M, 4), with bounding boxes in
                               [x1, y1, x2, y2] format.
 
     Returns:
-        np.ndarray: A (N, M) matrix of normalized center-distance similarity scores 
+        np.ndarray: A (N, M) matrix of normalized center-distance similarity scores
                     in the range [0, 1], where higher values indicate closer proximity.
     """
 
@@ -248,24 +249,23 @@ def ct_dist(
 
     # The linear rescaling is a naive version and needs more study
     ct_dist = ct_dist / ct_dist.max()
-    return ct_dist.max() - ct_dist # resize to (0,1)
+    return ct_dist.max() - ct_dist  # resize to (0,1)
 
 
 def speed_direction_batch(
-    dets : np.ndarray, 
-    tracks : np.ndarray
+    dets: np.ndarray, tracks: np.ndarray
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
     Computes normalized direction vectors (dy, dx) from tracks to detections.
 
-    For each pair of detection and track, this function computes the direction vector 
+    For each pair of detection and track, this function computes the direction vector
     from the center of the track bounding box to the center of the detection bounding box,
     and normalizes it to unit length.
 
     Args:
-        dets (np.ndarray): Array of detection bounding boxes with shape (N, 4), 
+        dets (np.ndarray): Array of detection bounding boxes with shape (N, 4),
                            in [x1, y1, x2, y2] format.
-        tracks (np.ndarray): Array of track bounding boxes with shape (M, 4), 
+        tracks (np.ndarray): Array of track bounding boxes with shape (M, 4),
                              in [x1, y1, x2, y2] format.
 
     Returns:
@@ -274,61 +274,61 @@ def speed_direction_batch(
             - dx: Normalized horizontal component of the direction vector.
     """
     tracks = tracks[..., np.newaxis]
-    CX1, CY1 = (dets[:,0] + dets[:,2])/2.0, (dets[:,1]+dets[:,3])/2.0
-    CX2, CY2 = (tracks[:,0] + tracks[:,2]) /2.0, (tracks[:,1]+tracks[:,3])/2.0
-    dx = CX1 - CX2 
-    dy = CY1 - CY2 
+    CX1, CY1 = (dets[:, 0] + dets[:, 2]) / 2.0, (dets[:, 1] + dets[:, 3]) / 2.0
+    CX2, CY2 = (tracks[:, 0] + tracks[:, 2]) / 2.0, (tracks[:, 1] + tracks[:, 3]) / 2.0
+    dx = CX1 - CX2
+    dy = CY1 - CY2
     norm = np.sqrt(dx**2 + dy**2) + 1e-6
-    dx = dx / norm 
+    dx = dx / norm
     dy = dy / norm
-    return dy, dx # size: num_track x num_det
+    return dy, dx  # size: num_track x num_det
 
 
-def linear_assignment(cost_matrix : np.ndarray) -> np.ndarray:
+def linear_assignment(cost_matrix: np.ndarray) -> np.ndarray:
     """
     Solves the linear assignment problem (also known as the Hungarian algorithm)
     to find the optimal one-to-one assignment with minimum total cost.
 
-    This function attempts to use the `lap` library (LAPJV algorithm) for efficient 
+    This function attempts to use the `lap` library (LAPJV algorithm) for efficient
     computation. If unavailable, it falls back to `scipy.optimize.linear_sum_assignment`.
 
     Args:
-        cost_matrix (np.ndarray): A 2D array of shape (N, M) representing the cost 
+        cost_matrix (np.ndarray): A 2D array of shape (N, M) representing the cost
                                   of assigning each row to each column.
 
     Returns:
-        np.ndarray: An array of shape (K, 2), where each row is a pair [row_index, col_index] 
+        np.ndarray: An array of shape (K, 2), where each row is a pair [row_index, col_index]
                     indicating an optimal assignment. K ≤ min(N, M).
     """
     try:
         import lap
+
         _, x, y = lap.lapjv(cost_matrix, extend_cost=True)
-        return np.array([[y[i],i] for i in x if i >= 0]) #
+        return np.array([[y[i], i] for i in x if i >= 0])  #
     except ImportError:
         from scipy.optimize import linear_sum_assignment
+
         x, y = linear_sum_assignment(cost_matrix)
         return np.array(list(zip(x, y)))
 
 
 def associate_detections_to_trackers(
-    detections : np.ndarray,
-    trackers : np.ndarray,
-    iou_threshold : float = 0.3
+    detections: np.ndarray, trackers: np.ndarray, iou_threshold: float = 0.3
 ) -> np.ndarray:
     """
     Assigns detections to existing trackers using Intersection over Union (IoU).
 
-    This function computes the IoU between each detection and each tracker, 
-    then solves the assignment problem to match detections to trackers based 
-    on the highest IoU values. Matches with IoU below the threshold are 
+    This function computes the IoU between each detection and each tracker,
+    then solves the assignment problem to match detections to trackers based
+    on the highest IoU values. Matches with IoU below the threshold are
     considered invalid and treated as unmatched.
 
     Args:
-        detections (np.ndarray): Array of shape (N, 4), representing N detected bounding boxes 
+        detections (np.ndarray): Array of shape (N, 4), representing N detected bounding boxes
                                  in [x1, y1, x2, y2] format.
-        trackers (np.ndarray): Array of shape (M, 4), representing M tracker bounding boxes 
+        trackers (np.ndarray): Array of shape (M, 4), representing M tracker bounding boxes
                                in [x1, y1, x2, y2] format.
-        iou_threshold (float, optional): Minimum IoU required to consider a detection-tracker 
+        iou_threshold (float, optional): Minimum IoU required to consider a detection-tracker
                                          pair as a valid match. Defaults to 0.3.
 
     Returns:
@@ -338,8 +338,12 @@ def associate_detections_to_trackers(
             - unmatched_trackers: Array of tracker indices that did not match any detection.
     """
 
-    if(len(trackers)==0):
-        return np.empty((0,2),dtype=int), np.arange(len(detections)), np.empty((0,5),dtype=int)
+    if len(trackers) == 0:
+        return (
+            np.empty((0, 2), dtype=int),
+            np.arange(len(detections)),
+            np.empty((0, 5), dtype=int),
+        )
 
     iou_matrix = iou_batch(detections, trackers)
 
@@ -350,51 +354,57 @@ def associate_detections_to_trackers(
         else:
             matched_indices = linear_assignment(-iou_matrix)
     else:
-        matched_indices = np.empty(shape=(0,2))
+        matched_indices = np.empty(shape=(0, 2))
 
     unmatched_detections = []
     for d, det in enumerate(detections):
-        if(d not in matched_indices[:,0]):
+        if d not in matched_indices[:, 0]:
             unmatched_detections.append(d)
     unmatched_trackers = []
     for t, trk in enumerate(trackers):
-        if(t not in matched_indices[:,1]):
+        if t not in matched_indices[:, 1]:
             unmatched_trackers.append(t)
 
-    #filter out matched with low IOU
+    # filter out matched with low IOU
     matches = []
     for m in matched_indices:
-        if(iou_matrix[m[0], m[1]]<iou_threshold):
+        if iou_matrix[m[0], m[1]] < iou_threshold:
             unmatched_detections.append(m[0])
             unmatched_trackers.append(m[1])
         else:
-            matches.append(m.reshape(1,2))
-    if(len(matches)==0):
-        matches = np.empty((0,2),dtype=int)
+            matches.append(m.reshape(1, 2))
+    if len(matches) == 0:
+        matches = np.empty((0, 2), dtype=int)
     else:
-        matches = np.concatenate(matches,axis=0)
+        matches = np.concatenate(matches, axis=0)
 
     return matches, np.array(unmatched_detections), np.array(unmatched_trackers)
 
 
-def associate(detections, trackers, iou_threshold, velocities, previous_obs, vdc_weight):    
-    if(len(trackers)==0):
-        return np.empty((0,2),dtype=int), np.arange(len(detections)), np.empty((0,5),dtype=int)
+def associate(
+    detections, trackers, iou_threshold, velocities, previous_obs, vdc_weight
+):
+    if len(trackers) == 0:
+        return (
+            np.empty((0, 2), dtype=int),
+            np.arange(len(detections)),
+            np.empty((0, 5), dtype=int),
+        )
 
     Y, X = speed_direction_batch(detections, previous_obs)
-    inertia_Y, inertia_X = velocities[:,0], velocities[:,1]
+    inertia_Y, inertia_X = velocities[:, 0], velocities[:, 1]
     inertia_Y = np.repeat(inertia_Y[:, np.newaxis], Y.shape[1], axis=1)
     inertia_X = np.repeat(inertia_X[:, np.newaxis], X.shape[1], axis=1)
     diff_angle_cos = inertia_X * X + inertia_Y * Y
     diff_angle_cos = np.clip(diff_angle_cos, a_min=-1, a_max=1)
     diff_angle = np.arccos(diff_angle_cos)
-    diff_angle = (np.pi /2.0 - np.abs(diff_angle)) / np.pi
+    diff_angle = (np.pi / 2.0 - np.abs(diff_angle)) / np.pi
 
     valid_mask = np.ones(previous_obs.shape[0])
-    valid_mask[np.where(previous_obs[:,4]<0)] = 0
-    
+    valid_mask[np.where(previous_obs[:, 4] < 0)] = 0
+
     iou_matrix = iou_batch(detections, trackers)
-    scores = np.repeat(detections[:,-1][:, np.newaxis], trackers.shape[0], axis=1)
+    scores = np.repeat(detections[:, -1][:, np.newaxis], trackers.shape[0], axis=1)
     # iou_matrix = iou_matrix * scores # a trick sometiems works, we don't encourage this
     valid_mask = np.repeat(valid_mask[:, np.newaxis], X.shape[1], axis=1)
 
@@ -407,57 +417,62 @@ def associate(detections, trackers, iou_threshold, velocities, previous_obs, vdc
         if a.sum(1).max() == 1 and a.sum(0).max() == 1:
             matched_indices = np.stack(np.where(a), axis=1)
         else:
-            matched_indices = linear_assignment(-(iou_matrix+angle_diff_cost))
+            matched_indices = linear_assignment(-(iou_matrix + angle_diff_cost))
     else:
-        matched_indices = np.empty(shape=(0,2))
+        matched_indices = np.empty(shape=(0, 2))
 
     unmatched_detections = []
     for d, det in enumerate(detections):
-        if(d not in matched_indices[:,0]):
+        if d not in matched_indices[:, 0]:
             unmatched_detections.append(d)
     unmatched_trackers = []
     for t, trk in enumerate(trackers):
-        if(t not in matched_indices[:,1]):
+        if t not in matched_indices[:, 1]:
             unmatched_trackers.append(t)
 
     # filter out matched with low IOU
     matches = []
     for m in matched_indices:
-        if(iou_matrix[m[0], m[1]]<iou_threshold):
+        if iou_matrix[m[0], m[1]] < iou_threshold:
             unmatched_detections.append(m[0])
             unmatched_trackers.append(m[1])
         else:
-            matches.append(m.reshape(1,2))
-    if(len(matches)==0):
-        matches = np.empty((0,2),dtype=int)
+            matches.append(m.reshape(1, 2))
+    if len(matches) == 0:
+        matches = np.empty((0, 2), dtype=int)
     else:
-        matches = np.concatenate(matches,axis=0)
+        matches = np.concatenate(matches, axis=0)
 
     return matches, np.array(unmatched_detections), np.array(unmatched_trackers)
 
 
-def associate_kitti(detections, trackers, det_cates, iou_threshold, 
-        velocities, previous_obs, vdc_weight):
-    if(len(trackers)==0):
-        return np.empty((0,2),dtype=int), np.arange(len(detections)), np.empty((0,5),dtype=int)
+def associate_kitti(
+    detections, trackers, det_cates, iou_threshold, velocities, previous_obs, vdc_weight
+):
+    if len(trackers) == 0:
+        return (
+            np.empty((0, 2), dtype=int),
+            np.arange(len(detections)),
+            np.empty((0, 5), dtype=int),
+        )
 
     """
         Cost from the velocity direction consistency
     """
     Y, X = speed_direction_batch(detections, previous_obs)
-    inertia_Y, inertia_X = velocities[:,0], velocities[:,1]
+    inertia_Y, inertia_X = velocities[:, 0], velocities[:, 1]
     inertia_Y = np.repeat(inertia_Y[:, np.newaxis], Y.shape[1], axis=1)
     inertia_X = np.repeat(inertia_X[:, np.newaxis], X.shape[1], axis=1)
     diff_angle_cos = inertia_X * X + inertia_Y * Y
     diff_angle_cos = np.clip(diff_angle_cos, a_min=-1, a_max=1)
     diff_angle = np.arccos(diff_angle_cos)
-    diff_angle = (np.pi /2.0 - np.abs(diff_angle)) / np.pi
+    diff_angle = (np.pi / 2.0 - np.abs(diff_angle)) / np.pi
 
     valid_mask = np.ones(previous_obs.shape[0])
-    valid_mask[np.where(previous_obs[:,4]<0)]=0  
+    valid_mask[np.where(previous_obs[:, 4] < 0)] = 0
     valid_mask = np.repeat(valid_mask[:, np.newaxis], X.shape[1], axis=1)
 
-    scores = np.repeat(detections[:,-1][:, np.newaxis], trackers.shape[0], axis=1)
+    scores = np.repeat(detections[:, -1][:, np.newaxis], trackers.shape[0], axis=1)
     angle_diff_cost = (valid_mask * diff_angle) * vdc_weight
     angle_diff_cost = angle_diff_cost.T
     angle_diff_cost = angle_diff_cost * scores
@@ -466,7 +481,6 @@ def associate_kitti(detections, trackers, det_cates, iou_threshold,
         Cost from IoU
     """
     iou_matrix = iou_batch(detections, trackers)
-    
 
     """
         With multiple categories, generate the cost for catgory mismatch
@@ -475,11 +489,11 @@ def associate_kitti(detections, trackers, det_cates, iou_threshold,
     num_trk = trackers.shape[0]
     cate_matrix = np.zeros((num_dets, num_trk))
     for i in range(num_dets):
-            for j in range(num_trk):
-                if det_cates[i] != trackers[j, 4]:
-                        cate_matrix[i][j] = -1e6
-    
-    cost_matrix = - iou_matrix -angle_diff_cost - cate_matrix
+        for j in range(num_trk):
+            if det_cates[i] != trackers[j, 4]:
+                cate_matrix[i][j] = -1e6
+
+    cost_matrix = -iou_matrix - angle_diff_cost - cate_matrix
 
     if min(iou_matrix.shape) > 0:
         a = (iou_matrix > iou_threshold).astype(np.int32)
@@ -488,28 +502,28 @@ def associate_kitti(detections, trackers, det_cates, iou_threshold,
         else:
             matched_indices = linear_assignment(cost_matrix)
     else:
-        matched_indices = np.empty(shape=(0,2))
+        matched_indices = np.empty(shape=(0, 2))
 
     unmatched_detections = []
     for d, det in enumerate(detections):
-        if(d not in matched_indices[:,0]):
+        if d not in matched_indices[:, 0]:
             unmatched_detections.append(d)
     unmatched_trackers = []
     for t, trk in enumerate(trackers):
-        if(t not in matched_indices[:,1]):
+        if t not in matched_indices[:, 1]:
             unmatched_trackers.append(t)
 
-    #filter out matched with low IOU
+    # filter out matched with low IOU
     matches = []
     for m in matched_indices:
-        if(iou_matrix[m[0], m[1]]<iou_threshold):
+        if iou_matrix[m[0], m[1]] < iou_threshold:
             unmatched_detections.append(m[0])
             unmatched_trackers.append(m[1])
         else:
-            matches.append(m.reshape(1,2))
-    if(len(matches)==0):
-        matches = np.empty((0,2),dtype=int)
+            matches.append(m.reshape(1, 2))
+    if len(matches) == 0:
+        matches = np.empty((0, 2), dtype=int)
     else:
-        matches = np.concatenate(matches,axis=0)
+        matches = np.concatenate(matches, axis=0)
 
     return matches, np.array(unmatched_detections), np.array(unmatched_trackers)

--- a/trackers/core/ocsort/filterpy_funcs.py
+++ b/trackers/core/ocsort/filterpy_funcs.py
@@ -1,0 +1,119 @@
+"""
+One to One copy of functions taken from Filterpy Library
+Should be removed once filterpy is added to the installation libraries
+
+Reference Link : https://github.com/rlabbe/filterpy
+"""
+
+from collections import deque
+import numpy as np
+from scipy.stats import norm, multivariate_normal
+
+def reshape_z(z, dim_z, ndim):
+    """ensure z is a (dim_z, 1) shaped vector"""
+
+    z = np.atleast_2d(z)
+    if z.shape[1] == dim_z:
+        z = z.T
+
+    if z.shape != (dim_z, 1):
+        raise ValueError(
+            "z (shape {}) must be convertible to shape ({}, 1)".format(z.shape, dim_z)
+        )
+
+    if ndim == 1:
+        z = z[:, 0]
+
+    if ndim == 0:
+        z = z[0, 0]
+
+    return z
+
+def pretty_str(label, arr):
+    """
+    Generates a pretty printed NumPy array with an assignment. Optionally
+    transposes column vectors so they are drawn on one line. Strictly speaking
+    arr can be any time convertible by `str(arr)`, but the output may not
+    be what you want if the type of the variable is not a scalar or an
+    ndarray.
+
+    Examples
+    --------
+    >>> pprint('cov', np.array([[4., .1], [.1, 5]]))
+    cov = [[4.  0.1]
+           [0.1 5. ]]
+
+    >>> print(pretty_str('x', np.array([[1], [2], [3]])))
+    x = [[1 2 3]].T
+    """
+
+    def is_col(a):
+        """return true if a is a column vector"""
+        try:
+            return a.shape[0] > 1 and a.shape[1] == 1
+        except (AttributeError, IndexError):
+            return False
+
+    # display empty lists correctly
+    try:
+        if len(arr) == 0:
+            return label + " = " + str(type(arr)())
+    except TypeError:
+        pass
+
+    if type(arr) is list or type(arr) is tuple or type(arr) is deque:
+        return "\n".join(
+            [pretty_str(label + "[" + str(i) + "]", x) for (i, x) in enumerate(arr)]
+        )
+
+    if label is None:
+        label = ""
+
+    if label:
+        label += " = "
+
+    if is_col(arr):
+        return label + str(arr.T).replace("\n", "") + ".T"
+
+    rows = str(arr).split("\n")
+    if not rows:
+        return ""
+
+    s = label + rows[0]
+    pad = " " * len(label)
+    for line in rows[1:]:
+        s = s + "\n" + pad + line
+
+    return s
+
+_support_singular = True
+
+def logpdf(
+        x, 
+        mean = None, 
+        cov = 1, 
+        allow_singular = True,
+    ):
+    """
+    Computes the log of the probability density function of the normal
+    N(mean, cov) for the data x. The normal may be univariate or multivariate.
+
+    Wrapper for older versions of scipy.multivariate_normal.logpdf which
+    don't support support the allow_singular keyword prior to verion 0.15.0.
+
+    If it is not supported, and cov is singular or not PSD you may get
+    an exception.
+
+    `x` and `mean` may be column vectors, row vectors, or lists.
+    """
+
+    if mean is not None:
+        flat_mean = np.asarray(mean).flatten()
+    else:
+        flat_mean = None
+
+    flat_x = np.asarray(x).flatten()
+
+    if _support_singular:
+        return multivariate_normal.logpdf(flat_x, flat_mean, cov, allow_singular)
+    return multivariate_normal.logpdf(flat_x, flat_mean, cov)

--- a/trackers/core/ocsort/filterpy_funcs.py
+++ b/trackers/core/ocsort/filterpy_funcs.py
@@ -6,8 +6,10 @@ Reference Link : https://github.com/rlabbe/filterpy
 """
 
 from collections import deque
+
 import numpy as np
-from scipy.stats import norm, multivariate_normal
+from scipy.stats import multivariate_normal
+
 
 def reshape_z(z, dim_z, ndim):
     """ensure z is a (dim_z, 1) shaped vector"""
@@ -28,6 +30,7 @@ def reshape_z(z, dim_z, ndim):
         z = z[0, 0]
 
     return z
+
 
 def pretty_str(label, arr):
     """
@@ -86,14 +89,16 @@ def pretty_str(label, arr):
 
     return s
 
+
 _support_singular = True
 
+
 def logpdf(
-        x, 
-        mean = None, 
-        cov = 1, 
-        allow_singular = True,
-    ):
+    x,
+    mean=None,
+    cov=1,
+    allow_singular=True,
+):
     """
     Computes the log of the probability density function of the normal
     N(mean, cov) for the data x. The normal may be univariate or multivariate.

--- a/trackers/core/ocsort/kalman_filter.py
+++ b/trackers/core/ocsort/kalman_filter.py
@@ -94,21 +94,22 @@ Reference Link : https://github.com/noahcao/OC_SORT/blob/master/trackers/ocsort_
 
 from __future__ import absolute_import, division
 
-from copy import deepcopy
-from math import log, exp, sqrt
 import sys
-import numpy as np
-from numpy import dot, zeros, eye, isscalar, shape
-import numpy.linalg as linalg
-from trackers.core.ocsort.filterpy_funcs import logpdf, pretty_str, reshape_z
+from copy import deepcopy
+from math import exp, log, sqrt
 
+import numpy as np
+import numpy.linalg as linalg
+from numpy import dot, eye, isscalar, shape, zeros
+
+from trackers.core.ocsort.filterpy_funcs import logpdf, pretty_str, reshape_z
 
 #  from filterpy.stats import logpdf
 # from filterpy.common import pretty_str, reshape_z
 
 
 class KalmanFilterNew(object):
-    """ Implements a Kalman filter. You are responsible for setting the
+    """Implements a Kalman filter. You are responsible for setting the
     various state variables to reasonable values; the defaults  will
     not give you a functional filter.
     For now the best documentation is my free book Kalman and Bayesian
@@ -153,7 +154,7 @@ class KalmanFilterNew(object):
     vector into just a position vector, so we use:
         .. code::
         f.H = np.array([[1., 0.]])
-    Define the state's covariance matrix P. 
+    Define the state's covariance matrix P.
     .. code::
         f.P = np.array([[1000.,    0.],
                         [   0., 1000.] ])
@@ -283,34 +284,34 @@ class KalmanFilterNew(object):
 
     def __init__(self, dim_x, dim_z, dim_u=0):
         if dim_x < 1:
-            raise ValueError('dim_x must be 1 or greater')
+            raise ValueError("dim_x must be 1 or greater")
         if dim_z < 1:
-            raise ValueError('dim_z must be 1 or greater')
+            raise ValueError("dim_z must be 1 or greater")
         if dim_u < 0:
-            raise ValueError('dim_u must be 0 or greater')
+            raise ValueError("dim_u must be 0 or greater")
 
         self.dim_x = dim_x
         self.dim_z = dim_z
         self.dim_u = dim_u
 
-        self.x = zeros((dim_x, 1))        # state
-        self.P = eye(dim_x)               # uncertainty covariance
-        self.Q = eye(dim_x)               # process uncertainty
-        self.B = None                     # control transition matrix
-        self.F = eye(dim_x)               # state transition matrix
-        self.H = zeros((dim_z, dim_x))    # measurement function
-        self.R = eye(dim_z)               # measurement uncertainty
-        self._alpha_sq = 1.               # fading memory control
-        self.M = np.zeros((dim_x, dim_z)) # process-measurement cross correlation
-        self.z = np.array([[None]*self.dim_z]).T
+        self.x = zeros((dim_x, 1))  # state
+        self.P = eye(dim_x)  # uncertainty covariance
+        self.Q = eye(dim_x)  # process uncertainty
+        self.B = None  # control transition matrix
+        self.F = eye(dim_x)  # state transition matrix
+        self.H = zeros((dim_z, dim_x))  # measurement function
+        self.R = eye(dim_z)  # measurement uncertainty
+        self._alpha_sq = 1.0  # fading memory control
+        self.M = np.zeros((dim_x, dim_z))  # process-measurement cross correlation
+        self.z = np.array([[None] * self.dim_z]).T
 
         # gain and residual are computed during the innovation step. We
         # save them so that in case you want to inspect them for various
         # purposes
-        self.K = np.zeros((dim_x, dim_z)) # kalman gain
+        self.K = np.zeros((dim_x, dim_z))  # kalman gain
         self.y = zeros((dim_z, 1))
-        self.S = np.zeros((dim_z, dim_z)) # system uncertainty
-        self.SI = np.zeros((dim_z, dim_z)) # inverse system uncertainty
+        self.S = np.zeros((dim_z, dim_z))  # system uncertainty
+        self.SI = np.zeros((dim_z, dim_z))  # inverse system uncertainty
 
         # identity matrix. Do not alter this.
         self._I = np.eye(dim_x)
@@ -320,7 +321,7 @@ class KalmanFilterNew(object):
         self.P_prior = self.P.copy()
 
         # these will always be a copy of x,P after update() is called
-        self.x_post = self.x.copy()             
+        self.x_post = self.x.copy()
         self.P_post = self.P.copy()
 
         # Only computed only if requested via property
@@ -328,14 +329,13 @@ class KalmanFilterNew(object):
         self._likelihood = sys.float_info.min
         self._mahalanobis = None
 
-        # keep all observations 
+        # keep all observations
         self.history_obs = []
 
         self.inv = np.linalg.inv
 
         self.attr_saved = None
-        self.observed = False 
-
+        self.observed = False
 
     def predict(self, u=None, B=None, F=None, Q=None):
         """
@@ -365,7 +365,6 @@ class KalmanFilterNew(object):
         elif isscalar(Q):
             Q = eye(self.dim_x) * Q
 
-
         # x = Fx + Bu
         if B is not None and u is not None:
             self.x = dot(F, self.x) + dot(B, u)
@@ -379,61 +378,57 @@ class KalmanFilterNew(object):
         self.x_prior = self.x.copy()
         self.P_prior = self.P.copy()
 
-
-
     def freeze(self):
         """
-            Save the parameters before non-observation forward
+        Save the parameters before non-observation forward
         """
         self.attr_saved = deepcopy(self.__dict__)
-
 
     def unfreeze(self):
         if self.attr_saved is not None:
             new_history = deepcopy(self.history_obs)
             self.__dict__ = self.attr_saved
-            # self.history_obs = new_history 
+            # self.history_obs = new_history
             self.history_obs = self.history_obs[:-1]
             occur = [int(d is None) for d in new_history]
-            indices = np.where(np.array(occur)==0)[0]
+            indices = np.where(np.array(occur) == 0)[0]
             index1 = indices[-2]
             index2 = indices[-1]
             box1 = new_history[index1]
-            x1, y1, s1, r1 = box1 
+            x1, y1, s1, r1 = box1
             w1 = np.sqrt(s1 * r1)
             h1 = np.sqrt(s1 / r1)
             box2 = new_history[index2]
-            x2, y2, s2, r2 = box2 
+            x2, y2, s2, r2 = box2
             w2 = np.sqrt(s2 * r2)
             h2 = np.sqrt(s2 / r2)
             time_gap = index2 - index1
-            dx = (x2-x1)/time_gap
-            dy = (y2-y1)/time_gap 
-            dw = (w2-w1)/time_gap 
-            dh = (h2-h1)/time_gap
+            dx = (x2 - x1) / time_gap
+            dy = (y2 - y1) / time_gap
+            dw = (w2 - w1) / time_gap
+            dh = (h2 - h1) / time_gap
             for i in range(index2 - index1):
                 """
                     The default virtual trajectory generation is by linear
-                    motion (constant speed hypothesis), you could modify this 
-                    part to implement your own. 
+                    motion (constant speed hypothesis), you could modify this
+                    part to implement your own.
                 """
-                x = x1 + (i+1) * dx 
-                y = y1 + (i+1) * dy 
-                w = w1 + (i+1) * dw 
-                h = h1 + (i+1) * dh
-                s = w * h 
+                x = x1 + (i + 1) * dx
+                y = y1 + (i + 1) * dy
+                w = w1 + (i + 1) * dw
+                h = h1 + (i + 1) * dh
+                s = w * h
                 r = w / float(h)
                 new_box = np.array([x, y, s, r]).reshape((4, 1))
                 """
                     I still use predict-update loop here to refresh the parameters,
                     but this can be faster by directly modifying the internal parameters
-                    as suggested in the paper. I keep this naive but slow way for 
+                    as suggested in the paper. I keep this naive but slow way for
                     easy read and understanding
                 """
                 self.update(new_box)
-                if not i == (index2-index1-1):
+                if not i == (index2 - index1 - 1):
                     self.predict()
-
 
     def update(self, z, R=None, H=None):
         """
@@ -462,7 +457,7 @@ class KalmanFilterNew(object):
 
         # append the observation
         self.history_obs.append(z)
-        
+
         if z is None:
             if self.observed:
                 """
@@ -470,13 +465,13 @@ class KalmanFilterNew(object):
                     potential online smoothing.
                 """
                 self.freeze()
-            self.observed = False 
-            self.z = np.array([[None]*self.dim_z]).T
+            self.observed = False
+            self.z = np.array([[None] * self.dim_z]).T
             self.x_post = self.x.copy()
             self.P_post = self.P.copy()
             self.y = zeros((self.dim_z, 1))
             return
-        
+
         # self.observed = True
         if not self.observed:
             """
@@ -597,7 +592,7 @@ class KalmanFilterNew(object):
         self._mahalanobis = None
 
         if z is None:
-            self.z = np.array([[None]*self.dim_z]).T
+            self.z = np.array([[None] * self.dim_z]).T
             self.x_post = self.x.copy()
             self.P_post = self.P.copy()
             self.y = zeros((self.dim_z, 1))
@@ -623,7 +618,7 @@ class KalmanFilterNew(object):
         self._mahalanobis = None
 
     def update_correlated(self, z, R=None, H=None):
-        """ Add a new measurement (z) to the Kalman filter assuming that
+        """Add a new measurement (z) to the Kalman filter assuming that
         process noise and measurement noise are correlated as defined in
         the `self.M` matrix.
         A partial derivation can be found in [1]
@@ -651,7 +646,7 @@ class KalmanFilterNew(object):
         self._mahalanobis = None
 
         if z is None:
-            self.z = np.array([[None]*self.dim_z]).T
+            self.z = np.array([[None] * self.dim_z]).T
             self.x_post = self.x.copy()
             self.P_post = self.P.copy()
             self.y = zeros((self.dim_z, 1))
@@ -672,7 +667,7 @@ class KalmanFilterNew(object):
         if self.x.ndim == 1 and shape(z) == (1, 1):
             z = z[0]
 
-        if shape(z) == (): # is it scalar, e.g. z=3 or z=np.array(3)
+        if shape(z) == ():  # is it scalar, e.g. z=3 or z=np.array(3)
             z = np.asarray([z])
 
         # y = z - Hx
@@ -699,87 +694,96 @@ class KalmanFilterNew(object):
         self.x_post = self.x.copy()
         self.P_post = self.P.copy()
 
-    def batch_filter(self, zs, Fs=None, Qs=None, Hs=None,
-                     Rs=None, Bs=None, us=None, update_first=False,
-                     saver=None):
-        """ Batch processes a sequences of measurements.
-        Parameters
-        ----------
-        zs : list-like
-            list of measurements at each time step `self.dt`. Missing
-            measurements must be represented by `None`.
-        Fs : None, list-like, default=None
-            optional value or list of values to use for the state transition
-            matrix F.
-            If Fs is None then self.F is used for all epochs.
-            Otherwise it must contain a list-like list of F's, one for
-            each epoch.  This allows you to have varying F per epoch.
-        Qs : None, np.array or list-like, default=None
-            optional value or list of values to use for the process error
-            covariance Q.
-            If Qs is None then self.Q is used for all epochs.
-            Otherwise it must contain a list-like list of Q's, one for
-            each epoch.  This allows you to have varying Q per epoch.
-        Hs : None, np.array or list-like, default=None
-            optional list of values to use for the measurement matrix H.
-            If Hs is None then self.H is used for all epochs.
-            If Hs contains a single matrix, then it is used as H for all
-            epochs.
-            Otherwise it must contain a list-like list of H's, one for
-            each epoch.  This allows you to have varying H per epoch.
-        Rs : None, np.array or list-like, default=None
-            optional list of values to use for the measurement error
-            covariance R.
-            If Rs is None then self.R is used for all epochs.
-            Otherwise it must contain a list-like list of R's, one for
-            each epoch.  This allows you to have varying R per epoch.
-        Bs : None, np.array or list-like, default=None
-            optional list of values to use for the control transition matrix B.
-            If Bs is None then self.B is used for all epochs.
-            Otherwise it must contain a list-like list of B's, one for
-            each epoch.  This allows you to have varying B per epoch.
-        us : None, np.array or list-like, default=None
-            optional list of values to use for the control input vector;
-            If us is None then None is used for all epochs (equivalent to 0,
-            or no control input).
-            Otherwise it must contain a list-like list of u's, one for
-            each epoch.
-       update_first : bool, optional, default=False
-            controls whether the order of operations is update followed by
-            predict, or predict followed by update. Default is predict->update.
-        saver : filterpy.common.Saver, optional
-            filterpy.common.Saver object. If provided, saver.save() will be
-            called after every epoch
-        Returns
-        -------
-        means : np.array((n,dim_x,1))
-            array of the state for each time step after the update. Each entry
-            is an np.array. In other words `means[k,:]` is the state at step
-            `k`.
-        covariance : np.array((n,dim_x,dim_x))
-            array of the covariances for each time step after the update.
-            In other words `covariance[k,:,:]` is the covariance at step `k`.
-        means_predictions : np.array((n,dim_x,1))
-            array of the state for each time step after the predictions. Each
-            entry is an np.array. In other words `means[k,:]` is the state at
-            step `k`.
-        covariance_predictions : np.array((n,dim_x,dim_x))
-            array of the covariances for each time step after the prediction.
-            In other words `covariance[k,:,:]` is the covariance at step `k`.
-        Examples
-        --------
-        .. code-block:: Python
-            # this example demonstrates tracking a measurement where the time
-            # between measurement varies, as stored in dts. This requires
-            # that F be recomputed for each epoch. The output is then smoothed
-            # with an RTS smoother.
-            zs = [t + random.randn()*4 for t in range (40)]
-            Fs = [np.array([[1., dt], [0, 1]] for dt in dts]
-            (mu, cov, _, _) = kf.batch_filter(zs, Fs=Fs)
-            (xs, Ps, Ks, Pps) = kf.rts_smoother(mu, cov, Fs=Fs)
+    def batch_filter(
+        self,
+        zs,
+        Fs=None,
+        Qs=None,
+        Hs=None,
+        Rs=None,
+        Bs=None,
+        us=None,
+        update_first=False,
+        saver=None,
+    ):
+        """Batch processes a sequences of measurements.
+         Parameters
+         ----------
+         zs : list-like
+             list of measurements at each time step `self.dt`. Missing
+             measurements must be represented by `None`.
+         Fs : None, list-like, default=None
+             optional value or list of values to use for the state transition
+             matrix F.
+             If Fs is None then self.F is used for all epochs.
+             Otherwise it must contain a list-like list of F's, one for
+             each epoch.  This allows you to have varying F per epoch.
+         Qs : None, np.array or list-like, default=None
+             optional value or list of values to use for the process error
+             covariance Q.
+             If Qs is None then self.Q is used for all epochs.
+             Otherwise it must contain a list-like list of Q's, one for
+             each epoch.  This allows you to have varying Q per epoch.
+         Hs : None, np.array or list-like, default=None
+             optional list of values to use for the measurement matrix H.
+             If Hs is None then self.H is used for all epochs.
+             If Hs contains a single matrix, then it is used as H for all
+             epochs.
+             Otherwise it must contain a list-like list of H's, one for
+             each epoch.  This allows you to have varying H per epoch.
+         Rs : None, np.array or list-like, default=None
+             optional list of values to use for the measurement error
+             covariance R.
+             If Rs is None then self.R is used for all epochs.
+             Otherwise it must contain a list-like list of R's, one for
+             each epoch.  This allows you to have varying R per epoch.
+         Bs : None, np.array or list-like, default=None
+             optional list of values to use for the control transition matrix B.
+             If Bs is None then self.B is used for all epochs.
+             Otherwise it must contain a list-like list of B's, one for
+             each epoch.  This allows you to have varying B per epoch.
+         us : None, np.array or list-like, default=None
+             optional list of values to use for the control input vector;
+             If us is None then None is used for all epochs (equivalent to 0,
+             or no control input).
+             Otherwise it must contain a list-like list of u's, one for
+             each epoch.
+        update_first : bool, optional, default=False
+             controls whether the order of operations is update followed by
+             predict, or predict followed by update. Default is predict->update.
+         saver : filterpy.common.Saver, optional
+             filterpy.common.Saver object. If provided, saver.save() will be
+             called after every epoch
+         Returns
+         -------
+         means : np.array((n,dim_x,1))
+             array of the state for each time step after the update. Each entry
+             is an np.array. In other words `means[k,:]` is the state at step
+             `k`.
+         covariance : np.array((n,dim_x,dim_x))
+             array of the covariances for each time step after the update.
+             In other words `covariance[k,:,:]` is the covariance at step `k`.
+         means_predictions : np.array((n,dim_x,1))
+             array of the state for each time step after the predictions. Each
+             entry is an np.array. In other words `means[k,:]` is the state at
+             step `k`.
+         covariance_predictions : np.array((n,dim_x,dim_x))
+             array of the covariances for each time step after the prediction.
+             In other words `covariance[k,:,:]` is the covariance at step `k`.
+         Examples
+         --------
+         .. code-block:: Python
+             # this example demonstrates tracking a measurement where the time
+             # between measurement varies, as stored in dts. This requires
+             # that F be recomputed for each epoch. The output is then smoothed
+             # with an RTS smoother.
+             zs = [t + random.randn()*4 for t in range (40)]
+             Fs = [np.array([[1., dt], [0, 1]] for dt in dts]
+             (mu, cov, _, _) = kf.batch_filter(zs, Fs=Fs)
+             (xs, Ps, Ks, Pps) = kf.rts_smoother(mu, cov, Fs=Fs)
         """
 
-        #pylint: disable=too-many-statements
+        # pylint: disable=too-many-statements
         n = np.size(zs, 0)
         if Fs is None:
             Fs = [self.F] * n
@@ -808,7 +812,6 @@ class KalmanFilterNew(object):
 
         if update_first:
             for i, (z, F, Q, H, R, B, u) in enumerate(zip(zs, Fs, Qs, Hs, Rs, Bs, us)):
-
                 self.update(z, R=R, H=H)
                 means[i, :] = self.x
                 covariances[i, :, :] = self.P
@@ -821,7 +824,6 @@ class KalmanFilterNew(object):
                     saver.save()
         else:
             for i, (z, F, Q, H, R, B, u) in enumerate(zip(zs, Fs, Qs, Hs, Rs, Bs, us)):
-
                 self.predict(u=u, B=B, F=F, Q=Q)
                 means_p[i, :] = self.x
                 covariances_p[i, :, :] = self.P
@@ -875,7 +877,7 @@ class KalmanFilterNew(object):
         """
 
         if len(Xs) != len(Ps):
-            raise ValueError('length of Xs and Ps must be the same')
+            raise ValueError("length of Xs and Ps must be the same")
 
         n = Xs.shape[0]
         dim_x = Xs.shape[1]
@@ -889,13 +891,13 @@ class KalmanFilterNew(object):
         K = zeros((n, dim_x, dim_x))
 
         x, P, Pp = Xs.copy(), Ps.copy(), Ps.copy()
-        for k in range(n-2, -1, -1):
-            Pp[k] = dot(dot(Fs[k+1], P[k]), Fs[k+1].T) + Qs[k+1]
+        for k in range(n - 2, -1, -1):
+            Pp[k] = dot(dot(Fs[k + 1], P[k]), Fs[k + 1].T) + Qs[k + 1]
 
-            #pylint: disable=bad-whitespace
-            K[k]  = dot(dot(P[k], Fs[k+1].T), inv(Pp[k]))
-            x[k] += dot(K[k], x[k+1] - dot(Fs[k+1], x[k]))
-            P[k] += dot(dot(K[k], P[k+1] - Pp[k]), K[k].T)
+            # pylint: disable=bad-whitespace
+            K[k] = dot(dot(P[k], Fs[k + 1].T), inv(Pp[k]))
+            x[k] += dot(K[k], x[k + 1] - dot(Fs[k + 1], x[k]))
+            P[k] += dot(dot(K[k], P[k + 1] - Pp[k]), K[k].T)
 
         return (x, P, K, Pp)
 
@@ -955,7 +957,7 @@ class KalmanFilterNew(object):
         -------
         (x, P) : tuple
             State vector and covariance array of the update.
-       """
+        """
 
         if z is None:
             return self.x, self.P
@@ -1037,7 +1039,7 @@ class KalmanFilterNew(object):
 
     @property
     def mahalanobis(self):
-        """"
+        """ "
         Mahalanobis distance of measurement. E.g. 3 means measurement
         was 3 standard deviations away from the predicted value.
         Returns
@@ -1057,7 +1059,7 @@ class KalmanFilterNew(object):
         filter's estimates. This formulation of the Fading memory filter
         (there are many) is due to Dan Simon [1]_.
         """
-        return self._alpha_sq**.5
+        return self._alpha_sq**0.5
 
     def log_likelihood_of(self, z):
         """
@@ -1072,39 +1074,41 @@ class KalmanFilterNew(object):
     @alpha.setter
     def alpha(self, value):
         if not np.isscalar(value) or value < 1:
-            raise ValueError('alpha must be a float greater than 1')
+            raise ValueError("alpha must be a float greater than 1")
 
         self._alpha_sq = value**2
 
     def __repr__(self):
-        return '\n'.join([
-            'KalmanFilter object',
-            pretty_str('dim_x', self.dim_x),
-            pretty_str('dim_z', self.dim_z),
-            pretty_str('dim_u', self.dim_u),
-            pretty_str('x', self.x),
-            pretty_str('P', self.P),
-            pretty_str('x_prior', self.x_prior),
-            pretty_str('P_prior', self.P_prior),
-            pretty_str('x_post', self.x_post),
-            pretty_str('P_post', self.P_post),
-            pretty_str('F', self.F),
-            pretty_str('Q', self.Q),
-            pretty_str('R', self.R),
-            pretty_str('H', self.H),
-            pretty_str('K', self.K),
-            pretty_str('y', self.y),
-            pretty_str('S', self.S),
-            pretty_str('SI', self.SI),
-            pretty_str('M', self.M),
-            pretty_str('B', self.B),
-            pretty_str('z', self.z),
-            pretty_str('log-likelihood', self.log_likelihood),
-            pretty_str('likelihood', self.likelihood),
-            pretty_str('mahalanobis', self.mahalanobis),
-            pretty_str('alpha', self.alpha),
-            pretty_str('inv', self.inv)
-            ])
+        return "\n".join(
+            [
+                "KalmanFilter object",
+                pretty_str("dim_x", self.dim_x),
+                pretty_str("dim_z", self.dim_z),
+                pretty_str("dim_u", self.dim_u),
+                pretty_str("x", self.x),
+                pretty_str("P", self.P),
+                pretty_str("x_prior", self.x_prior),
+                pretty_str("P_prior", self.P_prior),
+                pretty_str("x_post", self.x_post),
+                pretty_str("P_post", self.P_post),
+                pretty_str("F", self.F),
+                pretty_str("Q", self.Q),
+                pretty_str("R", self.R),
+                pretty_str("H", self.H),
+                pretty_str("K", self.K),
+                pretty_str("y", self.y),
+                pretty_str("S", self.S),
+                pretty_str("SI", self.SI),
+                pretty_str("M", self.M),
+                pretty_str("B", self.B),
+                pretty_str("z", self.z),
+                pretty_str("log-likelihood", self.log_likelihood),
+                pretty_str("likelihood", self.likelihood),
+                pretty_str("mahalanobis", self.mahalanobis),
+                pretty_str("alpha", self.alpha),
+                pretty_str("inv", self.inv),
+            ]
+        )
 
     def test_matrix_dimensions(self, z=None, H=None, R=None, F=None, Q=None):
         """
@@ -1132,37 +1136,44 @@ class KalmanFilterNew(object):
         x = self.x
         P = self.P
 
-        assert x.ndim == 1 or x.ndim == 2, \
-                "x must have one or two dimensions, but has {}".format(x.ndim)
+        assert x.ndim == 1 or x.ndim == 2, (
+            "x must have one or two dimensions, but has {}".format(x.ndim)
+        )
 
         if x.ndim == 1:
-            assert x.shape[0] == self.dim_x, \
-                   "Shape of x must be ({},{}), but is {}".format(
-                       self.dim_x, 1, x.shape)
+            assert x.shape[0] == self.dim_x, (
+                "Shape of x must be ({},{}), but is {}".format(self.dim_x, 1, x.shape)
+            )
         else:
-            assert x.shape == (self.dim_x, 1), \
-                   "Shape of x must be ({},{}), but is {}".format(
-                       self.dim_x, 1, x.shape)
+            assert x.shape == (self.dim_x, 1), (
+                "Shape of x must be ({},{}), but is {}".format(self.dim_x, 1, x.shape)
+            )
 
-        assert P.shape == (self.dim_x, self.dim_x), \
-               "Shape of P must be ({},{}), but is {}".format(
-                   self.dim_x, self.dim_x, P.shape)
+        assert P.shape == (self.dim_x, self.dim_x), (
+            "Shape of P must be ({},{}), but is {}".format(
+                self.dim_x, self.dim_x, P.shape
+            )
+        )
 
-        assert Q.shape == (self.dim_x, self.dim_x), \
-               "Shape of Q must be ({},{}), but is {}".format(
-                   self.dim_x, self.dim_x, P.shape)
+        assert Q.shape == (self.dim_x, self.dim_x), (
+            "Shape of Q must be ({},{}), but is {}".format(
+                self.dim_x, self.dim_x, P.shape
+            )
+        )
 
-        assert F.shape == (self.dim_x, self.dim_x), \
-               "Shape of F must be ({},{}), but is {}".format(
-                   self.dim_x, self.dim_x, F.shape)
+        assert F.shape == (self.dim_x, self.dim_x), (
+            "Shape of F must be ({},{}), but is {}".format(
+                self.dim_x, self.dim_x, F.shape
+            )
+        )
 
-        assert np.ndim(H) == 2, \
-               "Shape of H must be (dim_z, {}), but is {}".format(
-                   P.shape[0], shape(H))
+        assert np.ndim(H) == 2, "Shape of H must be (dim_z, {}), but is {}".format(
+            P.shape[0], shape(H)
+        )
 
-        assert H.shape[1] == P.shape[0], \
-               "Shape of H must be (dim_z, {}), but is {}".format(
-                   P.shape[0], H.shape)
+        assert H.shape[1] == P.shape[0], (
+            "Shape of H must be (dim_z, {}), but is {}".format(P.shape[0], H.shape)
+        )
 
         # shape of R must be the same as HPH'
         hph_shape = (H.shape[0], H.shape[0])
@@ -1170,13 +1181,15 @@ class KalmanFilterNew(object):
 
         if H.shape[0] == 1:
             # r can be scalar, 1D, or 2D in this case
-            assert r_shape in [(), (1,), (1, 1)], \
-            "R must be scalar or one element array, but is shaped {}".format(
-                r_shape)
+            assert r_shape in [(), (1,), (1, 1)], (
+                "R must be scalar or one element array, but is shaped {}".format(
+                    r_shape
+                )
+            )
         else:
-            assert r_shape == hph_shape, \
-            "shape of R should be {} but it is {}".format(hph_shape, r_shape)
-
+            assert r_shape == hph_shape, "shape of R should be {} but it is {}".format(
+                hph_shape, r_shape
+            )
 
         if z is not None:
             z_shape = shape(z)
@@ -1186,24 +1199,31 @@ class KalmanFilterNew(object):
         # H@x must have shape of z
         Hx = dot(H, x)
 
-        if z_shape == (): # scalar or np.array(scalar)
-            assert Hx.ndim == 1 or shape(Hx) == (1, 1), \
-            "shape of z should be {}, not {} for the given H".format(
-                shape(Hx), z_shape)
+        if z_shape == ():  # scalar or np.array(scalar)
+            assert Hx.ndim == 1 or shape(Hx) == (1, 1), (
+                "shape of z should be {}, not {} for the given H".format(
+                    shape(Hx), z_shape
+                )
+            )
 
         elif shape(Hx) == (1,):
-            assert z_shape[0] == 1, 'Shape of z must be {} for the given H'.format(shape(Hx))
+            assert z_shape[0] == 1, "Shape of z must be {} for the given H".format(
+                shape(Hx)
+            )
 
         else:
-            assert (z_shape == shape(Hx) or
-                    (len(z_shape) == 1 and shape(Hx) == (z_shape[0], 1))), \
-                    "shape of z should be {}, not {} for the given H".format(
-                        shape(Hx), z_shape)
+            assert z_shape == shape(Hx) or (
+                len(z_shape) == 1 and shape(Hx) == (z_shape[0], 1)
+            ), "shape of z should be {}, not {} for the given H".format(
+                shape(Hx), z_shape
+            )
 
         if np.ndim(Hx) > 1 and shape(Hx) != (1, 1):
-            assert shape(Hx) == z_shape, \
-               'shape of z should be {} for the given H, but it is {}'.format(
-                   shape(Hx), z_shape)
+            assert shape(Hx) == z_shape, (
+                "shape of z should be {} for the given H, but it is {}".format(
+                    shape(Hx), z_shape
+                )
+            )
 
 
 def update(x, P, z, R, H=None, return_all=False):
@@ -1247,7 +1267,7 @@ def update(x, P, z, R, H=None, return_all=False):
         log likelihood of the measurement
     """
 
-    #pylint: disable=bare-except
+    # pylint: disable=bare-except
 
     if z is None:
         if return_all:
@@ -1269,14 +1289,12 @@ def update(x, P, z, R, H=None, return_all=False):
     # project system uncertainty into measurement space
     S = dot(dot(H, P), H.T) + R
 
-
     # map system uncertainty into kalman gain
     try:
         K = dot(dot(P, H.T), linalg.inv(S))
     except:
         # can't invert a 1D array, annoyingly
-        K = dot(dot(P, H.T), 1./S)
-
+        K = dot(dot(P, H.T), 1.0 / S)
 
     # predict new x with residual scaled by the kalman gain
     x = x + dot(K, y)
@@ -1289,7 +1307,6 @@ def update(x, P, z, R, H=None, return_all=False):
     except:
         I_KH = np.array([1 - KH])
     P = dot(dot(I_KH, P), I_KH.T) + dot(dot(K, R), K.T)
-
 
     if return_all:
         # compute log likelihood
@@ -1326,7 +1343,6 @@ def update_steadystate(x, z, K, H=None):
     >>> update_steadystate(x, P, z, H)
     """
 
-
     if z is None:
         return x
 
@@ -1346,7 +1362,7 @@ def update_steadystate(x, z, K, H=None):
     return x + dot(K, y)
 
 
-def predict(x, P, F=1, Q=0, u=0, B=1, alpha=1.):
+def predict(x, P, F=1, Q=0, u=0, B=1, alpha=1.0):
     """
     Predict next state (prior) using the Kalman filter state propagation
     equations.
@@ -1418,9 +1434,9 @@ def predict_steadystate(x, F=1, u=0, B=1):
     return x
 
 
-
-def batch_filter(x, P, zs, Fs, Qs, Hs, Rs, Bs=None, us=None,
-                 update_first=False, saver=None):
+def batch_filter(
+    x, P, zs, Fs, Qs, Hs, Rs, Bs=None, us=None, update_first=False, saver=None
+):
     """
     Batch processes a sequences of measurements.
     Parameters
@@ -1495,12 +1511,11 @@ def batch_filter(x, P, zs, Fs, Qs, Hs, Rs, Bs=None, us=None,
     covariances_p = zeros((n, dim_x, dim_x))
 
     if us is None:
-        us = [0.] * n
-        Bs = [0.] * n
+        us = [0.0] * n
+        Bs = [0.0] * n
 
     if update_first:
         for i, (z, F, Q, H, R, B, u) in enumerate(zip(zs, Fs, Qs, Hs, Rs, Bs, us)):
-
             x, P = update(x, P, z, R=R, H=H)
             means[i, :] = x
             covariances[i, :, :] = P
@@ -1512,7 +1527,6 @@ def batch_filter(x, P, zs, Fs, Qs, Hs, Rs, Bs=None, us=None,
                 saver.save()
     else:
         for i, (z, F, Q, H, R, B, u) in enumerate(zip(zs, Fs, Qs, Hs, Rs, Bs, us)):
-
             x, P = predict(x, P, u=u, B=B, F=F, Q=Q)
             means_p[i, :] = x
             covariances_p[i, :, :] = P
@@ -1524,7 +1538,6 @@ def batch_filter(x, P, zs, Fs, Qs, Hs, Rs, Bs=None, us=None,
                 saver.save()
 
     return (means, covariances, means_p, covariances_p)
-
 
 
 def rts_smoother(Xs, Ps, Fs, Qs):
@@ -1562,7 +1575,7 @@ def rts_smoother(Xs, Ps, Fs, Qs):
     """
 
     if len(Xs) != len(Ps):
-        raise ValueError('length of Xs and Ps must be the same')
+        raise ValueError("length of Xs and Ps must be the same")
 
     n = Xs.shape[0]
     dim_x = Xs.shape[1]
@@ -1571,12 +1584,12 @@ def rts_smoother(Xs, Ps, Fs, Qs):
     K = zeros((n, dim_x, dim_x))
     x, P, pP = Xs.copy(), Ps.copy(), Ps.copy()
 
-    for k in range(n-2, -1, -1):
+    for k in range(n - 2, -1, -1):
         pP[k] = dot(dot(Fs[k], P[k]), Fs[k].T) + Qs[k]
 
-        #pylint: disable=bad-whitespace
-        K[k]  = dot(dot(P[k], Fs[k].T), linalg.inv(pP[k]))
-        x[k] += dot(K[k], x[k+1] - dot(Fs[k], x[k]))
-        P[k] += dot(dot(K[k], P[k+1] - pP[k]), K[k].T)
+        # pylint: disable=bad-whitespace
+        K[k] = dot(dot(P[k], Fs[k].T), linalg.inv(pP[k]))
+        x[k] += dot(K[k], x[k + 1] - dot(Fs[k], x[k]))
+        P[k] += dot(dot(K[k], P[k + 1] - pP[k]), K[k].T)
 
     return (x, P, K, pP)

--- a/trackers/core/ocsort/kalman_filter.py
+++ b/trackers/core/ocsort/kalman_filter.py
@@ -1,0 +1,1582 @@
+"""
+This module implements the linear Kalman filter in both an object
+oriented and procedural form. The KalmanFilter class implements
+the filter by storing the various matrices in instance variables,
+minimizing the amount of bookkeeping you have to do.
+All Kalman filters operate with a predict->update cycle. The
+predict step, implemented with the method or function predict(),
+uses the state transition matrix F to predict the state in the next
+time period (epoch). The state is stored as a gaussian (x, P), where
+x is the state (column) vector, and P is its covariance. Covariance
+matrix Q specifies the process covariance. In Bayesian terms, this
+prediction is called the *prior*, which you can think of colloquially
+as the estimate prior to incorporating the measurement.
+The update step, implemented with the method or function `update()`,
+incorporates the measurement z with covariance R, into the state
+estimate (x, P). The class stores the system uncertainty in S,
+the innovation (residual between prediction and measurement in
+measurement space) in y, and the Kalman gain in k. The procedural
+form returns these variables to you. In Bayesian terms this computes
+the *posterior* - the estimate after the information from the
+measurement is incorporated.
+Whether you use the OO form or procedural form is up to you. If
+matrices such as H, R, and F are changing each epoch, you'll probably
+opt to use the procedural form. If they are unchanging, the OO
+form is perhaps easier to use since you won't need to keep track
+of these matrices. This is especially useful if you are implementing
+banks of filters or comparing various KF designs for performance;
+a trivial coding bug could lead to using the wrong sets of matrices.
+This module also offers an implementation of the RTS smoother, and
+other helper functions, such as log likelihood computations.
+The Saver class allows you to easily save the state of the
+KalmanFilter class after every update
+This module expects NumPy arrays for all values that expect
+arrays, although in a few cases, particularly method parameters,
+it will accept types that convert to NumPy arrays, such as lists
+of lists. These exceptions are documented in the method or function.
+Examples
+--------
+The following example constructs a constant velocity kinematic
+filter, filters noisy data, and plots the results. It also demonstrates
+using the Saver class to save the state of the filter at each epoch.
+.. code-block:: Python
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from filterpy.kalman import KalmanFilter
+    from filterpy.common import Q_discrete_white_noise, Saver
+    r_std, q_std = 2., 0.003
+    cv = KalmanFilter(dim_x=2, dim_z=1)
+    cv.x = np.array([[0., 1.]]) # position, velocity
+    cv.F = np.array([[1, dt],[ [0, 1]])
+    cv.R = np.array([[r_std^^2]])
+    f.H = np.array([[1., 0.]])
+    f.P = np.diag([.1^^2, .03^^2)
+    f.Q = Q_discrete_white_noise(2, dt, q_std**2)
+    saver = Saver(cv)
+    for z in range(100):
+        cv.predict()
+        cv.update([z + randn() * r_std])
+        saver.save() # save the filter's state
+    saver.to_array()
+    plt.plot(saver.x[:, 0])
+    # plot all of the priors
+    plt.plot(saver.x_prior[:, 0])
+    # plot mahalanobis distance
+    plt.figure()
+    plt.plot(saver.mahalanobis)
+This code implements the same filter using the procedural form
+    x = np.array([[0., 1.]]) # position, velocity
+    F = np.array([[1, dt],[ [0, 1]])
+    R = np.array([[r_std^^2]])
+    H = np.array([[1., 0.]])
+    P = np.diag([.1^^2, .03^^2)
+    Q = Q_discrete_white_noise(2, dt, q_std**2)
+    for z in range(100):
+        x, P = predict(x, P, F=F, Q=Q)
+        x, P = update(x, P, z=[z + randn() * r_std], R=R, H=H)
+        xs.append(x[0, 0])
+    plt.plot(xs)
+For more examples see the test subdirectory, or refer to the
+book cited below. In it I both teach Kalman filtering from basic
+principles, and teach the use of this library in great detail.
+FilterPy library.
+http://github.com/rlabbe/filterpy
+Documentation at:
+https://filterpy.readthedocs.org
+Supporting book at:
+https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
+This is licensed under an MIT license. See the readme.MD file
+for more information.
+Copyright 2014-2018 Roger R Labbe Jr.
+
+Reference Link : https://github.com/noahcao/OC_SORT/blob/master/trackers/ocsort_tracker/kalmanfilter.py
+"""
+
+from __future__ import absolute_import, division
+
+from copy import deepcopy
+from math import log, exp, sqrt
+import sys
+import numpy as np
+from numpy import dot, zeros, eye, isscalar, shape
+import numpy.linalg as linalg
+from trackers.core.ocsort.filterpy_funcs import logpdf, pretty_str, reshape_z
+
+
+#  from filterpy.stats import logpdf
+# from filterpy.common import pretty_str, reshape_z
+
+
+class KalmanFilterNew(object):
+    """ Implements a Kalman filter. You are responsible for setting the
+    various state variables to reasonable values; the defaults  will
+    not give you a functional filter.
+    For now the best documentation is my free book Kalman and Bayesian
+    Filters in Python [2]_. The test files in this directory also give you a
+    basic idea of use, albeit without much description.
+    In brief, you will first construct this object, specifying the size of
+    the state vector with dim_x and the size of the measurement vector that
+    you will be using with dim_z. These are mostly used to perform size checks
+    when you assign values to the various matrices. For example, if you
+    specified dim_z=2 and then try to assign a 3x3 matrix to R (the
+    measurement noise matrix you will get an assert exception because R
+    should be 2x2. (If for whatever reason you need to alter the size of
+    things midstream just use the underscore version of the matrices to
+    assign directly: your_filter._R = a_3x3_matrix.)
+    After construction the filter will have default matrices created for you,
+    but you must specify the values for each. It’s usually easiest to just
+    overwrite them rather than assign to each element yourself. This will be
+    clearer in the example below. All are of type numpy.array.
+    Examples
+    --------
+    Here is a filter that tracks position and velocity using a sensor that only
+    reads position.
+    First construct the object with the required dimensionality. Here the state
+    (`dim_x`) has 2 coefficients (position and velocity), and the measurement
+    (`dim_z`) has one. In FilterPy `x` is the state, `z` is the measurement.
+    .. code::
+        from filterpy.kalman import KalmanFilter
+        f = KalmanFilter (dim_x=2, dim_z=1)
+    Assign the initial value for the state (position and velocity). You can do this
+    with a two dimensional array like so:
+        .. code::
+            f.x = np.array([[2.],    # position
+                            [0.]])   # velocity
+    or just use a one dimensional array, which I prefer doing.
+    .. code::
+        f.x = np.array([2., 0.])
+    Define the state transition matrix:
+        .. code::
+            f.F = np.array([[1.,1.],
+                            [0.,1.]])
+    Define the measurement function. Here we need to convert a position-velocity
+    vector into just a position vector, so we use:
+        .. code::
+        f.H = np.array([[1., 0.]])
+    Define the state's covariance matrix P. 
+    .. code::
+        f.P = np.array([[1000.,    0.],
+                        [   0., 1000.] ])
+    Now assign the measurement noise. Here the dimension is 1x1, so I can
+    use a scalar
+    .. code::
+        f.R = 5
+    I could have done this instead:
+    .. code::
+        f.R = np.array([[5.]])
+    Note that this must be a 2 dimensional array.
+    Finally, I will assign the process noise. Here I will take advantage of
+    another FilterPy library function:
+    .. code::
+        from filterpy.common import Q_discrete_white_noise
+        f.Q = Q_discrete_white_noise(dim=2, dt=0.1, var=0.13)
+    Now just perform the standard predict/update loop:
+    .. code::
+        while some_condition_is_true:
+            z = get_sensor_reading()
+            f.predict()
+            f.update(z)
+            do_something_with_estimate (f.x)
+    **Procedural Form**
+    This module also contains stand alone functions to perform Kalman filtering.
+    Use these if you are not a fan of objects.
+    **Example**
+    .. code::
+        while True:
+            z, R = read_sensor()
+            x, P = predict(x, P, F, Q)
+            x, P = update(x, P, z, R, H)
+    See my book Kalman and Bayesian Filters in Python [2]_.
+    You will have to set the following attributes after constructing this
+    object for the filter to perform properly. Please note that there are
+    various checks in place to ensure that you have made everything the
+    'correct' size. However, it is possible to provide incorrectly sized
+    arrays such that the linear algebra can not perform an operation.
+    It can also fail silently - you can end up with matrices of a size that
+    allows the linear algebra to work, but are the wrong shape for the problem
+    you are trying to solve.
+    Parameters
+    ----------
+    dim_x : int
+        Number of state variables for the Kalman filter. For example, if
+        you are tracking the position and velocity of an object in two
+        dimensions, dim_x would be 4.
+        This is used to set the default size of P, Q, and u
+    dim_z : int
+        Number of of measurement inputs. For example, if the sensor
+        provides you with position in (x,y), dim_z would be 2.
+    dim_u : int (optional)
+        size of the control input, if it is being used.
+        Default value of 0 indicates it is not used.
+    compute_log_likelihood : bool (default = True)
+        Computes log likelihood by default, but this can be a slow
+        computation, so if you never use it you can turn this computation
+        off.
+    Attributes
+    ----------
+    x : numpy.array(dim_x, 1)
+        Current state estimate. Any call to update() or predict() updates
+        this variable.
+    P : numpy.array(dim_x, dim_x)
+        Current state covariance matrix. Any call to update() or predict()
+        updates this variable.
+    x_prior : numpy.array(dim_x, 1)
+        Prior (predicted) state estimate. The *_prior and *_post attributes
+        are for convenience; they store the  prior and posterior of the
+        current epoch. Read Only.
+    P_prior : numpy.array(dim_x, dim_x)
+        Prior (predicted) state covariance matrix. Read Only.
+    x_post : numpy.array(dim_x, 1)
+        Posterior (updated) state estimate. Read Only.
+    P_post : numpy.array(dim_x, dim_x)
+        Posterior (updated) state covariance matrix. Read Only.
+    z : numpy.array
+        Last measurement used in update(). Read only.
+    R : numpy.array(dim_z, dim_z)
+        Measurement noise covariance matrix. Also known as the
+        observation covariance.
+    Q : numpy.array(dim_x, dim_x)
+        Process noise covariance matrix. Also known as the transition
+        covariance.
+    F : numpy.array()
+        State Transition matrix. Also known as `A` in some formulation.
+    H : numpy.array(dim_z, dim_x)
+        Measurement function. Also known as the observation matrix, or as `C`.
+    y : numpy.array
+        Residual of the update step. Read only.
+    K : numpy.array(dim_x, dim_z)
+        Kalman gain of the update step. Read only.
+    S :  numpy.array
+        System uncertainty (P projected to measurement space). Read only.
+    SI :  numpy.array
+        Inverse system uncertainty. Read only.
+    log_likelihood : float
+        log-likelihood of the last measurement. Read only.
+    likelihood : float
+        likelihood of last measurement. Read only.
+        Computed from the log-likelihood. The log-likelihood can be very
+        small,  meaning a large negative value such as -28000. Taking the
+        exp() of that results in 0.0, which can break typical algorithms
+        which multiply by this value, so by default we always return a
+        number >= sys.float_info.min.
+    mahalanobis : float
+        mahalanobis distance of the innovation. Read only.
+    inv : function, default numpy.linalg.inv
+        If you prefer another inverse function, such as the Moore-Penrose
+        pseudo inverse, set it to that instead: kf.inv = np.linalg.pinv
+        This is only used to invert self.S. If you know it is diagonal, you
+        might choose to set it to filterpy.common.inv_diagonal, which is
+        several times faster than numpy.linalg.inv for diagonal matrices.
+    alpha : float
+        Fading memory setting. 1.0 gives the normal Kalman filter, and
+        values slightly larger than 1.0 (such as 1.02) give a fading
+        memory effect - previous measurements have less influence on the
+        filter's estimates. This formulation of the Fading memory filter
+        (there are many) is due to Dan Simon [1]_.
+    References
+    ----------
+    .. [1] Dan Simon. "Optimal State Estimation." John Wiley & Sons.
+       p. 208-212. (2006)
+    .. [2] Roger Labbe. "Kalman and Bayesian Filters in Python"
+       https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
+    """
+
+    def __init__(self, dim_x, dim_z, dim_u=0):
+        if dim_x < 1:
+            raise ValueError('dim_x must be 1 or greater')
+        if dim_z < 1:
+            raise ValueError('dim_z must be 1 or greater')
+        if dim_u < 0:
+            raise ValueError('dim_u must be 0 or greater')
+
+        self.dim_x = dim_x
+        self.dim_z = dim_z
+        self.dim_u = dim_u
+
+        self.x = zeros((dim_x, 1))        # state
+        self.P = eye(dim_x)               # uncertainty covariance
+        self.Q = eye(dim_x)               # process uncertainty
+        self.B = None                     # control transition matrix
+        self.F = eye(dim_x)               # state transition matrix
+        self.H = zeros((dim_z, dim_x))    # measurement function
+        self.R = eye(dim_z)               # measurement uncertainty
+        self._alpha_sq = 1.               # fading memory control
+        self.M = np.zeros((dim_x, dim_z)) # process-measurement cross correlation
+        self.z = np.array([[None]*self.dim_z]).T
+
+        # gain and residual are computed during the innovation step. We
+        # save them so that in case you want to inspect them for various
+        # purposes
+        self.K = np.zeros((dim_x, dim_z)) # kalman gain
+        self.y = zeros((dim_z, 1))
+        self.S = np.zeros((dim_z, dim_z)) # system uncertainty
+        self.SI = np.zeros((dim_z, dim_z)) # inverse system uncertainty
+
+        # identity matrix. Do not alter this.
+        self._I = np.eye(dim_x)
+
+        # these will always be a copy of x,P after predict() is called
+        self.x_prior = self.x.copy()
+        self.P_prior = self.P.copy()
+
+        # these will always be a copy of x,P after update() is called
+        self.x_post = self.x.copy()             
+        self.P_post = self.P.copy()
+
+        # Only computed only if requested via property
+        self._log_likelihood = log(sys.float_info.min)
+        self._likelihood = sys.float_info.min
+        self._mahalanobis = None
+
+        # keep all observations 
+        self.history_obs = []
+
+        self.inv = np.linalg.inv
+
+        self.attr_saved = None
+        self.observed = False 
+
+
+    def predict(self, u=None, B=None, F=None, Q=None):
+        """
+        Predict next state (prior) using the Kalman filter state propagation
+        equations.
+        Parameters
+        ----------
+        u : np.array, default 0
+            Optional control vector.
+        B : np.array(dim_x, dim_u), or None
+            Optional control transition matrix; a value of None
+            will cause the filter to use `self.B`.
+        F : np.array(dim_x, dim_x), or None
+            Optional state transition matrix; a value of None
+            will cause the filter to use `self.F`.
+        Q : np.array(dim_x, dim_x), scalar, or None
+            Optional process noise matrix; a value of None will cause the
+            filter to use `self.Q`.
+        """
+
+        if B is None:
+            B = self.B
+        if F is None:
+            F = self.F
+        if Q is None:
+            Q = self.Q
+        elif isscalar(Q):
+            Q = eye(self.dim_x) * Q
+
+
+        # x = Fx + Bu
+        if B is not None and u is not None:
+            self.x = dot(F, self.x) + dot(B, u)
+        else:
+            self.x = dot(F, self.x)
+
+        # P = FPF' + Q
+        self.P = self._alpha_sq * dot(dot(F, self.P), F.T) + Q
+
+        # save prior
+        self.x_prior = self.x.copy()
+        self.P_prior = self.P.copy()
+
+
+
+    def freeze(self):
+        """
+            Save the parameters before non-observation forward
+        """
+        self.attr_saved = deepcopy(self.__dict__)
+
+
+    def unfreeze(self):
+        if self.attr_saved is not None:
+            new_history = deepcopy(self.history_obs)
+            self.__dict__ = self.attr_saved
+            # self.history_obs = new_history 
+            self.history_obs = self.history_obs[:-1]
+            occur = [int(d is None) for d in new_history]
+            indices = np.where(np.array(occur)==0)[0]
+            index1 = indices[-2]
+            index2 = indices[-1]
+            box1 = new_history[index1]
+            x1, y1, s1, r1 = box1 
+            w1 = np.sqrt(s1 * r1)
+            h1 = np.sqrt(s1 / r1)
+            box2 = new_history[index2]
+            x2, y2, s2, r2 = box2 
+            w2 = np.sqrt(s2 * r2)
+            h2 = np.sqrt(s2 / r2)
+            time_gap = index2 - index1
+            dx = (x2-x1)/time_gap
+            dy = (y2-y1)/time_gap 
+            dw = (w2-w1)/time_gap 
+            dh = (h2-h1)/time_gap
+            for i in range(index2 - index1):
+                """
+                    The default virtual trajectory generation is by linear
+                    motion (constant speed hypothesis), you could modify this 
+                    part to implement your own. 
+                """
+                x = x1 + (i+1) * dx 
+                y = y1 + (i+1) * dy 
+                w = w1 + (i+1) * dw 
+                h = h1 + (i+1) * dh
+                s = w * h 
+                r = w / float(h)
+                new_box = np.array([x, y, s, r]).reshape((4, 1))
+                """
+                    I still use predict-update loop here to refresh the parameters,
+                    but this can be faster by directly modifying the internal parameters
+                    as suggested in the paper. I keep this naive but slow way for 
+                    easy read and understanding
+                """
+                self.update(new_box)
+                if not i == (index2-index1-1):
+                    self.predict()
+
+
+    def update(self, z, R=None, H=None):
+        """
+        Add a new measurement (z) to the Kalman filter.
+        If z is None, nothing is computed. However, x_post and P_post are
+        updated with the prior (x_prior, P_prior), and self.z is set to None.
+        Parameters
+        ----------
+        z : (dim_z, 1): array_like
+            measurement for this update. z can be a scalar if dim_z is 1,
+            otherwise it must be convertible to a column vector.
+            If you pass in a value of H, z must be a column vector the
+            of the correct size.
+        R : np.array, scalar, or None
+            Optionally provide R to override the measurement noise for this
+            one call, otherwise  self.R will be used.
+        H : np.array, or None
+            Optionally provide H to override the measurement function for this
+            one call, otherwise self.H will be used.
+        """
+
+        # set to None to force recompute
+        self._log_likelihood = None
+        self._likelihood = None
+        self._mahalanobis = None
+
+        # append the observation
+        self.history_obs.append(z)
+        
+        if z is None:
+            if self.observed:
+                """
+                    Got no observation so freeze the current parameters for future
+                    potential online smoothing.
+                """
+                self.freeze()
+            self.observed = False 
+            self.z = np.array([[None]*self.dim_z]).T
+            self.x_post = self.x.copy()
+            self.P_post = self.P.copy()
+            self.y = zeros((self.dim_z, 1))
+            return
+        
+        # self.observed = True
+        if not self.observed:
+            """
+                Get observation, use online smoothing to re-update parameters
+            """
+            self.unfreeze()
+        self.observed = True
+
+        if R is None:
+            R = self.R
+        elif isscalar(R):
+            R = eye(self.dim_z) * R
+
+        if H is None:
+            z = reshape_z(z, self.dim_z, self.x.ndim)
+            H = self.H
+
+        # y = z - Hx
+        # error (residual) between measurement and prediction
+        self.y = z - dot(H, self.x)
+
+        # common subexpression for speed
+        PHT = dot(self.P, H.T)
+
+        # S = HPH' + R
+        # project system uncertainty into measurement space
+        self.S = dot(H, PHT) + R
+        self.SI = self.inv(self.S)
+        # K = PH'inv(S)
+        # map system uncertainty into kalman gain
+        self.K = dot(PHT, self.SI)
+
+        # x = x + Ky
+        # predict new x with residual scaled by the kalman gain
+        self.x = self.x + dot(self.K, self.y)
+
+        # P = (I-KH)P(I-KH)' + KRK'
+        # This is more numerically stable
+        # and works for non-optimal K vs the equation
+        # P = (I-KH)P usually seen in the literature.
+
+        I_KH = self._I - dot(self.K, H)
+        self.P = dot(dot(I_KH, self.P), I_KH.T) + dot(dot(self.K, R), self.K.T)
+
+        # save measurement and posterior state
+        self.z = deepcopy(z)
+        self.x_post = self.x.copy()
+        self.P_post = self.P.copy()
+
+    def predict_steadystate(self, u=0, B=None):
+        """
+        Predict state (prior) using the Kalman filter state propagation
+        equations. Only x is updated, P is left unchanged. See
+        update_steadstate() for a longer explanation of when to use this
+        method.
+        Parameters
+        ----------
+        u : np.array
+            Optional control vector. If non-zero, it is multiplied by B
+            to create the control input into the system.
+        B : np.array(dim_x, dim_u), or None
+            Optional control transition matrix; a value of None
+            will cause the filter to use `self.B`.
+        """
+
+        if B is None:
+            B = self.B
+
+        # x = Fx + Bu
+        if B is not None:
+            self.x = dot(self.F, self.x) + dot(B, u)
+        else:
+            self.x = dot(self.F, self.x)
+
+        # save prior
+        self.x_prior = self.x.copy()
+        self.P_prior = self.P.copy()
+
+    def update_steadystate(self, z):
+        """
+        Add a new measurement (z) to the Kalman filter without recomputing
+        the Kalman gain K, the state covariance P, or the system
+        uncertainty S.
+        You can use this for LTI systems since the Kalman gain and covariance
+        converge to a fixed value. Precompute these and assign them explicitly,
+        or run the Kalman filter using the normal predict()/update(0 cycle
+        until they converge.
+        The main advantage of this call is speed. We do significantly less
+        computation, notably avoiding a costly matrix inversion.
+        Use in conjunction with predict_steadystate(), otherwise P will grow
+        without bound.
+        Parameters
+        ----------
+        z : (dim_z, 1): array_like
+            measurement for this update. z can be a scalar if dim_z is 1,
+            otherwise it must be convertible to a column vector.
+        Examples
+        --------
+        >>> cv = kinematic_kf(dim=3, order=2) # 3D const velocity filter
+        >>> # let filter converge on representative data, then save k and P
+        >>> for i in range(100):
+        >>>     cv.predict()
+        >>>     cv.update([i, i, i])
+        >>> saved_k = np.copy(cv.K)
+        >>> saved_P = np.copy(cv.P)
+        later on:
+        >>> cv = kinematic_kf(dim=3, order=2) # 3D const velocity filter
+        >>> cv.K = np.copy(saved_K)
+        >>> cv.P = np.copy(saved_P)
+        >>> for i in range(100):
+        >>>     cv.predict_steadystate()
+        >>>     cv.update_steadystate([i, i, i])
+        """
+
+        # set to None to force recompute
+        self._log_likelihood = None
+        self._likelihood = None
+        self._mahalanobis = None
+
+        if z is None:
+            self.z = np.array([[None]*self.dim_z]).T
+            self.x_post = self.x.copy()
+            self.P_post = self.P.copy()
+            self.y = zeros((self.dim_z, 1))
+            return
+
+        z = reshape_z(z, self.dim_z, self.x.ndim)
+
+        # y = z - Hx
+        # error (residual) between measurement and prediction
+        self.y = z - dot(self.H, self.x)
+
+        # x = x + Ky
+        # predict new x with residual scaled by the kalman gain
+        self.x = self.x + dot(self.K, self.y)
+
+        self.z = deepcopy(z)
+        self.x_post = self.x.copy()
+        self.P_post = self.P.copy()
+
+        # set to None to force recompute
+        self._log_likelihood = None
+        self._likelihood = None
+        self._mahalanobis = None
+
+    def update_correlated(self, z, R=None, H=None):
+        """ Add a new measurement (z) to the Kalman filter assuming that
+        process noise and measurement noise are correlated as defined in
+        the `self.M` matrix.
+        A partial derivation can be found in [1]
+        If z is None, nothing is changed.
+        Parameters
+        ----------
+        z : (dim_z, 1): array_like
+            measurement for this update. z can be a scalar if dim_z is 1,
+            otherwise it must be convertible to a column vector.
+        R : np.array, scalar, or None
+            Optionally provide R to override the measurement noise for this
+            one call, otherwise  self.R will be used.
+        H : np.array,  or None
+            Optionally provide H to override the measurement function for this
+            one call, otherwise  self.H will be used.
+        References
+        ----------
+        .. [1] Bulut, Y. (2011). Applied Kalman filter theory (Doctoral dissertation, Northeastern University).
+               http://people.duke.edu/~hpgavin/SystemID/References/Balut-KalmanFilter-PhD-NEU-2011.pdf
+        """
+
+        # set to None to force recompute
+        self._log_likelihood = None
+        self._likelihood = None
+        self._mahalanobis = None
+
+        if z is None:
+            self.z = np.array([[None]*self.dim_z]).T
+            self.x_post = self.x.copy()
+            self.P_post = self.P.copy()
+            self.y = zeros((self.dim_z, 1))
+            return
+
+        if R is None:
+            R = self.R
+        elif isscalar(R):
+            R = eye(self.dim_z) * R
+
+        # rename for readability and a tiny extra bit of speed
+        if H is None:
+            z = reshape_z(z, self.dim_z, self.x.ndim)
+            H = self.H
+
+        # handle special case: if z is in form [[z]] but x is not a column
+        # vector dimensions will not match
+        if self.x.ndim == 1 and shape(z) == (1, 1):
+            z = z[0]
+
+        if shape(z) == (): # is it scalar, e.g. z=3 or z=np.array(3)
+            z = np.asarray([z])
+
+        # y = z - Hx
+        # error (residual) between measurement and prediction
+        self.y = z - dot(H, self.x)
+
+        # common subexpression for speed
+        PHT = dot(self.P, H.T)
+
+        # project system uncertainty into measurement space
+        self.S = dot(H, PHT) + dot(H, self.M) + dot(self.M.T, H.T) + R
+        self.SI = self.inv(self.S)
+
+        # K = PH'inv(S)
+        # map system uncertainty into kalman gain
+        self.K = dot(PHT + self.M, self.SI)
+
+        # x = x + Ky
+        # predict new x with residual scaled by the kalman gain
+        self.x = self.x + dot(self.K, self.y)
+        self.P = self.P - dot(self.K, dot(H, self.P) + self.M.T)
+
+        self.z = deepcopy(z)
+        self.x_post = self.x.copy()
+        self.P_post = self.P.copy()
+
+    def batch_filter(self, zs, Fs=None, Qs=None, Hs=None,
+                     Rs=None, Bs=None, us=None, update_first=False,
+                     saver=None):
+        """ Batch processes a sequences of measurements.
+        Parameters
+        ----------
+        zs : list-like
+            list of measurements at each time step `self.dt`. Missing
+            measurements must be represented by `None`.
+        Fs : None, list-like, default=None
+            optional value or list of values to use for the state transition
+            matrix F.
+            If Fs is None then self.F is used for all epochs.
+            Otherwise it must contain a list-like list of F's, one for
+            each epoch.  This allows you to have varying F per epoch.
+        Qs : None, np.array or list-like, default=None
+            optional value or list of values to use for the process error
+            covariance Q.
+            If Qs is None then self.Q is used for all epochs.
+            Otherwise it must contain a list-like list of Q's, one for
+            each epoch.  This allows you to have varying Q per epoch.
+        Hs : None, np.array or list-like, default=None
+            optional list of values to use for the measurement matrix H.
+            If Hs is None then self.H is used for all epochs.
+            If Hs contains a single matrix, then it is used as H for all
+            epochs.
+            Otherwise it must contain a list-like list of H's, one for
+            each epoch.  This allows you to have varying H per epoch.
+        Rs : None, np.array or list-like, default=None
+            optional list of values to use for the measurement error
+            covariance R.
+            If Rs is None then self.R is used for all epochs.
+            Otherwise it must contain a list-like list of R's, one for
+            each epoch.  This allows you to have varying R per epoch.
+        Bs : None, np.array or list-like, default=None
+            optional list of values to use for the control transition matrix B.
+            If Bs is None then self.B is used for all epochs.
+            Otherwise it must contain a list-like list of B's, one for
+            each epoch.  This allows you to have varying B per epoch.
+        us : None, np.array or list-like, default=None
+            optional list of values to use for the control input vector;
+            If us is None then None is used for all epochs (equivalent to 0,
+            or no control input).
+            Otherwise it must contain a list-like list of u's, one for
+            each epoch.
+       update_first : bool, optional, default=False
+            controls whether the order of operations is update followed by
+            predict, or predict followed by update. Default is predict->update.
+        saver : filterpy.common.Saver, optional
+            filterpy.common.Saver object. If provided, saver.save() will be
+            called after every epoch
+        Returns
+        -------
+        means : np.array((n,dim_x,1))
+            array of the state for each time step after the update. Each entry
+            is an np.array. In other words `means[k,:]` is the state at step
+            `k`.
+        covariance : np.array((n,dim_x,dim_x))
+            array of the covariances for each time step after the update.
+            In other words `covariance[k,:,:]` is the covariance at step `k`.
+        means_predictions : np.array((n,dim_x,1))
+            array of the state for each time step after the predictions. Each
+            entry is an np.array. In other words `means[k,:]` is the state at
+            step `k`.
+        covariance_predictions : np.array((n,dim_x,dim_x))
+            array of the covariances for each time step after the prediction.
+            In other words `covariance[k,:,:]` is the covariance at step `k`.
+        Examples
+        --------
+        .. code-block:: Python
+            # this example demonstrates tracking a measurement where the time
+            # between measurement varies, as stored in dts. This requires
+            # that F be recomputed for each epoch. The output is then smoothed
+            # with an RTS smoother.
+            zs = [t + random.randn()*4 for t in range (40)]
+            Fs = [np.array([[1., dt], [0, 1]] for dt in dts]
+            (mu, cov, _, _) = kf.batch_filter(zs, Fs=Fs)
+            (xs, Ps, Ks, Pps) = kf.rts_smoother(mu, cov, Fs=Fs)
+        """
+
+        #pylint: disable=too-many-statements
+        n = np.size(zs, 0)
+        if Fs is None:
+            Fs = [self.F] * n
+        if Qs is None:
+            Qs = [self.Q] * n
+        if Hs is None:
+            Hs = [self.H] * n
+        if Rs is None:
+            Rs = [self.R] * n
+        if Bs is None:
+            Bs = [self.B] * n
+        if us is None:
+            us = [0] * n
+
+        # mean estimates from Kalman Filter
+        if self.x.ndim == 1:
+            means = zeros((n, self.dim_x))
+            means_p = zeros((n, self.dim_x))
+        else:
+            means = zeros((n, self.dim_x, 1))
+            means_p = zeros((n, self.dim_x, 1))
+
+        # state covariances from Kalman Filter
+        covariances = zeros((n, self.dim_x, self.dim_x))
+        covariances_p = zeros((n, self.dim_x, self.dim_x))
+
+        if update_first:
+            for i, (z, F, Q, H, R, B, u) in enumerate(zip(zs, Fs, Qs, Hs, Rs, Bs, us)):
+
+                self.update(z, R=R, H=H)
+                means[i, :] = self.x
+                covariances[i, :, :] = self.P
+
+                self.predict(u=u, B=B, F=F, Q=Q)
+                means_p[i, :] = self.x
+                covariances_p[i, :, :] = self.P
+
+                if saver is not None:
+                    saver.save()
+        else:
+            for i, (z, F, Q, H, R, B, u) in enumerate(zip(zs, Fs, Qs, Hs, Rs, Bs, us)):
+
+                self.predict(u=u, B=B, F=F, Q=Q)
+                means_p[i, :] = self.x
+                covariances_p[i, :, :] = self.P
+
+                self.update(z, R=R, H=H)
+                means[i, :] = self.x
+                covariances[i, :, :] = self.P
+
+                if saver is not None:
+                    saver.save()
+
+        return (means, covariances, means_p, covariances_p)
+
+    def rts_smoother(self, Xs, Ps, Fs=None, Qs=None, inv=np.linalg.inv):
+        """
+        Runs the Rauch-Tung-Striebel Kalman smoother on a set of
+        means and covariances computed by a Kalman filter. The usual input
+        would come from the output of `KalmanFilter.batch_filter()`.
+        Parameters
+        ----------
+        Xs : numpy.array
+           array of the means (state variable x) of the output of a Kalman
+           filter.
+        Ps : numpy.array
+            array of the covariances of the output of a kalman filter.
+        Fs : list-like collection of numpy.array, optional
+            State transition matrix of the Kalman filter at each time step.
+            Optional, if not provided the filter's self.F will be used
+        Qs : list-like collection of numpy.array, optional
+            Process noise of the Kalman filter at each time step. Optional,
+            if not provided the filter's self.Q will be used
+        inv : function, default numpy.linalg.inv
+            If you prefer another inverse function, such as the Moore-Penrose
+            pseudo inverse, set it to that instead: kf.inv = np.linalg.pinv
+        Returns
+        -------
+        x : numpy.ndarray
+           smoothed means
+        P : numpy.ndarray
+           smoothed state covariances
+        K : numpy.ndarray
+            smoother gain at each step
+        Pp : numpy.ndarray
+           Predicted state covariances
+        Examples
+        --------
+        .. code-block:: Python
+            zs = [t + random.randn()*4 for t in range (40)]
+            (mu, cov, _, _) = kalman.batch_filter(zs)
+            (x, P, K, Pp) = rts_smoother(mu, cov, kf.F, kf.Q)
+        """
+
+        if len(Xs) != len(Ps):
+            raise ValueError('length of Xs and Ps must be the same')
+
+        n = Xs.shape[0]
+        dim_x = Xs.shape[1]
+
+        if Fs is None:
+            Fs = [self.F] * n
+        if Qs is None:
+            Qs = [self.Q] * n
+
+        # smoother gain
+        K = zeros((n, dim_x, dim_x))
+
+        x, P, Pp = Xs.copy(), Ps.copy(), Ps.copy()
+        for k in range(n-2, -1, -1):
+            Pp[k] = dot(dot(Fs[k+1], P[k]), Fs[k+1].T) + Qs[k+1]
+
+            #pylint: disable=bad-whitespace
+            K[k]  = dot(dot(P[k], Fs[k+1].T), inv(Pp[k]))
+            x[k] += dot(K[k], x[k+1] - dot(Fs[k+1], x[k]))
+            P[k] += dot(dot(K[k], P[k+1] - Pp[k]), K[k].T)
+
+        return (x, P, K, Pp)
+
+    def get_prediction(self, u=None, B=None, F=None, Q=None):
+        """
+        Predict next state (prior) using the Kalman filter state propagation
+        equations and returns it without modifying the object.
+        Parameters
+        ----------
+        u : np.array, default 0
+            Optional control vector.
+        B : np.array(dim_x, dim_u), or None
+            Optional control transition matrix; a value of None
+            will cause the filter to use `self.B`.
+        F : np.array(dim_x, dim_x), or None
+            Optional state transition matrix; a value of None
+            will cause the filter to use `self.F`.
+        Q : np.array(dim_x, dim_x), scalar, or None
+            Optional process noise matrix; a value of None will cause the
+            filter to use `self.Q`.
+        Returns
+        -------
+        (x, P) : tuple
+            State vector and covariance array of the prediction.
+        """
+
+        if B is None:
+            B = self.B
+        if F is None:
+            F = self.F
+        if Q is None:
+            Q = self.Q
+        elif isscalar(Q):
+            Q = eye(self.dim_x) * Q
+
+        # x = Fx + Bu
+        if B is not None and u is not None:
+            x = dot(F, self.x) + dot(B, u)
+        else:
+            x = dot(F, self.x)
+
+        # P = FPF' + Q
+        P = self._alpha_sq * dot(dot(F, self.P), F.T) + Q
+
+        return x, P
+
+    def get_update(self, z=None):
+        """
+        Computes the new estimate based on measurement `z` and returns it
+        without altering the state of the filter.
+        Parameters
+        ----------
+        z : (dim_z, 1): array_like
+            measurement for this update. z can be a scalar if dim_z is 1,
+            otherwise it must be convertible to a column vector.
+        Returns
+        -------
+        (x, P) : tuple
+            State vector and covariance array of the update.
+       """
+
+        if z is None:
+            return self.x, self.P
+        z = reshape_z(z, self.dim_z, self.x.ndim)
+
+        R = self.R
+        H = self.H
+        P = self.P
+        x = self.x
+
+        # error (residual) between measurement and prediction
+        y = z - dot(H, x)
+
+        # common subexpression for speed
+        PHT = dot(P, H.T)
+
+        # project system uncertainty into measurement space
+        S = dot(H, PHT) + R
+
+        # map system uncertainty into kalman gain
+        K = dot(PHT, self.inv(S))
+
+        # predict new x with residual scaled by the kalman gain
+        x = x + dot(K, y)
+
+        # P = (I-KH)P(I-KH)' + KRK'
+        I_KH = self._I - dot(K, H)
+        P = dot(dot(I_KH, P), I_KH.T) + dot(dot(K, R), K.T)
+
+        return x, P
+
+    def residual_of(self, z):
+        """
+        Returns the residual for the given measurement (z). Does not alter
+        the state of the filter.
+        """
+        z = reshape_z(z, self.dim_z, self.x.ndim)
+        return z - dot(self.H, self.x_prior)
+
+    def measurement_of_state(self, x):
+        """
+        Helper function that converts a state into a measurement.
+        Parameters
+        ----------
+        x : np.array
+            kalman state vector
+        Returns
+        -------
+        z : (dim_z, 1): array_like
+            measurement for this update. z can be a scalar if dim_z is 1,
+            otherwise it must be convertible to a column vector.
+        """
+
+        return dot(self.H, x)
+
+    @property
+    def log_likelihood(self):
+        """
+        log-likelihood of the last measurement.
+        """
+        if self._log_likelihood is None:
+            self._log_likelihood = logpdf(x=self.y, cov=self.S)
+        return self._log_likelihood
+
+    @property
+    def likelihood(self):
+        """
+        Computed from the log-likelihood. The log-likelihood can be very
+        small,  meaning a large negative value such as -28000. Taking the
+        exp() of that results in 0.0, which can break typical algorithms
+        which multiply by this value, so by default we always return a
+        number >= sys.float_info.min.
+        """
+        if self._likelihood is None:
+            self._likelihood = exp(self.log_likelihood)
+            if self._likelihood == 0:
+                self._likelihood = sys.float_info.min
+        return self._likelihood
+
+    @property
+    def mahalanobis(self):
+        """"
+        Mahalanobis distance of measurement. E.g. 3 means measurement
+        was 3 standard deviations away from the predicted value.
+        Returns
+        -------
+        mahalanobis : float
+        """
+        if self._mahalanobis is None:
+            self._mahalanobis = sqrt(float(dot(dot(self.y.T, self.SI), self.y)))
+        return self._mahalanobis
+
+    @property
+    def alpha(self):
+        """
+        Fading memory setting. 1.0 gives the normal Kalman filter, and
+        values slightly larger than 1.0 (such as 1.02) give a fading
+        memory effect - previous measurements have less influence on the
+        filter's estimates. This formulation of the Fading memory filter
+        (there are many) is due to Dan Simon [1]_.
+        """
+        return self._alpha_sq**.5
+
+    def log_likelihood_of(self, z):
+        """
+        log likelihood of the measurement `z`. This should only be called
+        after a call to update(). Calling after predict() will yield an
+        incorrect result."""
+
+        if z is None:
+            return log(sys.float_info.min)
+        return logpdf(z, dot(self.H, self.x), self.S)
+
+    @alpha.setter
+    def alpha(self, value):
+        if not np.isscalar(value) or value < 1:
+            raise ValueError('alpha must be a float greater than 1')
+
+        self._alpha_sq = value**2
+
+    def __repr__(self):
+        return '\n'.join([
+            'KalmanFilter object',
+            pretty_str('dim_x', self.dim_x),
+            pretty_str('dim_z', self.dim_z),
+            pretty_str('dim_u', self.dim_u),
+            pretty_str('x', self.x),
+            pretty_str('P', self.P),
+            pretty_str('x_prior', self.x_prior),
+            pretty_str('P_prior', self.P_prior),
+            pretty_str('x_post', self.x_post),
+            pretty_str('P_post', self.P_post),
+            pretty_str('F', self.F),
+            pretty_str('Q', self.Q),
+            pretty_str('R', self.R),
+            pretty_str('H', self.H),
+            pretty_str('K', self.K),
+            pretty_str('y', self.y),
+            pretty_str('S', self.S),
+            pretty_str('SI', self.SI),
+            pretty_str('M', self.M),
+            pretty_str('B', self.B),
+            pretty_str('z', self.z),
+            pretty_str('log-likelihood', self.log_likelihood),
+            pretty_str('likelihood', self.likelihood),
+            pretty_str('mahalanobis', self.mahalanobis),
+            pretty_str('alpha', self.alpha),
+            pretty_str('inv', self.inv)
+            ])
+
+    def test_matrix_dimensions(self, z=None, H=None, R=None, F=None, Q=None):
+        """
+        Performs a series of asserts to check that the size of everything
+        is what it should be. This can help you debug problems in your design.
+        If you pass in H, R, F, Q those will be used instead of this object's
+        value for those matrices.
+        Testing `z` (the measurement) is problamatic. x is a vector, and can be
+        implemented as either a 1D array or as a nx1 column vector. Thus Hx
+        can be of different shapes. Then, if Hx is a single value, it can
+        be either a 1D array or 2D vector. If either is true, z can reasonably
+        be a scalar (either '3' or np.array('3') are scalars under this
+        definition), a 1D, 1 element array, or a 2D, 1 element array. You are
+        allowed to pass in any combination that works.
+        """
+
+        if H is None:
+            H = self.H
+        if R is None:
+            R = self.R
+        if F is None:
+            F = self.F
+        if Q is None:
+            Q = self.Q
+        x = self.x
+        P = self.P
+
+        assert x.ndim == 1 or x.ndim == 2, \
+                "x must have one or two dimensions, but has {}".format(x.ndim)
+
+        if x.ndim == 1:
+            assert x.shape[0] == self.dim_x, \
+                   "Shape of x must be ({},{}), but is {}".format(
+                       self.dim_x, 1, x.shape)
+        else:
+            assert x.shape == (self.dim_x, 1), \
+                   "Shape of x must be ({},{}), but is {}".format(
+                       self.dim_x, 1, x.shape)
+
+        assert P.shape == (self.dim_x, self.dim_x), \
+               "Shape of P must be ({},{}), but is {}".format(
+                   self.dim_x, self.dim_x, P.shape)
+
+        assert Q.shape == (self.dim_x, self.dim_x), \
+               "Shape of Q must be ({},{}), but is {}".format(
+                   self.dim_x, self.dim_x, P.shape)
+
+        assert F.shape == (self.dim_x, self.dim_x), \
+               "Shape of F must be ({},{}), but is {}".format(
+                   self.dim_x, self.dim_x, F.shape)
+
+        assert np.ndim(H) == 2, \
+               "Shape of H must be (dim_z, {}), but is {}".format(
+                   P.shape[0], shape(H))
+
+        assert H.shape[1] == P.shape[0], \
+               "Shape of H must be (dim_z, {}), but is {}".format(
+                   P.shape[0], H.shape)
+
+        # shape of R must be the same as HPH'
+        hph_shape = (H.shape[0], H.shape[0])
+        r_shape = shape(R)
+
+        if H.shape[0] == 1:
+            # r can be scalar, 1D, or 2D in this case
+            assert r_shape in [(), (1,), (1, 1)], \
+            "R must be scalar or one element array, but is shaped {}".format(
+                r_shape)
+        else:
+            assert r_shape == hph_shape, \
+            "shape of R should be {} but it is {}".format(hph_shape, r_shape)
+
+
+        if z is not None:
+            z_shape = shape(z)
+        else:
+            z_shape = (self.dim_z, 1)
+
+        # H@x must have shape of z
+        Hx = dot(H, x)
+
+        if z_shape == (): # scalar or np.array(scalar)
+            assert Hx.ndim == 1 or shape(Hx) == (1, 1), \
+            "shape of z should be {}, not {} for the given H".format(
+                shape(Hx), z_shape)
+
+        elif shape(Hx) == (1,):
+            assert z_shape[0] == 1, 'Shape of z must be {} for the given H'.format(shape(Hx))
+
+        else:
+            assert (z_shape == shape(Hx) or
+                    (len(z_shape) == 1 and shape(Hx) == (z_shape[0], 1))), \
+                    "shape of z should be {}, not {} for the given H".format(
+                        shape(Hx), z_shape)
+
+        if np.ndim(Hx) > 1 and shape(Hx) != (1, 1):
+            assert shape(Hx) == z_shape, \
+               'shape of z should be {} for the given H, but it is {}'.format(
+                   shape(Hx), z_shape)
+
+
+def update(x, P, z, R, H=None, return_all=False):
+    """
+    Add a new measurement (z) to the Kalman filter. If z is None, nothing
+    is changed.
+    This can handle either the multidimensional or unidimensional case. If
+    all parameters are floats instead of arrays the filter will still work,
+    and return floats for x, P as the result.
+    update(1, 2, 1, 1, 1)  # univariate
+    update(x, P, 1
+    Parameters
+    ----------
+    x : numpy.array(dim_x, 1), or float
+        State estimate vector
+    P : numpy.array(dim_x, dim_x), or float
+        Covariance matrix
+    z : (dim_z, 1): array_like
+        measurement for this update. z can be a scalar if dim_z is 1,
+        otherwise it must be convertible to a column vector.
+    R : numpy.array(dim_z, dim_z), or float
+        Measurement noise matrix
+    H : numpy.array(dim_x, dim_x), or float, optional
+        Measurement function. If not provided, a value of 1 is assumed.
+    return_all : bool, default False
+        If true, y, K, S, and log_likelihood are returned, otherwise
+        only x and P are returned.
+    Returns
+    -------
+    x : numpy.array
+        Posterior state estimate vector
+    P : numpy.array
+        Posterior covariance matrix
+    y : numpy.array or scalar
+        Residua. Difference between measurement and state in measurement space
+    K : numpy.array
+        Kalman gain
+    S : numpy.array
+        System uncertainty in measurement space
+    log_likelihood : float
+        log likelihood of the measurement
+    """
+
+    #pylint: disable=bare-except
+
+    if z is None:
+        if return_all:
+            return x, P, None, None, None, None
+        return x, P
+
+    if H is None:
+        H = np.array([1])
+
+    if np.isscalar(H):
+        H = np.array([H])
+
+    Hx = np.atleast_1d(dot(H, x))
+    z = reshape_z(z, Hx.shape[0], x.ndim)
+
+    # error (residual) between measurement and prediction
+    y = z - Hx
+
+    # project system uncertainty into measurement space
+    S = dot(dot(H, P), H.T) + R
+
+
+    # map system uncertainty into kalman gain
+    try:
+        K = dot(dot(P, H.T), linalg.inv(S))
+    except:
+        # can't invert a 1D array, annoyingly
+        K = dot(dot(P, H.T), 1./S)
+
+
+    # predict new x with residual scaled by the kalman gain
+    x = x + dot(K, y)
+
+    # P = (I-KH)P(I-KH)' + KRK'
+    KH = dot(K, H)
+
+    try:
+        I_KH = np.eye(KH.shape[0]) - KH
+    except:
+        I_KH = np.array([1 - KH])
+    P = dot(dot(I_KH, P), I_KH.T) + dot(dot(K, R), K.T)
+
+
+    if return_all:
+        # compute log likelihood
+        log_likelihood = logpdf(z, dot(H, x), S)
+        return x, P, y, K, S, log_likelihood
+    return x, P
+
+
+def update_steadystate(x, z, K, H=None):
+    """
+    Add a new measurement (z) to the Kalman filter. If z is None, nothing
+    is changed.
+    Parameters
+    ----------
+    x : numpy.array(dim_x, 1), or float
+        State estimate vector
+    z : (dim_z, 1): array_like
+        measurement for this update. z can be a scalar if dim_z is 1,
+        otherwise it must be convertible to a column vector.
+    K : numpy.array, or float
+        Kalman gain matrix
+    H : numpy.array(dim_x, dim_x), or float, optional
+        Measurement function. If not provided, a value of 1 is assumed.
+    Returns
+    -------
+    x : numpy.array
+        Posterior state estimate vector
+    Examples
+    --------
+    This can handle either the multidimensional or unidimensional case. If
+    all parameters are floats instead of arrays the filter will still work,
+    and return floats for x, P as the result.
+    >>> update_steadystate(1, 2, 1)  # univariate
+    >>> update_steadystate(x, P, z, H)
+    """
+
+
+    if z is None:
+        return x
+
+    if H is None:
+        H = np.array([1])
+
+    if np.isscalar(H):
+        H = np.array([H])
+
+    Hx = np.atleast_1d(dot(H, x))
+    z = reshape_z(z, Hx.shape[0], x.ndim)
+
+    # error (residual) between measurement and prediction
+    y = z - Hx
+
+    # estimate new x with residual scaled by the kalman gain
+    return x + dot(K, y)
+
+
+def predict(x, P, F=1, Q=0, u=0, B=1, alpha=1.):
+    """
+    Predict next state (prior) using the Kalman filter state propagation
+    equations.
+    Parameters
+    ----------
+    x : numpy.array
+        State estimate vector
+    P : numpy.array
+        Covariance matrix
+    F : numpy.array()
+        State Transition matrix
+    Q : numpy.array, Optional
+        Process noise matrix
+    u : numpy.array, Optional, default 0.
+        Control vector. If non-zero, it is multiplied by B
+        to create the control input into the system.
+    B : numpy.array, optional, default 0.
+        Control transition matrix.
+    alpha : float, Optional, default=1.0
+        Fading memory setting. 1.0 gives the normal Kalman filter, and
+        values slightly larger than 1.0 (such as 1.02) give a fading
+        memory effect - previous measurements have less influence on the
+        filter's estimates. This formulation of the Fading memory filter
+        (there are many) is due to Dan Simon
+    Returns
+    -------
+    x : numpy.array
+        Prior state estimate vector
+    P : numpy.array
+        Prior covariance matrix
+    """
+
+    if np.isscalar(F):
+        F = np.array(F)
+    x = dot(F, x) + dot(B, u)
+    P = (alpha * alpha) * dot(dot(F, P), F.T) + Q
+
+    return x, P
+
+
+def predict_steadystate(x, F=1, u=0, B=1):
+    """
+    Predict next state (prior) using the Kalman filter state propagation
+    equations. This steady state form only computes x, assuming that the
+    covariance is constant.
+    Parameters
+    ----------
+    x : numpy.array
+        State estimate vector
+    P : numpy.array
+        Covariance matrix
+    F : numpy.array()
+        State Transition matrix
+    u : numpy.array, Optional, default 0.
+        Control vector. If non-zero, it is multiplied by B
+        to create the control input into the system.
+    B : numpy.array, optional, default 0.
+        Control transition matrix.
+    Returns
+    -------
+    x : numpy.array
+        Prior state estimate vector
+    """
+
+    if np.isscalar(F):
+        F = np.array(F)
+    x = dot(F, x) + dot(B, u)
+
+    return x
+
+
+
+def batch_filter(x, P, zs, Fs, Qs, Hs, Rs, Bs=None, us=None,
+                 update_first=False, saver=None):
+    """
+    Batch processes a sequences of measurements.
+    Parameters
+    ----------
+    zs : list-like
+        list of measurements at each time step. Missing measurements must be
+        represented by None.
+    Fs : list-like
+        list of values to use for the state transition matrix matrix.
+    Qs : list-like
+        list of values to use for the process error
+        covariance.
+    Hs : list-like
+        list of values to use for the measurement matrix.
+    Rs : list-like
+        list of values to use for the measurement error
+        covariance.
+    Bs : list-like, optional
+        list of values to use for the control transition matrix;
+        a value of None in any position will cause the filter
+        to use `self.B` for that time step.
+    us : list-like, optional
+        list of values to use for the control input vector;
+        a value of None in any position will cause the filter to use
+        0 for that time step.
+    update_first : bool, optional
+        controls whether the order of operations is update followed by
+        predict, or predict followed by update. Default is predict->update.
+        saver : filterpy.common.Saver, optional
+            filterpy.common.Saver object. If provided, saver.save() will be
+            called after every epoch
+    Returns
+    -------
+    means : np.array((n,dim_x,1))
+        array of the state for each time step after the update. Each entry
+        is an np.array. In other words `means[k,:]` is the state at step
+        `k`.
+    covariance : np.array((n,dim_x,dim_x))
+        array of the covariances for each time step after the update.
+        In other words `covariance[k,:,:]` is the covariance at step `k`.
+    means_predictions : np.array((n,dim_x,1))
+        array of the state for each time step after the predictions. Each
+        entry is an np.array. In other words `means[k,:]` is the state at
+        step `k`.
+    covariance_predictions : np.array((n,dim_x,dim_x))
+        array of the covariances for each time step after the prediction.
+        In other words `covariance[k,:,:]` is the covariance at step `k`.
+    Examples
+    --------
+    .. code-block:: Python
+        zs = [t + random.randn()*4 for t in range (40)]
+        Fs = [kf.F for t in range (40)]
+        Hs = [kf.H for t in range (40)]
+        (mu, cov, _, _) = kf.batch_filter(zs, Rs=R_list, Fs=Fs, Hs=Hs, Qs=None,
+                                          Bs=None, us=None, update_first=False)
+        (xs, Ps, Ks, Pps) = kf.rts_smoother(mu, cov, Fs=Fs, Qs=None)
+    """
+
+    n = np.size(zs, 0)
+    dim_x = x.shape[0]
+
+    # mean estimates from Kalman Filter
+    if x.ndim == 1:
+        means = zeros((n, dim_x))
+        means_p = zeros((n, dim_x))
+    else:
+        means = zeros((n, dim_x, 1))
+        means_p = zeros((n, dim_x, 1))
+
+    # state covariances from Kalman Filter
+    covariances = zeros((n, dim_x, dim_x))
+    covariances_p = zeros((n, dim_x, dim_x))
+
+    if us is None:
+        us = [0.] * n
+        Bs = [0.] * n
+
+    if update_first:
+        for i, (z, F, Q, H, R, B, u) in enumerate(zip(zs, Fs, Qs, Hs, Rs, Bs, us)):
+
+            x, P = update(x, P, z, R=R, H=H)
+            means[i, :] = x
+            covariances[i, :, :] = P
+
+            x, P = predict(x, P, u=u, B=B, F=F, Q=Q)
+            means_p[i, :] = x
+            covariances_p[i, :, :] = P
+            if saver is not None:
+                saver.save()
+    else:
+        for i, (z, F, Q, H, R, B, u) in enumerate(zip(zs, Fs, Qs, Hs, Rs, Bs, us)):
+
+            x, P = predict(x, P, u=u, B=B, F=F, Q=Q)
+            means_p[i, :] = x
+            covariances_p[i, :, :] = P
+
+            x, P = update(x, P, z, R=R, H=H)
+            means[i, :] = x
+            covariances[i, :, :] = P
+            if saver is not None:
+                saver.save()
+
+    return (means, covariances, means_p, covariances_p)
+
+
+
+def rts_smoother(Xs, Ps, Fs, Qs):
+    """
+    Runs the Rauch-Tung-Striebel Kalman smoother on a set of
+    means and covariances computed by a Kalman filter. The usual input
+    would come from the output of `KalmanFilter.batch_filter()`.
+    Parameters
+    ----------
+    Xs : numpy.array
+       array of the means (state variable x) of the output of a Kalman
+       filter.
+    Ps : numpy.array
+        array of the covariances of the output of a kalman filter.
+    Fs : list-like collection of numpy.array
+        State transition matrix of the Kalman filter at each time step.
+    Qs : list-like collection of numpy.array, optional
+        Process noise of the Kalman filter at each time step.
+    Returns
+    -------
+    x : numpy.ndarray
+       smoothed means
+    P : numpy.ndarray
+       smoothed state covariances
+    K : numpy.ndarray
+        smoother gain at each step
+    pP : numpy.ndarray
+       predicted state covariances
+    Examples
+    --------
+    .. code-block:: Python
+        zs = [t + random.randn()*4 for t in range (40)]
+        (mu, cov, _, _) = kalman.batch_filter(zs)
+        (x, P, K, pP) = rts_smoother(mu, cov, kf.F, kf.Q)
+    """
+
+    if len(Xs) != len(Ps):
+        raise ValueError('length of Xs and Ps must be the same')
+
+    n = Xs.shape[0]
+    dim_x = Xs.shape[1]
+
+    # smoother gain
+    K = zeros((n, dim_x, dim_x))
+    x, P, pP = Xs.copy(), Ps.copy(), Ps.copy()
+
+    for k in range(n-2, -1, -1):
+        pP[k] = dot(dot(Fs[k], P[k]), Fs[k].T) + Qs[k]
+
+        #pylint: disable=bad-whitespace
+        K[k]  = dot(dot(P[k], Fs[k].T), linalg.inv(pP[k]))
+        x[k] += dot(K[k], x[k+1] - dot(Fs[k], x[k]))
+        P[k] += dot(dot(K[k], P[k+1] - pP[k]), K[k].T)
+
+    return (x, P, K, pP)

--- a/trackers/core/ocsort/tracker.py
+++ b/trackers/core/ocsort/tracker.py
@@ -1,0 +1,503 @@
+"""
+Reference Link : https://github.com/noahcao/OC_SORT/blob/master/trackers/ocsort_tracker/ocsort.py
+"""
+
+from typing import List, Optional, Union, Tuple
+import numpy as np
+
+import supervision as sv
+
+from trackers.core.base import BaseTrackerWithFeatures
+from trackers.core.ocsort.association import *
+from trackers.core.ocsort.kalman_filter import KalmanFilterNew as KalmanFilter
+
+def k_previous_obs(
+    observations : np.ndarray,
+    cur_age : int,
+    k : int
+) -> np.ndarray:
+    """
+    Retrieves the last `k` observations for a given track.
+
+    This function extracts the most recent `k` observations from the 
+    observation history of a particular track based on the current age 
+    of the track.
+
+    Args:
+        observations (np.ndarray): Array of previous observations for the track.
+        cur_age (int): The number of frames the track has existed.
+        k (int): The number of most recent observations to retrieve.
+
+    Returns:
+        np.ndarray: An array containing the last `k` observations for the track.
+    """
+
+    if len(observations) == 0:
+        return np.array([-1, -1, -1, -1, -1])
+    for i in range(k):
+        dt = k - i
+        if cur_age - dt in observations:
+            return observations[cur_age - dt]
+        max_age = max(observations.keys())
+    return observations[max_age]
+
+def convert_bbox_to_z(bbox: np.ndarray) -> np.ndarray:
+    """
+    Converts a bounding box from [x1, y1, x2, y2] format to [x, y, s, r].
+
+    The returned format consists of:
+        - x, y: Center coordinates of the bounding box.
+        - s: Scale (area) of the bounding box.
+        - r: Aspect ratio (width divided by height).
+
+    Args:
+        bbox (List[int]): Bounding box in the format [x1, y1, x2, y2].
+
+    Returns:
+        List[float]: Converted bounding box in the format [x, y, s, r].
+    """
+    w = bbox[2] - bbox[0]
+    h = bbox[3] - bbox[1]
+    x = bbox[0] + w/2.
+    y = bbox[1] + h/2.
+    s = w * h  # scale is just area
+    r = w / float(h+1e-6)
+    return np.array([x, y, s, r]).reshape((4, 1))
+
+def convert_x_to_bbox(
+    x : Union[List[int], np.ndarray], 
+    score : Optional[float] = None
+) -> np.ndarray:
+    """
+    Converts a bounding box from center format [x, y, s, r] to corner format [x1, y1, x2, y2].
+
+    The input format:
+        - x, y: Center coordinates of the bounding box.
+        - s: Scale (area) of the bounding box.
+        - r: Aspect ratio (width divided by height).
+
+    The output format:
+        - x1, y1: Top-left corner of the bounding box.
+        - x2, y2: Bottom-right corner of the bounding box.
+
+    Args:
+        x (List[float] or np.ndarray): Bounding box in the format [x, y, s, r].
+        score (float, optional): Detection confidence score to include in the output.
+
+    Returns:
+        np.ndarray: Bounding box in the format [x1, y1, x2, y2] or 
+                    [x1, y1, x2, y2, score] if a score is provided.
+    """
+
+    w = np.sqrt(x[2] * x[3])
+    h = x[2] / w
+    if(score == None):
+      return np.array([x[0]-w/2., x[1]-h/2., x[0]+w/2., x[1]+h/2.]).reshape((1, 4))
+    else:
+      return np.array([x[0]-w/2., x[1]-h/2., x[0]+w/2., x[1]+h/2., score]).reshape((1, 5))
+
+def speed_direction(
+    bbox1 : Union[List[int], np.ndarray], 
+    bbox2 : Union[List[int], np.ndarray]
+) -> float:
+    """
+    Computes the normalized direction vector of movement between two bounding boxes.
+
+    Calculates the center points of the two bounding boxes and returns a unit 
+    vector indicating the direction of motion from `bbox1` to `bbox2`.
+
+    Args:
+        bbox1 (list or np.ndarray): First bounding box in the format [x1, y1, x2, y2].
+        bbox2 (list or np.ndarray): Second bounding box in the format [x1, y1, x2, y2].
+
+    Returns:
+        np.ndarray: A 2D unit vector [dy, dx] representing the normalized direction 
+                    of movement from the first box to the second.
+    """
+    cx1, cy1 = (bbox1[0]+bbox1[2]) / 2.0, (bbox1[1]+bbox1[3])/2.0
+    cx2, cy2 = (bbox2[0]+bbox2[2]) / 2.0, (bbox2[1]+bbox2[3])/2.0
+    speed = np.array([cy2-cy1, cx2-cx1])
+    norm = np.sqrt((cy2-cy1)**2 + (cx2-cx1)**2) + 1e-6
+    return speed / norm
+
+
+class KalmanBoxTracker(object):
+    """
+    This class represents the internal state of individual tracked objects observed as bbox.
+    """
+    count = 0
+
+    def __init__(
+        self, 
+        bbox : np.ndarray, 
+        delta_t : int = 3
+    ):
+        """
+        Initialises a tracker using initial bounding box.
+
+        """
+        # define constant velocity model
+        self.kf = KalmanFilter(dim_x=7, dim_z=4)
+        self.kf.F = np.array([[1, 0, 0, 0, 1, 0, 0], [0, 1, 0, 0, 0, 1, 0], [0, 0, 1, 0, 0, 0, 1], [
+                            0, 0, 0, 1, 0, 0, 0],  [0, 0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 1]])
+        self.kf.H = np.array([[1, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0]])
+
+        self.kf.R[2:, 2:] *= 10.
+        self.kf.P[4:, 4:] *= 1000.  # give high uncertainty to the unobservable initial velocities
+        self.kf.P *= 10.
+        self.kf.Q[-1, -1] *= 0.01
+        self.kf.Q[4:, 4:] *= 0.01
+
+        self.kf.x[:4] = convert_bbox_to_z(bbox)
+        self.time_since_update = 0
+        self.id = KalmanBoxTracker.count
+        KalmanBoxTracker.count += 1
+        self.history = []
+        self.hits = 0
+        self.hit_streak = 0
+        self.age = 0
+        position = None
+        """
+        NOTE: [-1,-1,-1,-1,-1] is a compromising placeholder for non-observation status, the same for the return of 
+        function k_previous_obs. It is ugly and I do not like it. But to support generate observation array in a 
+        fast and unified way, which you would see below k_observations = np.array([k_previous_obs(...]]), let's bear it for now.
+        """
+        self.last_observation = np.array([-1, -1, -1, -1, -1])  # placeholder
+        self.observations = dict()
+        self.history_observations = []
+        self.velocity = None
+        self.delta_t = delta_t
+
+    def update(
+        self, 
+        bbox : np.ndarray
+    ) -> None:
+        """
+        Updates the state vector with observed bbox.
+        """
+        if bbox is not None:
+            if self.last_observation.sum() >= 0:  # no previous observation
+                previous_box = None
+                for i in range(self.delta_t):
+                    dt = self.delta_t - i
+                    if self.age - dt in self.observations:
+                        previous_box = self.observations[self.age-dt]
+                        break
+                if previous_box is None:
+                    previous_box = self.last_observation
+                """
+                  Estimate the track speed direction with observations \Delta t steps away
+                """
+                self.velocity = speed_direction(previous_box, bbox)
+            
+            """
+              Insert new observations. This is a ugly way to maintain both self.observations
+              and self.history_observations. Bear it for the moment.
+            """
+            self.last_observation = bbox
+            self.observations[self.age] = bbox
+            self.history_observations.append(bbox)
+
+            self.time_since_update = 0
+            self.history = []
+            self.hits += 1
+            self.hit_streak += 1
+            self.kf.update(convert_bbox_to_z(bbox))
+        else:
+            self.kf.update(bbox)
+
+    def predict(self) -> np.ndarray:
+        """
+        Advances the state vector and returns the predicted bounding box estimate.
+        """
+        if((self.kf.x[6]+self.kf.x[2]) <= 0):
+            self.kf.x[6] *= 0.0
+
+        self.kf.predict()
+        self.age += 1
+        if(self.time_since_update > 0):
+            self.hit_streak = 0
+        self.time_since_update += 1
+        self.history.append(convert_x_to_bbox(self.kf.x))
+        return self.history[-1]
+
+    def get_state(self) -> np.ndarray:
+        """
+        Returns the current bounding box estimate.
+        """
+        return convert_x_to_bbox(self.kf.x)
+
+"""
+    We support multiple ways for association cost calculation, by default
+    we use IoU. GIoU may have better performance in some situations. We note 
+    that we hardly normalize the cost by all methods to (0,1) which may not be 
+    the best practice.
+"""
+
+ASSO_FUNCS = {  "iou": iou_batch,
+                "giou": giou_batch,
+                "ciou": ciou_batch,
+                "diou": diou_batch,
+                "ct_dist": ct_dist}
+
+class OCSORTTracker(BaseTrackerWithFeatures):
+
+    def __init__(
+        self,
+        det_thresh : float,
+        max_age : int = 30,
+        min_hits : int = 3,
+        iou_threshold : float = 0.3,
+        delta_t : int = 3,
+        asso_func : str = "iou",
+        inertia : float = 0.2,
+        use_byte : bool = False
+    ):
+        """
+        Initializes the tracker with specified parameters.
+
+        Args:
+            det_threh (float): Detection confidence threshold. Detections below this 
+                threshold are ignored.
+            max_age (int, optional): Maximum number of consecutive frames a track is 
+                kept alive without matching a new detection. Defaults to 30.
+            min_hits (int, optional): Minimum number of hits (successful matches) 
+                required to consider a track valid. Defaults to 3.
+            iou_threshold (float, optional): Minimum IOU required to associate a 
+                detection with an existing track. Defaults to 0.3.
+            delta_t (int, optional): Time interval (in frames) considered between 
+                detection updates. Useful in motion modeling. Defaults to 3.
+            asso_func (str, optional): Association metric to use. Must be one of 
+                {'iou', 'giou', 'ciou', 'diou', 'ct_dist'}, corresponding to keys 
+                in `ASSO_FUNCS`. Defaults to "iou".
+            inertia (float, optional): Blending factor between detection and prediction. 
+                A higher value places more weight on the prediction. Defaults to 0.2.
+            use_byte (bool, optional): Whether to use BYTE association logic for 
+                tracking. Defaults to False.
+        """
+        
+        self.max_age = max_age
+        self.min_hits = min_hits
+        self.iou_threshold = iou_threshold
+        self.trackers = []
+        self.frame_count = 0
+        self.det_thresh = det_thresh
+        self.delta_t = delta_t
+        self.asso_func = ASSO_FUNCS[asso_func]
+        self.inertia = inertia
+        self.use_byte = use_byte
+        KalmanBoxTracker.count = 0
+
+    def _existing_track_prediction(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        trks = np.zeros((len(self.trackers), 5))
+        to_del = []
+        for t, trk in enumerate(trks):
+            pos = self.trackers[t].predict()[0]
+            trk[:] = [pos[0], pos[1], pos[2], pos[3], 0]
+            if np.any(np.isnan(pos)):
+                to_del.append(t)
+        trks = np.ma.compress_rows(np.ma.masked_invalid(trks))
+        for t in reversed(to_del):
+            self.trackers.pop(t)
+        velocities = np.array(
+            [trk.velocity if trk.velocity is not None else np.array((0, 0)) for trk in self.trackers])
+        last_boxes = np.array([trk.last_observation for trk in self.trackers])
+        k_observations = np.array(
+            [k_previous_obs(trk.observations, trk.age, self.delta_t) for trk in self.trackers])
+        
+        return trks, velocities, last_boxes, k_observations
+    
+    def _byte_association(
+        self,
+        trks: np.ndarray,
+        dets_second: np.ndarray
+    ) -> np.ndarray:
+        """
+        Performs BYTE-level association as a secondary matching step.
+
+        This method is typically used after primary association (e.g., IOU-based) 
+        to match remaining unassociated tracks and detections using a secondary 
+        association strategy like confidence-guided IOU.
+
+        Args:
+            trks (np.ndarray): Array of unmatched track predictions in the format [[x1, y1, x2, y2, conf], [x1, y1, x2, y2, conf],...].
+            dets_second (np.ndarray): Array of unmatched detections in the same format.
+
+        Returns:
+            - matches (np.ndarray): Pairs of matched tracks based on Byte Association
+        """
+        u_trks = trks[unmatched_trks]
+        iou_left = self.asso_func(dets_second, u_trks)          # iou between low score detections and unmatched tracks
+        iou_left = np.array(iou_left)
+        if iou_left.max() > self.iou_threshold:
+            """
+                NOTE: by using a lower threshold, e.g., self.iou_threshold - 0.1, you may
+                get a higher performance especially on MOT17/MOT20 datasets. But we keep it
+                uniform here for simplicity
+            """
+            matched_indices = linear_assignment(-iou_left)
+            to_remove_trk_indices = []
+            for m in matched_indices:
+                det_ind, trk_ind = m[0], unmatched_trks[m[1]]
+                if iou_left[m[0], m[1]] < self.iou_threshold:
+                    continue
+                self.trackers[trk_ind].update(dets_second[det_ind, :])
+                to_remove_trk_indices.append(trk_ind)
+            unmatched_trks = np.setdiff1d(unmatched_trks, np.array(to_remove_trk_indices))
+
+        return unmatched_trks
+
+    def _update_detection_with_track_ids(
+        self,
+        detections : sv.Detections
+    ) -> np.ndarray:
+        """
+        Updation of matched detections with tracking IDs 
+        """
+
+        ret = []
+        to_remove = []
+        i = len(self.trackers)
+        for trk in reversed(self.trackers):
+            if trk.last_observation.sum() < 0:
+                d = trk.get_state()[0]
+            else:
+                """
+                    this is optional to use the recent observation or the kalman filter prediction,
+                    we didn't notice significant difference here
+                """
+                d = trk.last_observation[:4]
+            if (trk.time_since_update < 1) and (trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits):
+                # +1 as MOT benchmark requires positive
+                ret.append(np.concatenate((d, [trk.id+1])).reshape(1, -1))
+                detections.tracker_id[trk.position] = trk.id + 1
+            i -= 1
+            # remove dead tracklet
+            if(trk.time_since_update > self.max_age):
+                to_remove.append(i)
+
+        self.trackers = [item for i, item in enumerate(self.trackers) if i not in to_remove]
+
+        # if(len(ret) > 0):
+        #     ret = np.concatenate(ret)
+        #     detections.tracker_id = np.array(ret, dtype=int)
+        #     return detections
+        
+        # detections.tracker_id = np.array([], dtype=int)
+        return detections
+
+
+    def _get_unassociated_indices(
+        self,
+        dets,
+        last_boxes,
+        unmatched_dets,
+        unmatched_trks,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+
+        left_dets = dets[unmatched_dets]
+        left_trks = last_boxes[unmatched_trks]
+        iou_left = self.asso_func(left_dets, left_trks)
+        iou_left = np.array(iou_left)
+        if iou_left.max() > self.iou_threshold:
+            """
+                NOTE: by using a lower threshold, e.g., self.iou_threshold - 0.1, you may
+                get a higher performance especially on MOT17/MOT20 datasets. But we keep it
+                uniform here for simplicity
+            """
+            rematched_indices = linear_assignment(-iou_left)
+            to_remove_det_indices = []
+            to_remove_trk_indices = []
+            for m in rematched_indices:
+                det_ind, trk_ind = unmatched_dets[m[0]], unmatched_trks[m[1]]
+                if iou_left[m[0], m[1]] < self.iou_threshold:
+                    continue
+                self.trackers[trk_ind].update(dets[det_ind, :])
+                to_remove_det_indices.append(det_ind)
+                to_remove_trk_indices.append(trk_ind)
+            unmatched_dets = np.setdiff1d(unmatched_dets, np.array(to_remove_det_indices))
+            unmatched_trks = np.setdiff1d(unmatched_trks, np.array(to_remove_trk_indices))
+
+        return unmatched_dets, unmatched_trks
+
+    def update(
+        self, 
+        detections : sv.Detections
+    ) -> np.ndarray:
+
+        """
+        Params:
+          dets - a numpy array of detections in the format [[x1,y1,x2,y2,score],[x1,y1,x2,y2,score],...]
+        Requires: this method must be called once for each frame even with empty detections (use np.empty((0, 5)) for frames without detections).
+        Returns the a similar array, where the last column is the object ID.
+        NOTE: The number of objects returned may differ from the number of detections provided.
+        """
+
+        if len(detections) == 0:
+            detections.tracker_id = np.array([], dtype=int)
+            return detections
+        
+        detections.tracker_id = np.array([-1]*len(detections.xyxy))
+
+        self.frame_count += 1
+
+        detection_boxes = (
+            detections.xyxy if len(detections) > 0 else np.array([]).reshape(0, 4)
+        )
+
+        detections_confidence = (
+            detections.confidence if len(detections) > 0 else np.array([]).reshape(0, 4)
+        )
+
+        # Post Processing Detection Boxes
+        dets = np.concatenate((detection_boxes, np.expand_dims(detections_confidence, axis=-1)), axis=1)
+        inds_low = detections_confidence > 0.1
+        inds_high = detections_confidence < self.det_thresh
+        inds_second = np.logical_and(inds_low, inds_high)  # self.det_thresh > score > 0.1, for second matching
+        dets_second = dets[inds_second]  # detections for second matching
+        remain_inds = detections_confidence > self.det_thresh
+        dets = dets[remain_inds]
+
+        # Predict new locations for existing trackers
+        trks, velocities, last_boxes, k_observations = self._existing_track_prediction()
+
+        # First round of association
+        matched, unmatched_dets, unmatched_trks = associate(
+            dets, trks, self.iou_threshold, velocities, k_observations, self.inertia)
+        
+        # Update matched trackers with assigned detections
+        for m in matched:
+            self.trackers[m[1]].update(dets[m[0], :])
+            self.trackers[m[1]].position = m[0]
+
+        # Second round of associaton by OCR
+        if self.use_byte and len(dets_second) > 0 and unmatched_trks.shape[0] > 0:
+            unmatched_trks = self._byte_association(trks, dets_second)
+
+        # Associate detections to trackers based on Association Function
+        if unmatched_dets.shape[0] > 0 and unmatched_trks.shape[0] > 0:
+            unmatched_dets, unmatched_trks = self._get_unassociated_indices(dets, last_boxes, unmatched_dets, unmatched_trks)
+            
+        # Update unmatched tracks
+        for m in unmatched_trks:
+            self.trackers[m].update(None)
+
+        # Create new trackers for unmatched detections with confidence above threshold
+        for i in unmatched_dets:
+            trk = KalmanBoxTracker(dets[i, :], delta_t=self.delta_t)
+            trk.position = i
+            self.trackers.append(trk)
+
+        # Update detections with tracker IDs
+        dets = self._update_detection_with_track_ids(detections)
+        return dets
+    
+    def reset(self) -> None:
+        """
+        Resets the tracker's internal state.
+
+        Clears all active tracks and resets the track ID counter.
+        """
+        self.trackers = []
+        KalmanBoxTracker.count = 0


### PR DESCRIPTION
# Description

## Type of change
-   [x] New feature :  I've added OC-Sort Tracker functionality.
-   [x] This change requires a documentation update
 
## How has this change been tested, please provide a testcase or example of how you tested the change?

- The following colab notebook for testing the added tracker: [Colab Link](https://colab.research.google.com/drive/1MoGM5N2U-VU-0QgAZevwt8E3cNpQKY1f?usp=sharing
)
- The tracking video obtained after running the colab code: [Google Drive Link](https://drive.google.com/file/d/1g-gj1fI6JJ76jF3fJHypF5M2I981FiQ8/view?usp=sharing)

## Any specific deployment considerations

- There is a requirement for [filterpy](https://github.com/rlabbe/filterpy). For now, I've made a new file with those functions as a temporary working solution, but it should be added for future tracker implementation simplicity.
- Also, please add [lap](https://github.com/gatagat/lap) if possible. I've substituted it with scipy, but lap works faster.

## Docs

-  No doc update was done