### PR TITLE
Fix mkdocstrings deprecation warning in MkDocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,8 +87,10 @@ plugins:
             docstring_style: google
             # Controls the order of members (by source order in this case)
             members_order: source
-            # Controls whether to sort members alphabetically
-            sort_members: false
+
+            extra:
+              # Controls whether to sort members alphabetically
+              sort_members: false
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## What does this PR do?

This PR fixes a deprecation warning emitted by `mkdocstrings-python` during documentation builds.

The MkDocs configuration previously defined `sort_members` under `handlers.python.options`, which is no longer a supported option and caused a warning at build time. The documentation already relies on `members_order: source` to control member ordering, so removing `sort_members` does not change the rendered output.

As a result, `mkdocs serve` and CI doc builds run without warnings while preserving the existing documentation structure.

## Type of Change

Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)
