### PR TITLE
Preserve source video FPS in CLI track output

### DIFF
--- a/test/io_tests/test_video.py
+++ b/test/io_tests/test_video.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 
 from trackers import frames_from_source
+from trackers.io.video import _DEFAULT_OUTPUT_FPS, _VideoOutput
 
 FRAME_WIDTH = 96
 FRAME_HEIGHT = 96
@@ -208,3 +209,31 @@ class TestFramesFromSourceErrors:
     ) -> None:
         with pytest.raises(OSError, match="Failed to read image"):
             list(frames_from_source(directory_with_corrupted_image))
+
+
+class TestVideoOutputFPS:
+    def test_uses_source_fps_when_provided(self, tmp_path: Path) -> None:
+        output_path = tmp_path / "out.mp4"
+        frame = np.zeros((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8)
+
+        with _VideoOutput(output_path, fps=24.0) as video:
+            video.write(frame)
+
+        cap = cv2.VideoCapture(str(output_path))
+        assert cap.isOpened()
+        actual_fps = cap.get(cv2.CAP_PROP_FPS)
+        cap.release()
+        assert actual_fps == pytest.approx(24.0, abs=0.1)
+
+    def test_falls_back_to_default_fps(self, tmp_path: Path) -> None:
+        output_path = tmp_path / "out.mp4"
+        frame = np.zeros((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8)
+
+        with _VideoOutput(output_path) as video:
+            video.write(frame)
+
+        cap = cv2.VideoCapture(str(output_path))
+        assert cap.isOpened()
+        actual_fps = cap.get(cv2.CAP_PROP_FPS)
+        cap.release()
+        assert actual_fps == pytest.approx(_DEFAULT_OUTPUT_FPS, abs=0.1)

--- a/trackers/scripts/track.py
+++ b/trackers/scripts/track.py
@@ -19,7 +19,7 @@ from trackers import frames_from_source
 from trackers.core.base import BaseTracker
 from trackers.io.mot import _load_mot_file, _mot_frame_to_detections, _MOTOutput
 from trackers.io.paths import _resolve_video_output_path, _validate_output_path
-from trackers.io.video import _DisplayWindow, _VideoOutput
+from trackers.io.video import _DEFAULT_OUTPUT_FPS, _DisplayWindow, _VideoOutput
 from trackers.scripts.progress import _classify_source, _TrackingProgress
 from trackers.utils.device import _best_device
 
@@ -311,7 +311,10 @@ def run_track(args: argparse.Namespace) -> int:
 
     try:
         with (
-            _VideoOutput(args.output) as video,
+            _VideoOutput(
+                args.output,
+                fps=source_info.fps or _DEFAULT_OUTPUT_FPS,
+            ) as video,
             _MOTOutput(args.mot_output) as mot,
             display_ctx as display,
             _TrackingProgress(source_info) as progress,


### PR DESCRIPTION
## Summary

- Output videos were always written at 30 FPS regardless of the source frame rate. Now `_VideoOutput` receives the actual source FPS from `_classify_source` and falls back to `_DEFAULT_OUTPUT_FPS` (30.0) for sources without a known frame rate (e.g. image directories).
- Extracted `_DEFAULT_OUTPUT_FPS` constant to eliminate the magic number.
- Cleaned up `video.py`: renamed `h, w` to `height, width`, added return type annotations to `__enter__`/`__exit__`, removed forbidden module-level docstring.