### PR TITLE
Include links to example notebooks in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,33 @@ You can install and use `trackers` in a [**Python>=3.10**](https://www.python.or
         uv pip install trackers
         ```
 
+## Tutorials
+
+<div class="grid cards" markdown>
+
+-   **How to Track Objects with SORT**
+
+    ---
+
+    [![](https://storage.googleapis.com/com-roboflow-marketing/trackers/assets/sort-sample.png)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-track-objects-with-sort-tracker.ipynb)
+
+    End-to-end example showing how to run RF-DETR detection with the SORT tracker.
+
+    [:simple-googlecolab: Run Google Colab](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-track-objects-with-sort-tracker.ipynb)
+
+-   **How to Track Objects with ByteTrack**
+
+    ---
+
+    [![](https://storage.googleapis.com/com-roboflow-marketing/trackers/assets/bytetrack-sample.png)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-track-objects-with-bytetrack-tracker.ipynb)
+
+    End-to-end example showing how to run RF-DETR detection with the ByteTrack tracker.
+
+    [:simple-googlecolab: Run Google Colab](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-track-objects-with-bytetrack-tracker.ipynb)
+
+</div>
+
+
 ## Tracking Algorithms
 
 Trackers gives you clean, modular re-implementations of leading multi-object tracking algorithms. The package currently supports [SORT](https://arxiv.org/abs/1602.00763) and [ByteTrack](https://arxiv.org/abs/2110.06864). [OC-SORT](https://arxiv.org/abs/2203.14360) support is coming soon. For full results, see the [benchmarks](learn/benchmarks.md) page.

--- a/docs/trackers/bytetrack.md
+++ b/docs/trackers/bytetrack.md
@@ -7,6 +7,7 @@ comments: true
 ## Overview
 
 ByteTrack builds on the same Kalman filter plus Hungarian algorithm framework as SORT but changes the data association strategy to use almost every detection box regardless of confidence score. It runs a two-stage matching: first match high-confidence detections to tracks, then match low-confidence detections to any unmatched tracks using IoU. This reduces missed tracks and fragmentation for occluded or weak detections while retaining simplicity and high frame rates. ByteTrack has set state-of-the-art results on standard MOT benchmarks with real-time performance, because it recovers valid low-score detections instead of discarding them.
+
 ## Benchmarks
 
 For comparisons with other trackers, plus full details on the datasets and evaluation metrics used, see the [benchmarks](../learn/benchmarks.md) page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,13 @@ extra_css:
   - stylesheets/rf.css
 
 markdown_extensions:
+   # Adds support for card grids
+  - attr_list
+  - md_in_html
+  # Enables the use of icons and emojis
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   # Code syntax highlighting with line numbers and anchors
   - pymdownx.highlight:
       # Adds anchors to line numbers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trackers"
-version = "2.1.0rc0"
+version = "2.1.0"
 description = "A unified library for object tracking featuring clean room re-implementations of leading multi-object tracking algorithms"
 readme = "README.md"
 maintainers = [


### PR DESCRIPTION
## What does this PR do?

This pull request introduces several documentation and configuration improvements for the `trackers` library, with a focus on enhancing user onboarding and the presentation of tutorials. The main changes include the addition of a tutorials section to the documentation homepage, updates to the documentation theming and markdown capabilities, and a version bump to the stable `2.1.0` release.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

Documentation update

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change
