### PR TITLE
Update linting, testing, and build configurations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dev = [
     "pre-commit>=4.2.0",
 ]
 
-
 docs = [
     "jupyter>=1.1.1",
     "mkdocs>=1.6.1",
@@ -126,55 +125,16 @@ indent-width = 4
 
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "I", "A", "Q", "W", "RUF"]
-ignore = []
-# Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = [
-    "A",
-    "B",
-    "C",
-    "D",
-    "E",
-    "F",
-    "G",
-    "I",
-    "N",
-    "Q",
-    "S",
-    "T",
-    "W",
-    "ANN",
-    "ARG",
-    "BLE",
-    "COM",
-    "DJ",
-    "DTZ",
-    "EM",
-    "ERA",
-    "EXE",
-    "FBT",
-    "ICN",
-    "INP",
-    "ISC",
-    "NPY",
-    "PD",
-    "PGH",
-    "PIE",
-    "PL",
-    "PT",
-    "PTH",
-    "PYI",
-    "RET",
-    "RSE",
-    "RUF",
-    "SIM",
-    "SLF",
-    "TCH",
-    "TID",
-    "TRY",
-    "UP",
-    "YTT",
+select = [
+    "E",   # pycodestyle errors and warnings (https://docs.astral.sh/ruff/rules/#error-e)
+    "F",   # Pyflakes (imports, unused variables, etc.) (https://docs.astral.sh/ruff/rules/#pyflakes-f)
+    "I",   # isort (import sorting) (https://docs.astral.sh/ruff/rules/#isort-i)
+    "A",   # flake8-builtins (no use of built-in variable names) (https://docs.astral.sh/ruff/rules/#flake8-builtins-a)
+    "Q",   # flake8-quotes (consistent quote style) (https://docs.astral.sh/ruff/rules/#flake8-quotes-q)
+    "W",   # pycodestyle warnings (https://docs.astral.sh/ruff/rules/#warning-w)
+    "RUF", # Ruff-specific rules (https://docs.astral.sh/ruff/rules/#ruff-ruf)
 ]
+ignore = []
 unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,61 @@
 [tox]
-envlist = py310,py311,py312,py313
+envlist = py310,py311,py312,py313  # Python versions to test against (3.10-3.13) - https://tox.readthedocs.io/en/stable/config.html#envlist
 
 [testenv]
-changedir = test
-deps = pytest
-commands = pytest
+changedir = test  # Change to test directory before running commands - https://tox.readthedocs.io/en/stable/config.html#changeddir
+deps = pytest  # Install pytest for running tests - https://docs.pytest.org/en/stable/
+commands = pytest  # Run pytest to execute all tests - https://docs.pytest.org/en/stable/reference/reference.html#pytest.main
+
+[testenv:lint]
+changedir = .  # Run from project root for linting
+deps = ruff  # Install ruff for linting - https://docs.astral.sh/ruff/
+commands =
+    ruff check . --fix  # Run ruff linter with auto-fix (https://docs.astral.sh/ruff/rules/)
+    ruff format .  # Format code with ruff (https://docs.astral.sh/ruff/formatter/)
+
+[testenv:type]
+changedir = .  # Run from project root for type checking
+deps =
+    mypy  # Install mypy for type checking - https://mypy.readthedocs.io/
+    types-aiofiles  # Type stubs for aiofiles - https://pypi.org/project/types-aiofiles/
+    types-requests  # Type stubs for requests - https://pypi.org/project/types-requests/
+    types-tqdm  # Type stubs for tqdm - https://pypi.org/project/types-tqdm/
+commands =
+    mypy trackers test  # Run mypy type checker on trackers and test directories (https://mypy.readthedocs.io/en/stable/usage.html)
+
+[testenv:security]
+changedir = .  # Run from project root for security scanning
+deps = bandit  # Install bandit for security analysis - https://bandit.readthedocs.io/
+commands =
+    bandit -c pyproject.toml -r trackers test  # Run bandit security checks on trackers and test (https://bandit.readthedocs.io/en/latest/plugins.html)
+
+[testenv:pre-commit]
+changedir = .  # Run from project root for pre-commit hooks
+deps = pre-commit  # Install pre-commit framework - https://pre-commit.com/
+commands =
+    pre-commit run --all-files  # Run all pre-commit hooks on all files (https://pre-commit.com/usage.html)
+
+[testenv:docs]
+changedir = docs  # Change to docs directory
+deps =
+    mkdocs  # Install mkdocs for documentation generation - https://www.mkdocs.org/
+    mkdocs-material  # Material theme for mkdocs - https://squidfunk.github.io/mkdocs-material/
+    mkdocstrings-python  # Auto-generate Python documentation - https://mkdocstrings.github.io/python/
+commands =
+    mkdocs build  # Build documentation site (https://www.mkdocs.org/getting-started/#building-the-documentation)
+
+[testenv:all]
+changedir = .  # Run all checks in project root
+deps =
+    pytest
+    ruff
+    mypy
+    bandit
+    pre-commit
+commands =
+    pytest  # Run all tests
+    ruff check .  # Run ruff linter (no auto-fix to catch issues)
+    ruff format . --check  # Check code formatting
+    mypy trackers test  # Run type checking
+    bandit -c pyproject.toml -r trackers test  # Run security checks
+    pre-commit run --all-files  # Run pre-commit hooks

--- a/tox.ini
+++ b/tox.ini
@@ -1,61 +1,7 @@
 [tox]
-envlist = py310,py311,py312,py313  # Python versions to test against (3.10-3.13) - https://tox.readthedocs.io/en/stable/config.html#envlist
+envlist = py310,py311,py312,py313
 
 [testenv]
-changedir = test  # Change to test directory before running commands - https://tox.readthedocs.io/en/stable/config.html#changeddir
-deps = pytest  # Install pytest for running tests - https://docs.pytest.org/en/stable/
-commands = pytest  # Run pytest to execute all tests - https://docs.pytest.org/en/stable/reference/reference.html#pytest.main
-
-[testenv:lint]
-changedir = .  # Run from project root for linting
-deps = ruff  # Install ruff for linting - https://docs.astral.sh/ruff/
-commands =
-    ruff check . --fix  # Run ruff linter with auto-fix (https://docs.astral.sh/ruff/rules/)
-    ruff format .  # Format code with ruff (https://docs.astral.sh/ruff/formatter/)
-
-[testenv:type]
-changedir = .  # Run from project root for type checking
-deps =
-    mypy  # Install mypy for type checking - https://mypy.readthedocs.io/
-    types-aiofiles  # Type stubs for aiofiles - https://pypi.org/project/types-aiofiles/
-    types-requests  # Type stubs for requests - https://pypi.org/project/types-requests/
-    types-tqdm  # Type stubs for tqdm - https://pypi.org/project/types-tqdm/
-commands =
-    mypy trackers test  # Run mypy type checker on trackers and test directories (https://mypy.readthedocs.io/en/stable/usage.html)
-
-[testenv:security]
-changedir = .  # Run from project root for security scanning
-deps = bandit  # Install bandit for security analysis - https://bandit.readthedocs.io/
-commands =
-    bandit -c pyproject.toml -r trackers test  # Run bandit security checks on trackers and test (https://bandit.readthedocs.io/en/latest/plugins.html)
-
-[testenv:pre-commit]
-changedir = .  # Run from project root for pre-commit hooks
-deps = pre-commit  # Install pre-commit framework - https://pre-commit.com/
-commands =
-    pre-commit run --all-files  # Run all pre-commit hooks on all files (https://pre-commit.com/usage.html)
-
-[testenv:docs]
-changedir = docs  # Change to docs directory
-deps =
-    mkdocs  # Install mkdocs for documentation generation - https://www.mkdocs.org/
-    mkdocs-material  # Material theme for mkdocs - https://squidfunk.github.io/mkdocs-material/
-    mkdocstrings-python  # Auto-generate Python documentation - https://mkdocstrings.github.io/python/
-commands =
-    mkdocs build  # Build documentation site (https://www.mkdocs.org/getting-started/#building-the-documentation)
-
-[testenv:all]
-changedir = .  # Run all checks in project root
-deps =
-    pytest
-    ruff
-    mypy
-    bandit
-    pre-commit
-commands =
-    pytest  # Run all tests
-    ruff check .  # Run ruff linter (no auto-fix to catch issues)
-    ruff format . --check  # Check code formatting
-    mypy trackers test  # Run type checking
-    bandit -c pyproject.toml -r trackers test  # Run security checks
-    pre-commit run --all-files  # Run pre-commit hooks
+changedir = test
+deps = pytest
+commands = pytest


### PR DESCRIPTION
This pull request updates the `pyproject.toml` configuration, focusing on simplifying and clarifying the Ruff linter rules. The main changes involve streamlining the list of selected linting codes, adding inline documentation for each, and removing the explicit list of fixable rules.

**Linter configuration updates:**

* Simplified the `select` list under `[tool.ruff.lint]` to only include the most relevant rule categories, and added comments explaining each code for better clarity.
* Removed the explicit `fixable` list, relying on default behavior instead, which reduces maintenance overhead.

**General cleanup:**

* Removed an extra blank line before the `docs` dependencies section for consistency.