### PR TITLE
Fix bug causing failure to load local models in DeepSORT + ReID

### DIFF
--- a/trackers/core/reid/model.py
+++ b/trackers/core/reid/model.py
@@ -70,10 +70,12 @@ def _initialize_reid_model_from_timm(
 def _initialize_reid_model_from_checkpoint(cls, checkpoint_path: str, config_path: str):
     state_dict, config = load_safetensors_checkpoint(checkpoint_path, config_path)
     model_name = config.get("architecture")
+    if model_name is None:
+        raise ValueError(f"The config at {config_path} is missing the 'architecture' key.")
     init_kwargs = {}
     init_kwargs["pretrained"] = False
     reid_model_instance = _initialize_reid_model_from_timm(
-        cls, model_name_or_checkpoint_path=model_name, **init_kwargs
+        cls, model_name_or_checkpoint_path=model_name, device="auto", **init_kwargs
     )
     if config.get("projection_dimension"):
         reid_model_instance._add_projection_layer(

--- a/trackers/core/reid/model.py
+++ b/trackers/core/reid/model.py
@@ -67,15 +67,13 @@ def _initialize_reid_model_from_timm(
     return cls(model, device, transforms, model_metadata)
 
 
-def _initialize_reid_model_from_checkpoint(cls, checkpoint_path: str, config_path:str):
+def _initialize_reid_model_from_checkpoint(cls, checkpoint_path: str, config_path: str):
     state_dict, config = load_safetensors_checkpoint(checkpoint_path, config_path)
     model_name = config.get("architecture")
     init_kwargs = {}
     init_kwargs["pretrained"] = False
     reid_model_instance = _initialize_reid_model_from_timm(
-        cls, 
-        model_name_or_checkpoint_path=model_name, 
-        **init_kwargs
+        cls, model_name_or_checkpoint_path=model_name, **init_kwargs
     )
     if config.get("projection_dimension"):
         reid_model_instance._add_projection_layer(
@@ -83,7 +81,7 @@ def _initialize_reid_model_from_checkpoint(cls, checkpoint_path: str, config_pat
         )
     for k, v in state_dict.items():
         state_dict[k] = v.to(reid_model_instance.device)
-    reid_model_instance.backbone_model.load_state_dict(state_dict,strict=False)
+    reid_model_instance.backbone_model.load_state_dict(state_dict, strict=False)
     return reid_model_instance
 
 
@@ -127,7 +125,7 @@ class ReIDModel:
     def from_timm(
         cls,
         model_name_or_checkpoint_path: str,
-        config_path:Optional[str] = None,
+        config_path: Optional[str] = None,
         device: Optional[str] = "auto",
         get_pooled_features: bool = True,
         **kwargs,
@@ -150,11 +148,11 @@ class ReIDModel:
         Returns:
             ReIDModel: A new instance of `ReIDModel`.
         """
-        if os.path.exists(model_name_or_checkpoint_path) and os.path.exists(config_path):
+        if os.path.exists(model_name_or_checkpoint_path) and os.path.exists(
+            config_path
+        ):
             return _initialize_reid_model_from_checkpoint(
-                cls, 
-                model_name_or_checkpoint_path, 
-                config_path
+                cls, model_name_or_checkpoint_path, config_path
             )
         else:
             return _initialize_reid_model_from_timm(

--- a/trackers/core/reid/model.py
+++ b/trackers/core/reid/model.py
@@ -71,7 +71,9 @@ def _initialize_reid_model_from_checkpoint(cls, checkpoint_path: str, config_pat
     state_dict, config = load_safetensors_checkpoint(checkpoint_path, config_path)
     model_name = config.get("architecture")
     if model_name is None:
-        raise ValueError(f"The config at {config_path} is missing the 'architecture' key.")
+        raise ValueError(
+            f"The config at {config_path} is missing the 'architecture' key."
+        )
     init_kwargs = {}
     init_kwargs["pretrained"] = False
     reid_model_instance = _initialize_reid_model_from_timm(

--- a/trackers/core/reid/model.py
+++ b/trackers/core/reid/model.py
@@ -138,7 +138,8 @@ class ReIDModel:
             model_name_or_checkpoint_path (str): Name of the timm model to use or
                 path to a safetensors checkpoint. If the exact model name is not
                 found, the closest match from `timm.list_models` will be used.
-            config_path (str): Path to the config file for the local safetensors checkpoint.
+            config_path (str): Path to the config file for the local 
+                safetensors checkpoint.
             device (str): Device to run the model on.
             get_pooled_features (bool): Whether to get the pooled features from the
                 model or not.
@@ -148,8 +149,10 @@ class ReIDModel:
         Returns:
             ReIDModel: A new instance of `ReIDModel`.
         """
-        if os.path.exists(model_name_or_checkpoint_path) and os.path.exists(
-            config_path
+        if (
+            config_path is not None
+            and os.path.exists(model_name_or_checkpoint_path)
+            and os.path.exists(config_path)
         ):
             return _initialize_reid_model_from_checkpoint(
                 cls, model_name_or_checkpoint_path, config_path

--- a/trackers/core/reid/model.py
+++ b/trackers/core/reid/model.py
@@ -67,18 +67,23 @@ def _initialize_reid_model_from_timm(
     return cls(model, device, transforms, model_metadata)
 
 
-def _initialize_reid_model_from_checkpoint(cls, checkpoint_path: str):
-    state_dict, config = load_safetensors_checkpoint(checkpoint_path)
+def _initialize_reid_model_from_checkpoint(cls, checkpoint_path: str, config_path:str):
+    state_dict, config = load_safetensors_checkpoint(checkpoint_path, config_path)
+    model_name = config.get("architecture")
+    init_kwargs = {}
+    init_kwargs["pretrained"] = False
     reid_model_instance = _initialize_reid_model_from_timm(
-        cls, **config["model_metadata"]
+        cls, 
+        model_name_or_checkpoint_path=model_name, 
+        **init_kwargs
     )
-    if config["projection_dimension"]:
+    if config.get("projection_dimension"):
         reid_model_instance._add_projection_layer(
-            projection_dimension=config["projection_dimension"]
+            projection_dimension=config.get("projection_dimension")
         )
     for k, v in state_dict.items():
-        state_dict[k].to(reid_model_instance.device)
-    reid_model_instance.backbone_model.load_state_dict(state_dict)
+        state_dict[k] = v.to(reid_model_instance.device)
+    reid_model_instance.backbone_model.load_state_dict(state_dict,strict=False)
     return reid_model_instance
 
 
@@ -122,6 +127,7 @@ class ReIDModel:
     def from_timm(
         cls,
         model_name_or_checkpoint_path: str,
+        config_path:Optional[str] = None,
         device: Optional[str] = "auto",
         get_pooled_features: bool = True,
         **kwargs,
@@ -134,6 +140,7 @@ class ReIDModel:
             model_name_or_checkpoint_path (str): Name of the timm model to use or
                 path to a safetensors checkpoint. If the exact model name is not
                 found, the closest match from `timm.list_models` will be used.
+            config_path (str): Path to the config file for the local safetensors checkpoint.
             device (str): Device to run the model on.
             get_pooled_features (bool): Whether to get the pooled features from the
                 model or not.
@@ -143,9 +150,11 @@ class ReIDModel:
         Returns:
             ReIDModel: A new instance of `ReIDModel`.
         """
-        if os.path.exists(model_name_or_checkpoint_path):
+        if os.path.exists(model_name_or_checkpoint_path) and os.path.exists(config_path):
             return _initialize_reid_model_from_checkpoint(
-                cls, model_name_or_checkpoint_path
+                cls, 
+                model_name_or_checkpoint_path, 
+                config_path
             )
         else:
             return _initialize_reid_model_from_timm(

--- a/trackers/core/reid/model.py
+++ b/trackers/core/reid/model.py
@@ -138,7 +138,7 @@ class ReIDModel:
             model_name_or_checkpoint_path (str): Name of the timm model to use or
                 path to a safetensors checkpoint. If the exact model name is not
                 found, the closest match from `timm.list_models` will be used.
-            config_path (str): Path to the config file for the local 
+            config_path (str): Path to the config file for the local
                 safetensors checkpoint.
             device (str): Device to run the model on.
             get_pooled_features (bool): Whether to get the pooled features from the

--- a/trackers/utils/torch_utils.py
+++ b/trackers/utils/torch_utils.py
@@ -87,4 +87,3 @@ def load_safetensors_checkpoint(
         model_metadata = {**kwargs, **model_metadata}
     config["model_metadata"] = model_metadata
     return state_dict, config
-

--- a/trackers/utils/torch_utils.py
+++ b/trackers/utils/torch_utils.py
@@ -64,7 +64,8 @@ def load_safetensors_checkpoint(
     device: str = "cpu",
 ) -> Tuple[dict[str, torch.Tensor], dict[str, Any]]:
     """
-    Load a safetensors checkpoint into a dictionary of tensors and a separate JSON config file.
+    Load a safetensors checkpoint into a dictionary of tensors and a
+    separate JSON config file.
 
     Args:
         checkpoint_path (str): The path to the safetensors checkpoint.


### PR DESCRIPTION
## What does this PR do?

This PR fixes issues related to loading local "vanilla" timm checkpoints (e.g., standard .safetensors files downloaded directly from HuggingFace).
﻿
Specifically, it addresses two problems:
﻿
Fixes NoneType Error on Missing Metadata: Standard timm checkpoints do not contain the custom "config" key in their metadata. Previously, this caused a TypeError when the code attempted to parse non-existent config data.
﻿
Enables Offline Loading: Previously, pretrained=True was hardcoded in _initialize_reid_model_from_timm. This forced a network connection to HuggingFace even when a local checkpoint_path was provided.This PR exposes the pretrained argument via init_kwargs.

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 --> #120

## Type of Change

- Bug fix (non-breaking change that fixes an issue)


## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
reid_model = ReIDModel.from_timm(
    model_name_or_checkpoint_path="/path/to/local/model.safetensors", 
    config_path="path/to/local/config.json"
)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
The standard timm weights only contain tensor data and basic metadata (format info), lacking the custom configuration dictionary expected by the previous implementation. By allowing pretrained to be set to False and bypassing the strict metadata parsing when a model name is explicitly provided, we can support a wider range of standard checkpoints.
