### PR TITLE
Update publish-docs workflow to support 'develop' & custom tags

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -56,7 +56,7 @@ jobs:
         run: uv run mike deploy --push develop
 
       - name: 🚀 Deploy Custom Ref Docs
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop'
+        if: github.event_name == 'workflow_dispatch'
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,12 +4,17 @@ on:
   push:
     branches: [main, develop]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to deploy'
+        required: false
+        default: 'main'
   release:
     types: [published]
 
 # Ensure only one concurrent deployment
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref}}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 # Restrict permissions by default
@@ -28,6 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: 🐍 Install uv and set Python
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
@@ -44,10 +50,20 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: 🚀 Deploy Development Docs
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'workflow_dispatch'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/develop')
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: uv run mike deploy --push develop
+
+      - name: 🚀 Deploy Custom Ref Docs
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop'
+        env:
+          MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REF_NAME="${{ github.event.inputs.ref }}"
+          # If it's a full ref like refs/heads/branch or refs/tags/tag, extract the name
+          CLEAN_REF=$(echo $REF_NAME | sed 's|refs/.*/||')
+          uv run mike deploy --push $CLEAN_REF
 
       - name: 🚀 Deploy Release Docs
         if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,8 +2,7 @@ name: Build and Publish Docs
 
 on:
   push:
-    branches:
-      - main
+    branches: [main, develop]
   workflow_dispatch:
   release:
     types: [published]
@@ -11,7 +10,7 @@ on:
 # Ensure only one concurrent deployment
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref}}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Restrict permissions by default
 permissions:
@@ -30,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🐍 Install uv and set Python 3.10
+      - name: 🐍 Install uv and set Python
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
         with:
           python-version: "3.10"
@@ -45,7 +44,7 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: 🚀 Deploy Development Docs
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'workflow_dispatch'
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: uv run mike deploy --push develop

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           REF_NAME="${{ github.event.inputs.ref }}"
           # If it's a full ref like refs/heads/branch or refs/tags/tag, extract the name
-          CLEAN_REF=$(echo $REF_NAME | sed 's|refs/.*/||')
+          CLEAN_REF=$(echo "$REF_NAME" | sed 's|^refs/[^/]*/||')
           uv run mike deploy --push $CLEAN_REF
 
       - name: 🚀 Deploy Release Docs


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to support deployments from both the `main` and `develop` branches, as well as custom refs via manual triggers. It also improves flexibility in deploying documentation for different branches or tags and adjusts concurrency settings for deployments.

**Workflow trigger and concurrency improvements:**

* The workflow can now be triggered on pushes to both `main` and `develop` branches, as well as manually via `workflow_dispatch` with an optional `ref` input for custom deployments.
* Concurrency group is simplified to use only the workflow name, and in-progress deployments are no longer canceled when a new one starts.

**Deployment logic enhancements:**

* The checkout step now uses the provided `ref` input if available, allowing for flexible deployments of specific branches or tags.
* Separate deployment steps are added for development docs (on push to `develop`) and custom ref docs (on manual dispatch with a ref that is not `develop`), enabling more granular control over which docs are published and when.