### PR TITLE
fix ByteTrack code snippets. use ByteTrackTracker over ByteTrack.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,9 +77,9 @@ With a modular design, Trackers lets you combine object detectors from different
     import cv2
     import supervision as sv
     from rfdetr import RFDETRMedium
-    from trackers import ByteTrack
+    from trackers import ByteTrackTracker
 
-    tracker = ByteTrack()
+    tracker = ByteTrackTracker()
     model = RFDETRMedium()
 
     box_annotator = sv.BoxAnnotator()
@@ -115,9 +115,9 @@ With a modular design, Trackers lets you combine object detectors from different
     import cv2
     import supervision as sv
     from inference import get_model
-    from trackers import ByteTrack
+    from trackers import ByteTrackTracker
 
-    tracker = ByteTrack()
+    tracker = ByteTrackTracker()
     model = get_model(model_id="rfdetr-medium")
 
     box_annotator = sv.BoxAnnotator()
@@ -154,9 +154,9 @@ With a modular design, Trackers lets you combine object detectors from different
     import cv2
     import supervision as sv
     from ultralytics import YOLO
-    from trackers import ByteTrack
+    from trackers import ByteTrackTracker
 
-    tracker = ByteTrack()
+    tracker = ByteTrackTracker()
     model = YOLO("yolo26m.pt")
 
     box_annotator = sv.BoxAnnotator()
@@ -193,10 +193,10 @@ With a modular design, Trackers lets you combine object detectors from different
     import torch
     import cv2
     import supervision as sv
-    from trackers import ByteTrack
+    from trackers import ByteTrackTracker
     from transformers import RTDetrImageProcessor, RTDetrV2ForObjectDetection
 
-    tracker = ByteTrack()
+    tracker = ByteTrackTracker()
     processor = RTDetrImageProcessor.from_pretrained("PekingU/rtdetr_v2_r18vd")
     model = RTDetrV2ForObjectDetection.from_pretrained("PekingU/rtdetr_v2_r18vd")
 


### PR DESCRIPTION
## What does this PR do?

All usage examples now import and instantiate `ByteTrackTracker` instead of `ByteTrack` class.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)
- Documentation update