### PR TITLE
Simplify GH Actions workflows for docs

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -14,23 +14,20 @@ jobs:
     name: Test docs build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - name: 🐍 Install uv and set Python ${{ matrix.python-version }}
+      - name: 🐍 Install uv and set Python
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           activate-environment: true
 
       - name: 🏗️ Install dependencies
-        run: uv pip install -r pyproject.toml --group docs --python-version ${{ matrix.python-version }}
+        run: uv pip install -r pyproject.toml --group docs
 
       - name: 🧪 Test Docs Build
         run: uv run mkdocs build --verbose

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🐍 Install uv and set Python ${{ matrix.python-version }}
+      - name: 🐍 Install uv and set Python 3.10
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
         with:
           python-version: "3.10"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -24,9 +24,6 @@ jobs:
     name: Publish Docs
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,36 +33,27 @@ jobs:
       - name: 🐍 Install uv and set Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           activate-environment: true
 
-      - name: 🔑 Create GitHub App token (mkdocs)
-        id: mkdocs_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.MKDOCS_APP_ID }}
-          private-key: ${{ secrets.MKDOCS_PEM }}
-          owner: roboflow
-          repositories: mkdocs-material-insiders
-
       - name: 🏗️ Install dependencies
-        run: |
-          uv pip install -r pyproject.toml --group docs
-          # Install mkdocs-material-insiders using the GitHub App token
-          uv pip install "git+https://roboflow:${{ steps.mkdocs_token.outputs.token }}@github.com/roboflow/mkdocs-material-insiders.git@9.5.49-insiders-4.53.14#egg=mkdocs-material[imaging]"
+        run: uv pip install -r pyproject.toml --group docs
 
       - name: ⚙️ Configure git for github-actions
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: 🚀 Deploy Development Docs
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
-        run: |
-          MKDOCS_GIT_COMMITTERS_APIKEY=${{ secrets.GITHUB_TOKEN }} uv run mike deploy --push develop
+        env:
+          MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
+        run: uv run mike deploy --push develop
 
       - name: 🚀 Deploy Release Docs
         if: github.event_name == 'release' && github.event.action == 'published'
+        env:
+          MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          MKDOCS_GIT_COMMITTERS_APIKEY=${{ secrets.GITHUB_TOKEN }} uv run mike deploy --push --update-aliases $latest_tag latest
+          uv run mike deploy --push --update-aliases $latest_tag latest


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflows for building and publishing documentation. The main changes are the removal of the Python version matrix, hardcoding the Python version, and cleaning up how dependencies and deployment are handled. This streamlines the CI/CD process and removes unnecessary complexity.

**Workflow simplification:**

* Removed the Python version matrix from both `.github/workflows/ci-build-docs.yml` and `.github/workflows/publish-docs.yml`, and now hardcode the Python version as `"3.10"` in the workflow steps. [[1]](diffhunk://#diff-61fc86768decdb974bea5fae038250c463e7d9d35c980b0ec5fcda4ef46ae31dL17-R30) [[2]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L27-L29)
* Simplified dependency installation by removing the use of matrix variables and directly running `uv pip install -r pyproject.toml --group docs`. [[1]](diffhunk://#diff-61fc86768decdb974bea5fae038250c463e7d9d35c980b0ec5fcda4ef46ae31dL17-R30) [[2]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L39-R59)

**Publishing and deployment improvements:**

* Removed the step that created a GitHub App token and the special installation of `mkdocs-material-insiders`, further simplifying the publish workflow.
* Updated Git configuration in the publish workflow to use the `${{ github.actor }}` instead of hardcoded bot credentials.
* Changed the way the `MKDOCS_GIT_COMMITTERS_APIKEY` environment variable is set for deployment steps, using the `env` key instead of inline in the `run` command.

---

it will be the same as `supervision`