### PR TITLE
chore: Redundant types from docstrings

### DIFF
--- a/trackers/core/bytetrack/kalman_box_tracker.py
+++ b/trackers/core/bytetrack/kalman_box_tracker.py
@@ -14,20 +14,20 @@ class ByteTrackKalmanBoxTracker:
     its position.
 
     Attributes:
-        tracker_id (int): Unique identifier for the tracker.
-        number_of_successful_updates (int): Number of times the object has been
+        tracker_id: Unique identifier for the tracker.
+        number_of_successful_updates: Number of times the object has been
             updated successfully.
-        time_since_update (int): Number of frames since the last update.
-        state (np.ndarray): State vector of the bounding box.
-        F (np.ndarray): State transition matrix.
-        H (np.ndarray): Measurement matrix.
-        Q (np.ndarray): Process noise covariance matrix.
-        R (np.ndarray): Measurement noise covariance matrix.
-        P (np.ndarray): Error covariance matrix.
-        count_id (int): Class variable to assign unique IDs to each tracker.
+        time_since_update: Number of frames since the last update.
+        state: State vector of the bounding box.
+        F: State transition matrix.
+        H: Measurement matrix.
+        Q: Process noise covariance matrix.
+        R: Measurement noise covariance matrix.
+        P: Error covariance matrix.
+        count_id: Class variable to assign unique IDs to each tracker.
 
     Args:
-        bbox (np.ndarray): Initial bounding box in the form [x1, y1, x2, y2].
+        bbox: Initial bounding box in the form [x1, y1, x2, y2].
     """
 
     count_id = 0
@@ -38,7 +38,7 @@ class ByteTrackKalmanBoxTracker:
         Class method that returns the next available tracker ID.
 
         Returns:
-            int: The next available tracker ID.
+            The next available tracker ID.
         """
         next_id = cls.count_id
         cls.count_id += 1
@@ -109,7 +109,7 @@ class ByteTrackKalmanBoxTracker:
         Updates the state with a new detected bounding box.
 
         Args:
-            bbox (np.ndarray): Detected bounding box in the form [x1, y1, x2, y2].
+            bbox: Detected bounding box in the form [x1, y1, x2, y2].
         """
         self.time_since_update = 0
         self.number_of_successful_updates += 1
@@ -134,7 +134,7 @@ class ByteTrackKalmanBoxTracker:
         Returns the current bounding box estimate from the state vector.
 
         Returns:
-            np.ndarray: The bounding box [x1, y1, x2, y2].
+            The bounding box [x1, y1, x2, y2].
         """
         return np.array(
             [

--- a/trackers/core/sort/kalman_box_tracker.py
+++ b/trackers/core/sort/kalman_box_tracker.py
@@ -15,20 +15,20 @@ class SORTKalmanBoxTracker:
     its position.
 
     Attributes:
-        tracker_id (int): Unique identifier for the tracker.
-        number_of_successful_updates (int): Number of times the object has been
+        tracker_id: Unique identifier for the tracker.
+        number_of_successful_updates: Number of times the object has been
             updated successfully.
-        time_since_update (int): Number of frames since the last update.
-        state (np.ndarray): State vector of the bounding box.
-        F (np.ndarray): State transition matrix.
-        H (np.ndarray): Measurement matrix.
-        Q (np.ndarray): Process noise covariance matrix.
-        R (np.ndarray): Measurement noise covariance matrix.
-        P (np.ndarray): Error covariance matrix.
-        count_id (int): Class variable to assign unique IDs to each tracker.
+        time_since_update: Number of frames since the last update.
+        state: State vector of the bounding box.
+        F: State transition matrix.
+        H: Measurement matrix.
+        Q: Process noise covariance matrix.
+        R: Measurement noise covariance matrix.
+        P: Error covariance matrix.
+        count_id: Class variable to assign unique IDs to each tracker.
 
     Args:
-        bbox (np.ndarray): Initial bounding box in the form [x1, y1, x2, y2].
+        bbox: Initial bounding box in the form [x1, y1, x2, y2].
     """
 
     count_id: int = 0
@@ -111,7 +111,7 @@ class SORTKalmanBoxTracker:
         Updates the state with a new detected bounding box.
 
         Args:
-            bbox (np.ndarray): Detected bounding box in the form [x1, y1, x2, y2].
+            bbox: Detected bounding box in the form [x1, y1, x2, y2].
         """
         self.time_since_update = 0
         self.number_of_successful_updates += 1
@@ -140,6 +140,6 @@ class SORTKalmanBoxTracker:
         Returns the current bounding box estimate from the state vector.
 
         Returns:
-            np.ndarray: The bounding box [x1, y1, x2, y2]
+            The bounding box [x1, y1, x2, y2].
         """
         return self.state[:4, 0].flatten().astype(np.float32)

--- a/trackers/utils/sort_utils.py
+++ b/trackers/utils/sort_utils.py
@@ -29,14 +29,14 @@ def get_alive_trackers(
     it was just updated).
 
     Args:
-        trackers (Sequence[KalmanBoxTrackerType]): List of KalmanBoxTracker objects.
-        minimum_consecutive_frames (int): Number of consecutive frames that an object
+        trackers: List of KalmanBoxTracker objects.
+        minimum_consecutive_frames: Number of consecutive frames that an object
             must be tracked before it is considered a 'valid' track.
-        maximum_frames_without_update (int): Maximum number of frames without update
+        maximum_frames_without_update: Maximum number of frames without update
             before a track is considered dead.
 
     Returns:
-        List[KalmanBoxTrackerType]: List of alive trackers.
+        List of alive trackers.
     """
     alive_trackers = []
     for tracker in trackers:
@@ -56,11 +56,12 @@ def get_iou_matrix(
     Build IOU cost matrix between detections and predicted bounding boxes
 
     Args:
-        detection_boxes (np.ndarray): Detected bounding boxes in the
+        trackers: List of KalmanBoxTracker objects.
+        detection_boxes: Detected bounding boxes in the
             form [x1, y1, x2, y2].
 
     Returns:
-        np.ndarray: IOU cost matrix.
+        IOU cost matrix.
     """
     predicted_boxes = np.array([t.get_state_bbox() for t in trackers])
     if len(predicted_boxes) == 0 and len(trackers) > 0:
@@ -88,17 +89,17 @@ def update_detections_with_track_ids(
     it is assigned an ID to the detection that just updated it.
 
     Args:
-        trackers (Sequence[SORTKalmanBoxTracker]): List of SORTKalmanBoxTracker objects.
-        detections (sv.Detections): The latest set of object detections.
-        detection_boxes (np.ndarray): Detected bounding boxes in the
+        trackers: List of SORTKalmanBoxTracker objects.
+        detections: The latest set of object detections.
+        detection_boxes: Detected bounding boxes in the
             form [x1, y1, x2, y2].
-        minimum_iou_threshold (float): IOU threshold for associating detections to
+        minimum_iou_threshold: IOU threshold for associating detections to
             existing tracks.
-        minimum_consecutive_frames (int): Number of consecutive frames that an object
+        minimum_consecutive_frames: Number of consecutive frames that an object
             must be tracked before it is considered a 'valid' track.
 
     Returns:
-        sv.Detections: A copy of the detections with `tracker_id` set
+        A copy of the detections with `tracker_id` set
             for each detection that is tracked.
     """
     # Re-run association in the same way (could also store direct mapping)


### PR DESCRIPTION
## What does this PR do?

This pull request improves the clarity and consistency of docstrings and type annotations across the ByteTrack and SORT tracking modules. The main changes focus on standardizing docstring formats, making argument and return types clearer, and simplifying descriptions to help users and developers better understand the code and its expected inputs/outputs.

## Type of Change

Documentation update