### PR TITLE
Use same docs stylesheet as supervision

### DIFF
--- a/docs/overrides/stylesheets/rf.css
+++ b/docs/overrides/stylesheets/rf.css
@@ -58,7 +58,7 @@ body.light {
 .md-header__inner {
   align-items: center;
   display: grid;
-  grid-template-columns: 0.1fr 1fr 2fr 2fr;
+  grid-template-columns: 0.1fr 1.4fr 2fr 2fr;
   padding-right: 1rem;
 }
 .md-search__inner {
@@ -179,7 +179,7 @@ body {
 .md-main__inner, .md-header__inner, .md-grid {
   max-width: 100%;
 }
-@media (max-width: 1000px) {
+@media (max-width: 1200px) {
   .md-header__inner {
     display: flex;
   }
@@ -239,4 +239,12 @@ body[data-md-url$="/cookbooks/"] .md-content {
 }
 .md-nav--secondary .md-nav__title {
   position: initial !important;
+}
+
+.md-header__title .md-ellipsis {
+  overflow: initial !important;
+  text-overflow: initial !important;
+}
+.md-search {
+  flex-grow: 0;
 }


### PR DESCRIPTION
# Description

This PR updates the `trackers` documentation to use the same stylesheet as the `supervision` repository.

## Type of change

Docs theme change.

## How has this change been tested, please provide a testcase or example of how you tested the change?

This PR can be changed by running `mkdocs serve` locally and ensuring the styles look consistent with https://supervision.roboflow.com/develop/.

## Any specific deployment considerations

N/A

## Docs

N/A