### PR TITLE
Add Apache 2.0 license headers across Trackers package

### DIFF
--- a/trackers/__init__.py
+++ b/trackers/__init__.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 from trackers.core.bytetrack.tracker import ByteTrackTracker
 from trackers.core.sort.tracker import SORTTracker
 

--- a/trackers/core/__init__.py
+++ b/trackers/core/__init__.py
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------

--- a/trackers/core/base.py
+++ b/trackers/core/base.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 from abc import ABC, abstractmethod
 
 import numpy as np

--- a/trackers/core/bytetrack/__init__.py
+++ b/trackers/core/bytetrack/__init__.py
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------

--- a/trackers/core/bytetrack/kalman_box_tracker.py
+++ b/trackers/core/bytetrack/kalman_box_tracker.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 import numpy as np
 
 

--- a/trackers/core/bytetrack/tracker.py
+++ b/trackers/core/bytetrack/tracker.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 from copy import deepcopy
 from typing import cast
 

--- a/trackers/core/sort/__init__.py
+++ b/trackers/core/sort/__init__.py
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------

--- a/trackers/core/sort/kalman_box_tracker.py
+++ b/trackers/core/sort/kalman_box_tracker.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 import numpy as np
 from numpy.typing import NDArray
 

--- a/trackers/core/sort/tracker.py
+++ b/trackers/core/sort/tracker.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 import numpy as np
 import supervision as sv
 from scipy.optimize import linear_sum_assignment

--- a/trackers/utils/__init__.py
+++ b/trackers/utils/__init__.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 from trackers.utils.sort_utils import (
     get_alive_trackers,
     get_iou_matrix,

--- a/trackers/utils/sort_utils.py
+++ b/trackers/utils/sort_utils.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 from copy import deepcopy
 from typing import List, Sequence, Set, TypeVar, Union
 


### PR DESCRIPTION
## What does this PR do?

This pull request adds standard copyright and license headers to all major Python modules in the `trackers` package. These headers clarify the licensing (Apache License, Version 2.0) and ownership (Roboflow) for the codebase, helping ensure legal compliance and consistent documentation across files.