### PR TITLE
Sanitize configs after bumping py3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ target = ["test", "trackers"]
 tests = ["B201", "B301", "B318", "B314", "B303", "B413", "B412"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311,py312,py313
+envlist = py310,py311,py312,py313
 
 [testenv]
 changedir = test


### PR DESCRIPTION
This pull request updates the project's Python version support by removing Python 3.9 from the test environments and setting Python 3.10 as the minimum supported version for both linting and testing.

Python version support updates:

* Updated the `envlist` in `tox.ini` to remove Python 3.9, so tests will now only run on Python 3.10 and above.
* Changed the `target-version` in the `[tool.ruff]` section of `pyproject.toml` from `py39` to `py310`, ensuring linting is aligned with the new minimum supported Python version.