### PR TITLE
Remove unused `exclude` rules from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: test/.*\.py
       - id: check-executables-have-shebangs
       - id: check-toml
       - id: check-case-conflict
@@ -18,7 +17,6 @@ repos:
       - id: detect-private-key
       - id: pretty-format-json
         args: ['--autofix', '--no-sort-keys', '--indent=4']
-        exclude: /.*\.ipynb
       - id: end-of-file-fixer
       - id: mixed-line-ending
 
@@ -33,9 +31,9 @@ repos:
       rev: v0.14.13
       hooks:
       -   id: ruff-check
-          args: [--fix, --exit-non-zero-on-fix]
+          args: [--fix]
       -   id: ruff-format
-          types_or: [ python, pyi, jupyter]
+          types_or: [python, pyi, jupyter]
 
   -   repo: https://github.com/pre-commit/mirrors-mypy
       rev: 'v1.19.1'


### PR DESCRIPTION
This pull request makes minor updates to the `.pre-commit-config.yaml` file, primarily simplifying hook configurations and removing some exclusions.

Configuration simplification:

* Removed the exclusion for Python test files from the `trailing-whitespace` hook, so it now runs on all `.py` files.
* Removed the exclusion for Jupyter notebooks (`.ipynb` files) from the `pretty-format-json` hook, so it now runs on all JSON files.
* Updated the `ruff-check` hook arguments to remove `--exit-non-zero-on-fix`, so it will no longer exit with a non-zero status when fixes are applied.