### PR TITLE
Add source-aware progress reporting to CLI track command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
     "numpy>=2.0.2",
     "supervision>=0.26.1",
     "scipy>=1.13.1",
-    "opencv-python>=4.8.0"
+    "opencv-python>=4.8.0",
+    "rich>=13.0.0"
 ]
 
 [project.optional-dependencies]

--- a/test/scripts/test_progress.py
+++ b/test/scripts/test_progress.py
@@ -1,0 +1,356 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import time
+from io import StringIO
+from pathlib import Path
+from typing import Callable
+from unittest.mock import MagicMock, patch
+
+import cv2
+import numpy as np
+import pytest
+from rich.console import Console
+
+from trackers.scripts.progress import (
+    _classify_source,
+    _format_time,
+    _SourceInfo,
+    _TrackingProgress,
+)
+
+FRAME_WIDTH = 64
+FRAME_HEIGHT = 64
+FRAME_SIZE = (FRAME_WIDTH, FRAME_HEIGHT)
+
+
+@pytest.fixture
+def video_factory(tmp_path: Path) -> Callable[[int], Path]:
+    """Create a small test video with *n* frames."""
+
+    def _create(n_frames: int) -> Path:
+        video_path = tmp_path / f"video_{n_frames}.mp4"
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        writer = cv2.VideoWriter(str(video_path), fourcc, 25.0, FRAME_SIZE)
+        for _ in range(n_frames):
+            writer.write(np.zeros((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8))
+        writer.release()
+        return video_path
+
+    return _create
+
+
+@pytest.fixture
+def image_directory_factory(tmp_path: Path) -> Callable[[int], Path]:
+    """Create a directory with *n* PNG images."""
+
+    def _create(n_frames: int) -> Path:
+        directory = tmp_path / f"imgdir_{n_frames}"
+        directory.mkdir(exist_ok=True)
+        frame = np.zeros((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8)
+        for i in range(n_frames):
+            cv2.imwrite(str(directory / f"{i:04d}.png"), frame)
+        return directory
+
+    return _create
+
+
+def _make_console() -> tuple[Console, StringIO]:
+    """Return a Console that writes to a StringIO buffer."""
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=200)
+    return console, buf
+
+
+class TestClassifySource:
+    def test_video_file(self, video_factory: Callable[[int], Path]) -> None:
+        video_path = video_factory(10)
+        info = _classify_source(str(video_path))
+
+        assert info.source_type == "video"
+        assert info.total_frames is not None
+        assert info.total_frames > 0
+        assert info.fps is not None
+        assert info.fps > 0
+
+    def test_image_directory(
+        self, image_directory_factory: Callable[[int], Path]
+    ) -> None:
+        directory = image_directory_factory(7)
+        info = _classify_source(str(directory))
+
+        assert info.source_type == "image_dir"
+        assert info.total_frames == 7
+        assert info.fps is None
+
+    def test_image_directory_path_object(
+        self, image_directory_factory: Callable[[int], Path]
+    ) -> None:
+        directory = image_directory_factory(3)
+        info = _classify_source(directory)
+
+        assert info.source_type == "image_dir"
+        assert info.total_frames == 3
+
+    def test_webcam_from_int(self) -> None:
+        info = _classify_source(0)
+
+        assert info.source_type == "webcam"
+        assert info.total_frames is None
+        assert info.fps is None
+
+    def test_webcam_from_str(self) -> None:
+        info = _classify_source("0")
+
+        assert info.source_type == "webcam"
+        assert info.total_frames is None
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "rtsp://192.168.1.10:554/stream",
+            "http://example.com/stream.mjpg",
+            "https://example.com/stream.mjpg",
+        ],
+    )
+    def test_stream_url(self, url: str) -> None:
+        info = _classify_source(url)
+
+        assert info.source_type == "stream"
+        assert info.total_frames is None
+        assert info.fps is None
+
+    def test_video_with_zero_frame_count(self) -> None:
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = True
+        mock_cap.get.side_effect = lambda prop: {
+            cv2.CAP_PROP_FRAME_COUNT: 0.0,
+            cv2.CAP_PROP_FPS: 30.0,
+        }.get(prop, 0.0)
+
+        with patch("trackers.scripts.progress.cv2.VideoCapture", return_value=mock_cap):
+            info = _classify_source("some_video.mp4")
+
+        assert info.source_type == "video"
+        assert info.total_frames is None
+        mock_cap.release.assert_called_once()
+
+    def test_nonexistent_file(self) -> None:
+        info = _classify_source("/nonexistent/video.mp4")
+
+        assert info.source_type == "video"
+        assert info.total_frames is None
+
+    def test_empty_image_directory(self, tmp_path: Path) -> None:
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        info = _classify_source(str(empty_dir))
+
+        assert info.source_type == "image_dir"
+        assert info.total_frames is None
+
+
+class TestFormatTime:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (0, "0:00"),
+            (5, "0:05"),
+            (65, "1:05"),
+            (3661, "1:01:01"),
+            (-1, "--"),
+        ],
+    )
+    def test_format_time(self, seconds: float, expected: str) -> None:
+        assert _format_time(seconds) == expected
+
+
+class TestBuildLine:
+    def test_bounded_format(self) -> None:
+        console, _ = _make_console()
+        source_info = _SourceInfo(source_type="video", total_frames=100)
+        progress = _TrackingProgress(source_info, console=console)
+        progress._start_time = time.monotonic() - 5.0
+        progress._frames_processed = 50
+
+        line = progress._build_line("⠹")
+        text = line.plain
+
+        assert "50 / 100" in text
+        assert "frames" in text
+        assert "50%" in text
+        assert "fps" in text
+        assert "elapsed" in text
+        assert "eta" in text
+
+    def test_unbounded_format(self) -> None:
+        console, _ = _make_console()
+        source_info = _SourceInfo(source_type="webcam")
+        progress = _TrackingProgress(source_info, console=console)
+        progress._start_time = time.monotonic() - 5.0
+        progress._frames_processed = 50
+
+        line = progress._build_line("⠹")
+        text = line.plain
+
+        assert "50 / --" in text
+        assert "frames" in text
+        assert "--" in text
+        assert "fps" in text
+        assert "elapsed" in text
+        assert "eta --" in text
+
+    def test_final_no_eta(self) -> None:
+        console, _ = _make_console()
+        source_info = _SourceInfo(source_type="video", total_frames=100)
+        progress = _TrackingProgress(source_info, console=console)
+        progress._start_time = time.monotonic() - 5.0
+        progress._frames_processed = 100
+
+        line = progress._build_line("✓", show_eta=False)
+        text = line.plain
+
+        assert "eta" not in text
+        assert "✓" in text
+
+    def test_suffix_appended(self) -> None:
+        console, _ = _make_console()
+        source_info = _SourceInfo(source_type="video", total_frames=100)
+        progress = _TrackingProgress(source_info, console=console)
+        progress._start_time = time.monotonic() - 5.0
+        progress._frames_processed = 50
+
+        line = progress._build_line("✗", show_eta=False, suffix="(interrupted)")
+        text = line.plain
+
+        assert text.endswith("(interrupted)")
+
+    def test_zero_elapsed_no_crash(self) -> None:
+        console, _ = _make_console()
+        source_info = _SourceInfo(source_type="video", total_frames=100)
+        progress = _TrackingProgress(source_info, console=console)
+        progress._start_time = time.monotonic()
+        progress._frames_processed = 0
+
+        # Should not raise ZeroDivisionError
+        line = progress._build_line("⠹")
+        text = line.plain
+
+        assert "fps" in text
+
+
+class TestTrackingProgressLifecycle:
+    def test_bounded_completed(self) -> None:
+        console, buf = _make_console()
+        source_info = _SourceInfo(source_type="video", total_frames=5)
+
+        with _TrackingProgress(source_info, console=console) as progress:
+            for _ in range(5):
+                progress.update()
+            progress.complete()
+
+        output = buf.getvalue()
+        assert "✓" in output
+        assert "(interrupted)" not in output
+
+    def test_bounded_interrupted_by_display_quit(self) -> None:
+        console, buf = _make_console()
+        source_info = _SourceInfo(source_type="video", total_frames=10)
+
+        with _TrackingProgress(source_info, console=console) as progress:
+            for _ in range(5):
+                progress.update()
+            progress.complete(interrupted=True)
+
+        output = buf.getvalue()
+        assert "✗" in output
+        assert "(interrupted)" in output
+
+    def test_bounded_keyboard_interrupt(self) -> None:
+        console, buf = _make_console()
+        source_info = _SourceInfo(source_type="video", total_frames=10)
+
+        progress = _TrackingProgress(source_info, console=console)
+        progress.__enter__()
+        for _ in range(3):
+            progress.update()
+
+        # Simulate KeyboardInterrupt in __exit__
+        progress.__exit__(KeyboardInterrupt, KeyboardInterrupt(), None)
+
+        output = buf.getvalue()
+        assert "✗" in output
+        assert "(interrupted)" in output
+
+    def test_unbounded_completed(self) -> None:
+        console, buf = _make_console()
+        source_info = _SourceInfo(source_type="webcam")
+
+        with _TrackingProgress(source_info, console=console) as progress:
+            for _ in range(20):
+                progress.update()
+            progress.complete()
+
+        output = buf.getvalue()
+        assert "✓" in output
+
+    def test_unbounded_keyboard_interrupt(self) -> None:
+        console, buf = _make_console()
+        source_info = _SourceInfo(source_type="stream")
+
+        progress = _TrackingProgress(source_info, console=console)
+        progress.__enter__()
+        for _ in range(10):
+            progress.update()
+
+        progress.__exit__(KeyboardInterrupt, KeyboardInterrupt(), None)
+
+        output = buf.getvalue()
+        assert "✓" in output
+        assert "(interrupted)" not in output
+
+    def test_error_shows_source_lost(self) -> None:
+        console, buf = _make_console()
+        source_info = _SourceInfo(source_type="stream")
+
+        progress = _TrackingProgress(source_info, console=console)
+        progress.__enter__()
+        for _ in range(5):
+            progress.update()
+
+        err = RuntimeError("connection lost")
+        progress.__exit__(RuntimeError, err, None)
+
+        output = buf.getvalue()
+        assert "✗" in output
+        assert "(source lost)" in output
+
+    def test_frames_count_in_output(self) -> None:
+        console, buf = _make_console()
+        source_info = _SourceInfo(source_type="image_dir", total_frames=30)
+
+        with _TrackingProgress(source_info, console=console) as progress:
+            for _ in range(30):
+                progress.update()
+            progress.complete()
+
+        output = buf.getvalue()
+        assert "30 / 30" in output
+
+    def test_unbounded_frames_count_in_output(self) -> None:
+        console, buf = _make_console()
+        source_info = _SourceInfo(source_type="webcam")
+
+        with _TrackingProgress(source_info, console=console) as progress:
+            for _ in range(42):
+                progress.update()
+            progress.complete()
+
+        output = buf.getvalue()
+        assert "42 / --" in output

--- a/trackers/scripts/progress.py
+++ b/trackers/scripts/progress.py
@@ -161,15 +161,13 @@ class _TrackingProgress:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: object,
-    ) -> bool:
+    ) -> None:
         if self._live is not None:
             self._live.__exit__(None, None, None)
 
         icon, suffix = self._resolve_final_state(exc_type)
         final = self._build_line(icon, show_eta=False, suffix=suffix)
         self._console.print(final)
-
-        return False  # never suppress exceptions
 
     @property
     def _is_bounded(self) -> bool:

--- a/trackers/scripts/progress.py
+++ b/trackers/scripts/progress.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import itertools
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Union
+
+import cv2
+from rich.console import Console
+from rich.live import Live
+from rich.text import Text
+
+from trackers.io.video import IMAGE_EXTENSIONS
+
+_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+_STREAM_PREFIXES = ("rtsp://", "http://", "https://")
+_ICON_OK = "✓"
+_ICON_FAIL = "✗"
+
+
+@dataclass
+class _SourceInfo:
+    """Metadata about a frame source used to drive progress display.
+
+    Attributes:
+        source_type: Kind of source (`video`, `image_dir`, `webcam`,
+            `stream`).
+        total_frames: Total frame count when known, `None` for unbounded
+            sources such as webcams and network streams.
+        fps: Source frame-rate when known, `None` otherwise.
+    """
+
+    source_type: Literal["video", "image_dir", "webcam", "stream"]
+    total_frames: int | None = None
+    fps: float | None = None
+
+
+def _classify_source(source: Union[str, Path, int]) -> _SourceInfo:
+    """Classify a frame source and extract metadata.
+
+    The function inspects *source* without consuming any frames so it can be
+    called before the main processing loop.
+
+    Args:
+        source: The same value accepted by `frames_from_source`.
+
+    Returns:
+        A `_SourceInfo` describing the source.
+    """
+    if isinstance(source, int) or (isinstance(source, str) and source.isdigit()):
+        return _SourceInfo(source_type="webcam")
+
+    source_str = str(source)
+
+    if any(source_str.lower().startswith(p) for p in _STREAM_PREFIXES):
+        return _SourceInfo(source_type="stream")
+
+    path = Path(source_str)
+    if path.is_dir():
+        count = sum(
+            1
+            for p in path.iterdir()
+            if p.is_file() and p.suffix.lower() in IMAGE_EXTENSIONS
+        )
+        return _SourceInfo(
+            source_type="image_dir",
+            total_frames=count if count > 0 else None,
+        )
+
+    cap = cv2.VideoCapture(source_str)
+    if not cap.isOpened():
+        # Cannot open; still classify as video - the real error will come
+        # from frames_from_source later.
+        return _SourceInfo(source_type="video")
+
+    try:
+        total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        return _SourceInfo(
+            source_type="video",
+            total_frames=total if total > 0 else None,
+            fps=fps if fps and fps > 0 else None,
+        )
+    finally:
+        cap.release()
+
+
+def _format_time(seconds: float) -> str:
+    """Format `seconds` as `H:MM:SS` or `M:SS`."""
+    if seconds < 0:
+        return "--"
+    minutes, seconds_remainder = divmod(int(seconds), 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours > 0:
+        return f"{hours}:{minutes:02d}:{seconds_remainder:02d}"
+    return f"{minutes}:{seconds_remainder:02d}"
+
+
+class _TrackingProgress:
+    """Context-manager that renders a single live progress line.
+
+    Args:
+        source_info: Source metadata returned by `_classify_source`.
+        console: Optional `Console` instance (useful for testing with a
+            `StringIO` file).
+    """
+
+    def __init__(
+        self,
+        source_info: _SourceInfo,
+        console: Console | None = None,
+    ) -> None:
+        self._source_info = source_info
+        self._console = console or Console()
+        self._frames_processed = 0
+        self._start_time: float = 0.0
+        self._spinner = itertools.cycle(_SPINNER_FRAMES)
+        self._live: Live | None = None
+        self._interrupted = False
+
+    def update(self) -> None:
+        """Record one processed frame and refresh the display."""
+        self._frames_processed += 1
+        icon = next(self._spinner)
+        if self._live is not None:
+            self._live.update(self._build_line(icon))
+
+    def complete(self, *, interrupted: bool = False) -> None:
+        """Signal that the processing loop has ended.
+
+        Must be called before leaving the `with` block so that `__exit__`
+        can render the correct final state.
+
+        Args:
+            interrupted: `True` when the loop was terminated early (e.g.
+                display-quit).
+        """
+        self._interrupted = interrupted
+
+    def __enter__(self) -> _TrackingProgress:
+        self._start_time = time.monotonic()
+        self._live = Live(
+            self._build_line("⠋"),
+            console=self._console,
+            refresh_per_second=12,
+            transient=True,
+        )
+        self._live.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> bool:
+        if self._live is not None:
+            self._live.__exit__(None, None, None)
+
+        icon, suffix = self._resolve_final_state(exc_type)
+        final = self._build_line(icon, show_eta=False, suffix=suffix)
+        self._console.print(final)
+
+        return False  # never suppress exceptions
+
+    @property
+    def _is_bounded(self) -> bool:
+        """Whether the source has a known total frame count."""
+        return self._source_info.total_frames is not None
+
+    def _resolve_final_state(
+        self, exc_type: type[BaseException] | None
+    ) -> tuple[str, str]:
+        """Return `(icon, suffix)` for the final printed line."""
+        is_real_error = exc_type is not None and not issubclass(
+            exc_type, KeyboardInterrupt
+        )
+
+        if is_real_error:
+            return (_ICON_FAIL, "(source lost)")
+
+        was_stopped_early = exc_type is not None or self._interrupted
+
+        if was_stopped_early and self._is_bounded:
+            return (_ICON_FAIL, "(interrupted)")
+
+        return (_ICON_OK, "")
+
+    def _build_line(
+        self,
+        icon: str,
+        *,
+        show_eta: bool = True,
+        suffix: str = "",
+    ) -> Text:
+        """Compose the single-line progress string."""
+        elapsed = time.monotonic() - self._start_time
+        fps = self._frames_processed / elapsed if elapsed > 0 else 0.0
+        total = self._source_info.total_frames
+
+        if total is not None:
+            total_str = str(total)
+            frames_part = f"{self._frames_processed:>{len(total_str)}} / {total_str}"
+        else:
+            frames_part = f"{self._frames_processed} / --"
+
+        if total is not None and total > 0:
+            percentage = self._frames_processed / total * 100
+            percentage_part = f"{percentage:>3.0f}%"
+        else:
+            percentage_part = "  --"
+
+        fps_part = f"{fps:>.1f} fps"
+        elapsed_part = f"{_format_time(elapsed)} elapsed"
+
+        parts = [
+            f"{icon} Tracking",
+            f"{frames_part} frames",
+            percentage_part,
+            fps_part,
+            elapsed_part,
+        ]
+
+        if show_eta:
+            if total is not None and fps > 0:
+                remaining = (total - self._frames_processed) / fps
+                parts.append(f"eta {_format_time(remaining)}")
+            else:
+                parts.append("eta --")
+
+        if suffix:
+            parts.append(suffix)
+
+        return Text("   ".join(parts))

--- a/uv.lock
+++ b/uv.lock
@@ -3898,6 +3898,7 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "opencv-python" },
+    { name = "rich" },
     { name = "scipy" },
     { name = "supervision" },
 ]
@@ -3939,6 +3940,7 @@ requires-dist = [
     { name = "inference-models", marker = "extra == 'detection'", specifier = "==0.18.6rc8" },
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "opencv-python", specifier = ">=4.8.0" },
+    { name = "rich", specifier = ">=13.0.0" },
     { name = "scipy", specifier = ">=1.13.1" },
     { name = "supervision", specifier = ">=0.26.1" },
 ]


### PR DESCRIPTION
## Summary

- Add real-time progress display to `trackers track` that adapts to the source type: bounded sources (video files, image directories) show frame count, percentage, FPS, elapsed time, and ETA; unbounded sources (webcams, RTSP streams) show frame count, FPS, and elapsed time with `--` for unknown fields.
- Introduce `_TrackingProgress` context manager and `_classify_source` helper in a new `trackers/scripts/progress.py` module, using `rich.live.Live` for terminal rendering.
- Final status line reflects exit reason: `✓` for normal completion, `✗` with `(interrupted)` for early exit on bounded sources, and `✗` with `(source lost)` on runtime errors.