### PR TITLE
Migrate security rules to Ruff's S (bandit)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,23 +20,16 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
 
-  -   repo: https://github.com/PyCQA/bandit
-      rev: '1.9.3'
-      hooks:
-      -   id: bandit
-          args: ["-c", "pyproject.toml"]
-          additional_dependencies: ["bandit[toml]"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.13
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+        types_or: [python, pyi, jupyter]
 
-  -   repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.14.13
-      hooks:
-      -   id: ruff-check
-          args: [--fix]
-      -   id: ruff-format
-          types_or: [python, pyi, jupyter]
-
-  -   repo: https://github.com/pre-commit/mirrors-mypy
-      rev: 'v1.19.1'
-      hooks:
-      -   id: mypy
-          additional_dependencies: [numpy,types-aiofiles]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.19.1'
+    hooks:
+      - id: mypy
+        additional_dependencies: [numpy,types-aiofiles]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,9 @@ dev = [
     "uv>=0.4.20",
     "pytest>=8.3.3",
     "ruff>=0.6.9",
-    "bandit>=1.8.3",
     "mypy>=1.15.0",
     "pre-commit>=4.2.0",
 ]
-
 docs = [
     "jupyter>=1.1.1",
     "mkdocs>=1.6.1",
@@ -84,10 +82,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["trackers"]
-
-[tool.bandit]
-target = ["test", "trackers"]
-tests = ["B201", "B301", "B318", "B314", "B303", "B413", "B412"]
 
 [tool.ruff]
 target-version = "py310"
@@ -132,7 +126,8 @@ select = [
     "A",   # flake8-builtins (no use of built-in variable names) (https://docs.astral.sh/ruff/rules/#flake8-builtins-a)
     "Q",   # flake8-quotes (consistent quote style) (https://docs.astral.sh/ruff/rules/#flake8-quotes-q)
     "W",   # pycodestyle warnings (https://docs.astral.sh/ruff/rules/#warning-w)
-    "RUF", # Ruff-specific rules (https://docs.astral.sh/ruff/rules/#ruff-ruf)
+    "RUF", # Ruff-specific rules (https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf)
+    "S",   # security rules (https://docs.astral.sh/ruff/rules/#flake8-bandit-s)
 ]
 ignore = []
 unfixable = []
@@ -150,6 +145,8 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401"]
+"test" = []
+"trackers" = []
 
 [tool.ruff.lint.mccabe]
 # Flag errors (`C901`) whenever the complexity level exceeds 10.


### PR DESCRIPTION
This pull request removes Bandit as a security linting tool in favor of using Ruff's built-in security rules. The configuration files have been updated to reflect this change, simplifying the linting setup and consolidating security checks under Ruff.

**Linting and security tool changes:**

* Removed Bandit from the pre-commit configuration by deleting its entry from `.pre-commit-config.yaml`.
* Removed Bandit from the development dependencies in the `pyproject.toml` file.
* Deleted the `[tool.bandit]` configuration section from `pyproject.toml`.

**Ruff configuration updates:**

* Added Ruff's security rules (`"S"`) to the linting selection in `pyproject.toml`, with a clarifying comment and updated link.
* Added empty per-file ignore lists for the `test` and `trackers` directories in Ruff's configuration.