### PR TITLE
allow --classes to accept class names in addition to integer IDs

### DIFF
--- a/docs/javascripts/command_builder.js
+++ b/docs/javascripts/command_builder.js
@@ -67,7 +67,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function isValidClasses(value) {
-    return /^[\d,\s]*$/.test(value);
+    return /^[\w,\s]*$/.test(value);
   }
 
   // Generate command from state
@@ -148,7 +148,7 @@ document.addEventListener("DOMContentLoaded", function () {
         errors.push("Confidence must be between 0.05 and 1");
       }
       if (state.classes && !isValidClasses(state.classes)) {
-        errors.push("Classes must contain only numbers, commas, and spaces");
+        errors.push("Classes must contain only names, numbers, commas, and spaces");
       }
     }
 
@@ -184,7 +184,7 @@ document.addEventListener("DOMContentLoaded", function () {
     getValidationErrors,
     inputSanitizers: {
       classes(value) {
-        return value.replace(/[^\d,\s]/g, "");
+        return value.replace(/[^\w,\s]/g, "");
       },
     },
     onInputChange({ key, value, isCommit, builder: instance }) {
@@ -278,7 +278,7 @@ document.addEventListener("DOMContentLoaded", function () {
         )
       );
       modelOptionsContent.appendChild(
-        createTextInputRow("classes", "0, 2", "classes", state.classes, "cb-row--anchor-3")
+        createTextInputRow("classes", "person, car", "classes", state.classes, "cb-row--anchor-3")
       );
       code.appendChild(modelOptionsContent);
 

--- a/docs/learn/track.md
+++ b/docs/learn/track.md
@@ -176,7 +176,7 @@ Trackers don't detect objects—they link detections across frames. A detection 
     trackers track --source source.mp4 --model rfdetr-medium \
         --model.confidence 0.3 \
         --model.device cuda \
-        --classes 0,2
+        --classes person,car
     ```
 
     <table>
@@ -210,7 +210,7 @@ Trackers don't detect objects—they link detections across frames. A detection 
         </tr>
         <tr>
           <td><code>--classes</code></td>
-          <td>Comma-separated class IDs to track. Example: <code>0</code> for persons, <code>0,2</code> for persons and cars.</td>
+          <td>Comma-separated class names or IDs to track. Example: <code>person,car</code> or <code>0,2</code>.</td>
           <td>all</td>
         </tr>
         <tr>

--- a/test/scripts/test_track.py
+++ b/test/scripts/test_track.py
@@ -124,7 +124,13 @@ class TestFormatLabels:
 
 
 class TestResolveClassFilter:
-    CLASS_NAMES: ClassVar[list[str]] = ["person", "bicycle", "car", "motorcycle", "airplane"]
+    CLASS_NAMES: ClassVar[list[str]] = [
+        "person",
+        "bicycle",
+        "car",
+        "motorcycle",
+        "airplane",
+    ]
 
     @pytest.mark.parametrize(
         "classes_arg,expected",

--- a/test/scripts/test_track.py
+++ b/test/scripts/test_track.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import numpy as np
 import pytest
 import supervision as sv
@@ -122,7 +124,7 @@ class TestFormatLabels:
 
 
 class TestResolveClassFilter:
-    CLASS_NAMES = ["person", "bicycle", "car", "motorcycle", "airplane"]
+    CLASS_NAMES: ClassVar[list[str]] = ["person", "bicycle", "car", "motorcycle", "airplane"]
 
     @pytest.mark.parametrize(
         "classes_arg,expected",

--- a/test/scripts/test_track.py
+++ b/test/scripts/test_track.py
@@ -13,6 +13,7 @@ import supervision as sv
 from trackers.scripts.track import (
     _format_labels,
     _init_annotators,
+    _resolve_class_filter,
 )
 
 
@@ -118,3 +119,39 @@ class TestFormatLabels:
         detections = sv.Detections(**detections_kwargs)
         labels = _format_labels(detections, class_names, **label_flags)
         assert labels == expected
+
+
+class TestResolveClassFilter:
+    CLASS_NAMES = ["person", "bicycle", "car", "motorcycle", "airplane"]
+
+    @pytest.mark.parametrize(
+        "classes_arg,expected",
+        [
+            pytest.param(None, None, id="none_returns_none"),
+            pytest.param("", None, id="empty_returns_none"),
+            pytest.param("0,2", [0, 2], id="integer_ids"),
+            pytest.param("person,car", [0, 2], id="class_names"),
+            pytest.param("person,2,motorcycle", [0, 2, 3], id="mixed_names_and_ids"),
+            pytest.param(" person , car ", [0, 2], id="whitespace_stripped"),
+            pytest.param("99", [99], id="out_of_range_id_kept"),
+        ],
+    )
+    def test_resolves_classes(
+        self,
+        classes_arg: str | None,
+        expected: list[int] | None,
+    ) -> None:
+        result = _resolve_class_filter(classes_arg, self.CLASS_NAMES)
+        assert result == expected
+
+    def test_unknown_name_warns_and_skips(self, capsys: pytest.CaptureFixture) -> None:
+        result = _resolve_class_filter("person,unicorn,car", self.CLASS_NAMES)
+        assert result == [0, 2]
+        assert "unicorn" in capsys.readouterr().err
+
+    def test_all_unknown_names_returns_none(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        result = _resolve_class_filter("unicorn,dragon", self.CLASS_NAMES)
+        assert result is None
+        assert "unicorn" in capsys.readouterr().err

--- a/trackers/scripts/track.py
+++ b/trackers/scripts/track.py
@@ -5,8 +5,6 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""Track objects in video using detection models and tracking algorithms."""
-
 from __future__ import annotations
 
 import argparse
@@ -122,8 +120,8 @@ def add_track_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--classes",
         type=str,
         default=None,
-        metavar="IDS",
-        help="Filter by class IDs (comma-separated, e.g., 0,1,2).",
+        metavar="NAMES_OR_IDS",
+        help="Filter by class names or IDs (comma-separated, e.g., person,car or 0,1,2).",
     )
 
     # Tracker options
@@ -268,11 +266,6 @@ def run_track(args: argparse.Namespace) -> int:
     if args.mot_output:
         _validate_output_path(args.mot_output, overwrite=args.overwrite)
 
-    # Parse class filter
-    class_filter = None
-    if args.classes:
-        class_filter = [int(c.strip()) for c in args.classes.split(",")]
-
     # Create detection source
     if args.detections:
         model = None
@@ -286,6 +279,9 @@ def run_track(args: argparse.Namespace) -> int:
         )
         detections_data = None
         class_names = getattr(model, "class_names", [])
+
+    # Resolve class filter (names and/or integer IDs)
+    class_filter = _resolve_class_filter(args.classes, class_names)
 
     # Create tracker
     tracker_params = _extract_tracker_params(args.tracker, args)
@@ -375,6 +371,46 @@ def run_track(args: argparse.Namespace) -> int:
         pass  # progress.__exit__ already printed the final line
 
     return 0
+
+
+def _resolve_class_filter(
+    classes_arg: str | None,
+    class_names: list[str],
+) -> list[int] | None:
+    """Resolve a comma-separated `--classes` value to a list of integer IDs.
+
+    Each token is checked independently: if it parses as an `int` it is used
+    directly as a class ID; otherwise it is looked up by name in *class_names*.
+    Unknown names are printed as warnings and skipped.
+
+    Args:
+        classes_arg: Raw `--classes` string (e.g. `"person,car"` or
+            `"0,2"` or `"person,2"`). `None` means no filter.
+        class_names: Ordered list of class names where the index equals the
+            class ID (as provided by the model).
+
+    Returns:
+        List of integer class IDs, or `None` when no valid filter remains.
+    """
+    if not classes_arg:
+        return None
+
+    requested = [token.strip() for token in classes_arg.split(",")]
+    name_to_id = {name: i for i, name in enumerate(class_names)}
+    class_filter: list[int] = []
+    for token in requested:
+        try:
+            class_filter.append(int(token))
+        except ValueError:
+            if token in name_to_id:
+                class_filter.append(name_to_id[token])
+            else:
+                print(
+                    f"Warning: class '{token}' not found in model class "
+                    "list, skipping.",
+                    file=sys.stderr,
+                )
+    return class_filter if class_filter else None
 
 
 def _init_model(

--- a/trackers/scripts/track.py
+++ b/trackers/scripts/track.py
@@ -121,7 +121,7 @@ def add_track_subparser(subparsers: argparse._SubParsersAction) -> None:
         type=str,
         default=None,
         metavar="NAMES_OR_IDS",
-        help="Filter by class names or IDs (comma-separated, e.g., person,car or 0,1,2).",
+        help="Filter by class names or IDs (comma-separated, e.g., person,car).",
     )
 
     # Tracker options


### PR DESCRIPTION
Summary

- The --classes CLI flag now accepts class names (e.g. person,car), integer IDs (e.g. 0,2), or a mix of both (e.g. person,2,dog). Integer tokens are used directly; name tokens are resolved against the model's class list. Unknown names print a warning and are skipped.
- Updated docs and the interactive command builder to reflect the new format.
- Added 9 unit tests covering names, IDs, mixed input, whitespace, unknown names, and edge cases.
- Removed pre-existing module-level docstring from track.py per coding standards.