### PR TITLE
fix(eval): simplify directory expectations for `evaluate_mot_sequences`

### DIFF
--- a/docs/learn/evaluate.md
+++ b/docs/learn/evaluate.md
@@ -95,28 +95,25 @@ Ground truth and tracker files use MOT Challenge text format — a simple comma-
 
 ## Directory Layouts
 
-The evaluator automatically detects whether you're using a flat or MOT-style structure. It also tries to infer benchmark name, split, and tracker name from folder names.
+The evaluator automatically detects whether you're using a flat or MOT-style structure. Both `gt_dir` and `tracker_dir` should point directly at the parent directory of the sequences.
 
 === "MOT Layout"
 
-    Standard MOT Challenge nested structure.
+    Standard MOT Challenge nested structure. Point `gt_dir` at the directory that directly contains the sequence folders, and `tracker_dir` at the directory containing the `{seq}.txt` files.
 
     ```
-    data/
-    ├── MOT17-train/
-    │   ├── MOT17-02-FRCNN/
-    │   │   └── gt/gt.txt
-    │   ├── MOT17-04-FRCNN/
-    │   │   └── gt/gt.txt
-    │   └── MOT17-05-FRCNN/
-    │       └── gt/gt.txt
-    └── trackers/
-        └── MOT17-train/
-            └── ByteTrack/
-                └── data/
-                    ├── MOT17-02-FRCNN.txt
-                    ├── MOT17-04-FRCNN.txt
-                    └── MOT17-05-FRCNN.txt
+    gt/
+    ├── MOT17-02-FRCNN/
+    │   └── gt/gt.txt
+    ├── MOT17-04-FRCNN/
+    │   └── gt/gt.txt
+    └── MOT17-05-FRCNN/
+        └── gt/gt.txt
+
+    trackers/
+    ├── MOT17-02-FRCNN.txt
+    ├── MOT17-04-FRCNN.txt
+    └── MOT17-05-FRCNN.txt
     ```
 
     **Python**
@@ -125,23 +122,15 @@ The evaluator automatically detects whether you're using a flat or MOT-style str
     from trackers.eval import evaluate_mot_sequences
 
     result = evaluate_mot_sequences(
-        gt_dir="data",
-        tracker_dir="data/trackers",
-        benchmark="MOT17",
-        split="train",
-        tracker_name="ByteTrack",
+        gt_dir="gt",
+        tracker_dir="trackers",
     )
     ```
 
     **CLI**
 
     ```bash
-    trackers eval \
-        --gt-dir data \
-        --tracker-dir data/trackers \
-        --benchmark MOT17 \
-        --split train \
-        --tracker-name ByteTrack
+    trackers eval --gt-dir gt --tracker-dir trackers
     ```
 
 === "Flat Layout"
@@ -149,15 +138,15 @@ The evaluator automatically detects whether you're using a flat or MOT-style str
     One `.txt` file per sequence, placed directly in the directories.
 
     ```
-    data/
-    ├── gt/
-    │   ├── MOT17-02-FRCNN.txt
-    │   ├── MOT17-04-FRCNN.txt
-    │   └── MOT17-05-FRCNN.txt
-    └── trackers/
-        ├── MOT17-02-FRCNN.txt
-        ├── MOT17-04-FRCNN.txt
-        └── MOT17-05-FRCNN.txt
+    gt/
+    ├── MOT17-02-FRCNN.txt
+    ├── MOT17-04-FRCNN.txt
+    └── MOT17-05-FRCNN.txt
+
+    trackers/
+    ├── MOT17-02-FRCNN.txt
+    ├── MOT17-04-FRCNN.txt
+    └── MOT17-05-FRCNN.txt
     ```
 
     **Python**
@@ -166,15 +155,15 @@ The evaluator automatically detects whether you're using a flat or MOT-style str
     from trackers.eval import evaluate_mot_sequences
 
     result = evaluate_mot_sequences(
-        gt_dir="data/gt",
-        tracker_dir="data/trackers",
+        gt_dir="gt",
+        tracker_dir="trackers",
     )
     ```
 
     **CLI**
 
     ```bash
-    trackers eval --gt-dir data/gt --tracker-dir data/trackers
+    trackers eval --gt-dir gt --tracker-dir trackers
     ```
 
 ---

--- a/trackers/scripts/eval.py
+++ b/trackers/scripts/eval.py
@@ -57,24 +57,6 @@ def add_eval_subparser(subparsers: argparse._SubParsersAction) -> None:
         metavar="PATH",
         help="Sequence map file listing sequences to evaluate.",
     )
-    bench_group.add_argument(
-        "--benchmark",
-        type=str,
-        metavar="NAME",
-        help="Override auto-detected benchmark name (e.g., MOT17, SportsMOT).",
-    )
-    bench_group.add_argument(
-        "--split",
-        type=str,
-        metavar="NAME",
-        help="Override auto-detected split name (e.g., train, val, test).",
-    )
-    bench_group.add_argument(
-        "--tracker-name",
-        type=str,
-        metavar="NAME",
-        help="Override auto-detected tracker name.",
-    )
 
     # Common options
     parser.add_argument(
@@ -169,9 +151,6 @@ def run_eval(args: argparse.Namespace) -> int:
                 seqmap=args.seqmap,
                 metrics=args.metrics,
                 threshold=args.threshold,
-                benchmark=args.benchmark,
-                split=args.split,
-                tracker_name=args.tracker_name,
             )
             print(bench_result.table(columns=columns))
 


### PR DESCRIPTION
## Summary

- Simplify `evaluate_mot_sequences` so `gt_dir` and `tracker_dir` always point directly at the parent of sequences, removing the `{benchmark}-{split}` auto-detection layer (~180 lines deleted)
- Remove `benchmark`, `split`, and `tracker_name` parameters from the Python API and `--benchmark`, `--split`, `--tracker-name` from the CLI