### PR TITLE
resolve docs build / pin `mkdocstrings-python<2.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ docs = [
     "mkdocs-jupyter>=0.25.1",
     "mkdocs-material>=9.6.11",
     "mkdocs-minify-plugin>=0.8.0",
-    "mkdocstrings>=0.29.1",
+    "mkdocstrings-python>=1.10.9, <2.0.0", # todo: breaking changes in 2.x
     "mkdocstrings-python>=1.16.10",
     "mike>=2.1.3",
 ]


### PR DESCRIPTION
# Description

This pull request makes a small update to the documentation dependencies in `pyproject.toml` by restricting the version of `mkdocstrings-python` to below 2.0.0 to avoid breaking changes in the 2.x series.

In particular, it shall resolve failing docs' CI failing on the default branch...
```
ERROR   -  Error reading page 'assets.md':
ERROR   -  Invalid options: PythonOptions.__init__() got an unexpected keyword argument 'paths'

Aborted with a BuildError!
Error: Process completed with exit code 1.
```
