### PR TITLE
Revamp README for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
+<div align="center">
+    <img width="200" src="https://raw.githubusercontent.com/roboflow/trackers/refs/heads/main/docs/assets/logo-trackers-violet.svg" alt="trackers logo">
+    <h1>trackers</h1>
+    <p>Multi-object tracking. One pip install. Any detector.</p>
+
 [![version](https://badge.fury.io/py/trackers.svg)](https://badge.fury.io/py/trackers)
 [![downloads](https://img.shields.io/pypi/dm/trackers)](https://pypistats.org/packages/trackers)
 [![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/trackers/blob/main/LICENSE.md)
 [![python-version](https://img.shields.io/pypi/pyversions/trackers)](https://badge.fury.io/py/trackers)
 [![hf space](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/Roboflow/Trackers)
 [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-track-objects-with-bytetrack-tracker.ipynb)
-
-<div align="center">
-    <h1 align="center">trackers</h1>
-    <img width="200" src="https://raw.githubusercontent.com/roboflow/trackers/refs/heads/main/docs/assets/logo-trackers-violet.svg" alt="trackers logo">
+[![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
 </div>
-
-`trackers` gives you clean, modular re-implementations of leading multi-object tracking algorithms released under the permissive Apache 2.0 license. You combine them with any detection model you already use.
 
 https://github.com/user-attachments/assets/eef9b00a-cfe4-40f7-a495-954550e3ef1f
 
-## Install
+## Try It Now
 
-You can install and use `trackers` in a [**Python>=3.10**](https://www.python.org/) environment. For detailed installation instructions, including installing from source and setting up a local development environment, check out our [install](https://trackers.roboflow.com/develop/learn/install/) page.
+No install needed. Try trackers in your browser with our [Hugging Face Playground](https://huggingface.co/spaces/roboflow/trackers).
+
+## Install
 
 ```bash
 pip install trackers
@@ -25,61 +27,31 @@ pip install trackers
 <details>
 <summary>install from source</summary>
 
-<br>
-
-By installing `trackers` from source, you can explore the most recent features and enhancements that have not yet been officially released. Please note that these updates are still in development and may not be as stable as the latest published release.
-
 ```bash
-pip install https://github.com/roboflow/trackers/archive/refs/heads/develop.zip
+pip install git+https://github.com/roboflow/trackers.git
 ```
 
 </details>
 
-## Quickstart
+## Track from CLI
 
-Use the `trackers` CLI to quickly test how our tracking algorithms perform on your videos and streams. This feature is experimental; see the [CLI documentation](https://trackers.roboflow.com/develop/learn/track) for details.
+Point at a video, webcam, RTSP stream, or image directory. Get tracked output.
+
+Use our [interactive command builder](https://trackers.roboflow.com/develop/learn/track) to configure your tracking pipeline.
 
 ```bash
-trackers track --source source.mp4 --output output.mp4 --model rfdetr-nano --tracker bytetrack
+trackers track \
+    --source video.mp4 \
+    --output output.mp4 \
+    --model rfdetr-medium \
+    --tracker bytetrack \
+    --show-labels \
+    --show-trajectories
 ```
 
-## Tracking Algorithms
+## Track from Python
 
-`trackers` gives you clean, modular re-implementations of leading multi-object tracking algorithms. The package currently supports [SORT](https://arxiv.org/abs/1602.00763) and [ByteTrack](https://arxiv.org/abs/2110.06864). [OC-SORT](https://arxiv.org/abs/2203.14360), [BoT-SORT](https://arxiv.org/abs/2206.14651), and [McByte](https://arxiv.org/abs/2506.01373) support is coming soon. For comparisons, see the [tracker comparison](https://trackers.roboflow.com/develop/trackers/comparison/) page.
-
-| Algorithm | MOT17 HOTA | MOT17 IDF1 | MOT17 MOTA | SportsMOT HOTA | SoccerNet HOTA |
-| :-------: | :--------: | :--------: | :--------: | :------------: | :------------: |
-|   SORT    |    58.4    |    69.9    |    67.2    |      70.9      |      81.6      |
-| ByteTrack |  **60.1**  |  **73.2**  |  **74.1**  |    **73.0**    |    **84.0**    |
-|  OC-SORT  |     —      |     —      |     —      |       —        |       —        |
-| BoT-SORT  |     —      |     —      |     —      |       —        |       —        |
-|  McByte   |     —      |     —      |     —      |       —        |       —        |
-
-## Integration
-
-With a modular design, `trackers` lets you combine object detectors from different libraries with the tracker of your choice.
-
-```python
-import cv2
-from rfdetr import RFDETRNano
-from trackers import ByteTrackTracker
-
-model = RFDETRNano()
-tracker = ByteTrackTracker()
-
-cap = cv2.VideoCapture("source.mp4")
-while True:
-    ret, frame = cap.read()
-    if not ret:
-        break
-
-    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-    detections = model.predict(frame_rgb)
-    detections = tracker.update(detections)
-```
-
-<details>
-<summary>run with Inference</summary>
+Plug trackers into your existing detection pipeline. Works with any detector.
 
 ```python
 import cv2
@@ -87,51 +59,62 @@ import supervision as sv
 from inference import get_model
 from trackers import ByteTrackTracker
 
-model = get_model(model_id="rfdetr-nano")
+model = get_model(model_id="rfdetr-medium")
 tracker = ByteTrackTracker()
 
-cap = cv2.VideoCapture("source.mp4")
-while True:
+label_annotator = sv.LabelAnnotator()
+trajectory_annotator = sv.TrajectoryAnnotator()
+
+cap = cv2.VideoCapture("video.mp4")
+while cap.isOpened():
     ret, frame = cap.read()
     if not ret:
         break
 
     result = model.infer(frame)[0]
     detections = sv.Detections.from_inference(result)
-    detections = tracker.update(detections)
+    tracked = tracker.update(detections)
+
+    frame = label_annotator.annotate(frame, tracked)
+    frame = trajectory_annotator.annotate(frame, tracked)
 ```
 
-</details>
+## Evaluate
 
-<details>
-<summary>run with Ultralytics</summary>
+Benchmark your tracker against ground truth with standard MOT metrics.
 
-```python
-import cv2
-import supervision as sv
-from ultralytics import YOLO
-from trackers import ByteTrackTracker
-
-model = YOLO("yolo11n.pt")
-tracker = ByteTrackTracker()
-
-cap = cv2.VideoCapture("source.mp4")
-while True:
-    ret, frame = cap.read()
-    if not ret:
-        break
-
-    result = model(frame)[0]
-    detections = sv.Detections.from_ultralytics(result)
-    detections = tracker.update(detections)
+```bash
+trackers eval \
+    --gt-dir data/gt \
+    --tracker-dir data/trackers \
+    --metrics CLEAR HOTA Identity
 ```
 
-</details>
+```
+Sequence                        MOTA    HOTA    IDF1  IDSW
+----------------------------------------------------------
+MOT17-02-FRCNN                75.600  62.300  72.100    42
+MOT17-04-FRCNN                78.200  65.100  74.800    31
+----------------------------------------------------------
+COMBINED                      75.033  62.400  72.033    73
+```
+
+## Algorithms
+
+Clean, modular implementations of leading trackers. See the [tracker comparison](https://trackers.roboflow.com/develop/trackers/comparison/) for detailed benchmarks.
+
+| Algorithm | MOT17 | SportsMOT | SoccerNet |
+| :-------: | :---: | :-------: | :-------: |
+| [SORT](https://arxiv.org/abs/1602.00763) | 58.4 | 70.9 | 81.6 |
+| [ByteTrack](https://arxiv.org/abs/2110.06864) | **60.1** | **73.0** | **84.0** |
+| [OC-SORT](https://arxiv.org/abs/2203.14360) | — | — | — |
+| [BoT-SORT](https://arxiv.org/abs/2206.14651) | — | — | — |
+| [McByte](https://arxiv.org/abs/2506.01373) | — | — | — |
+
+## Contributing
+
+We welcome contributions. Read our [contributor guidelines](https://github.com/roboflow/trackers/blob/main/CONTRIBUTING.md) to get started.
 
 ## License
 
 The code is released under the [Apache 2.0 license](https://github.com/roboflow/trackers/blob/main/LICENSE).
-
-## Contribution
-
-We welcome all contributions—whether it’s reporting issues, suggesting features, or submitting pull requests. Please read our [contributor guidelines](https://github.com/roboflow/trackers/blob/main/CONTRIBUTING.md) to learn about our processes and best practices.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
     <img width="200" src="https://raw.githubusercontent.com/roboflow/trackers/refs/heads/main/docs/assets/logo-trackers-violet.svg" alt="trackers logo">
     <h1>trackers</h1>
-    <p>Multi-object tracking. One pip install. Any detector.</p>
+    <p>Plug-and-play multi-object tracking for any detection model.</p>
 
 [![version](https://badge.fury.io/py/trackers.svg)](https://badge.fury.io/py/trackers)
 [![downloads](https://img.shields.io/pypi/dm/trackers)](https://pypistats.org/packages/trackers)
@@ -12,9 +12,7 @@
 [![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
 </div>
 
-https://github.com/user-attachments/assets/eef9b00a-cfe4-40f7-a495-954550e3ef1f
-
-## Try It Now
+## Try It
 
 No install needed. Try trackers in your browser with our [Hugging Face Playground](https://huggingface.co/spaces/roboflow/trackers).
 
@@ -32,6 +30,8 @@ pip install git+https://github.com/roboflow/trackers.git
 ```
 
 </details>
+
+https://github.com/user-attachments/assets/eef9b00a-cfe4-40f7-a495-954550e3ef1f
 
 ## Track from CLI
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![hf space](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/Roboflow/Trackers)
 [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-track-objects-with-bytetrack-tracker.ipynb)
 [![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
+
 </div>
 
 https://github.com/user-attachments/assets/eef9b00a-cfe4-40f7-a495-954550e3ef1f
@@ -103,13 +104,13 @@ COMBINED                      75.033  62.400  72.033    73
 
 Clean, modular implementations of leading trackers. See the [tracker comparison](https://trackers.roboflow.com/develop/trackers/comparison/) for detailed benchmarks.
 
-| Algorithm | MOT17 | SportsMOT | SoccerNet |
-| :-------: | :---: | :-------: | :-------: |
-| [SORT](https://arxiv.org/abs/1602.00763) | 58.4 | 70.9 | 81.6 |
-| [ByteTrack](https://arxiv.org/abs/2110.06864) | **60.1** | **73.0** | **84.0** |
-| [OC-SORT](https://arxiv.org/abs/2203.14360) | — | — | — |
-| [BoT-SORT](https://arxiv.org/abs/2206.14651) | — | — | — |
-| [McByte](https://arxiv.org/abs/2506.01373) | — | — | — |
+|                   Algorithm                   |  MOT17   | SportsMOT | SoccerNet |
+| :-------------------------------------------: | :------: | :-------: | :-------: |
+|   [SORT](https://arxiv.org/abs/1602.00763)    |   58.4   |   70.9    |   81.6    |
+| [ByteTrack](https://arxiv.org/abs/2110.06864) | **60.1** | **73.0**  | **84.0**  |
+|  [OC-SORT](https://arxiv.org/abs/2203.14360)  |    —     |     —     |     —     |
+| [BoT-SORT](https://arxiv.org/abs/2206.14651)  |    —     |     —     |     —     |
+|  [McByte](https://arxiv.org/abs/2506.01373)   |    —     |     —     |     —     |
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trackers"
-version = "2.2.0rc1"
+version = "2.2.0"
 description = "A unified library for object tracking featuring clean room re-implementations of leading multi-object tracking algorithms"
 readme = "README.md"
 maintainers = [


### PR DESCRIPTION
Restructure README to improve first impressions and lower barrier to entry:

- Add centered hero with tagline "Multi-object tracking. One pip install. Any detector."
- Add "Try It Now" section linking to HF Playground for zero-install trial
- Add HF Space and Colab badges
- Showcase CLI and Python tracking with visualization (labels + trajectories)
- Add Evaluate section highlighting trackers eval command
- Simplify algorithms table to HOTA-only metrics
- Link to interactive command builder for CLI configuration