### PR TITLE
Replace develop branch with `release/*` branches

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -2,7 +2,7 @@ name: Docs Test WorkFlow 📚
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, 'release/*']
 
 # Restrict permissions by default
 permissions:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,7 +2,7 @@ name: Pytest/Test Workflow
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, 'release/*']
 
 jobs:
   run-tests:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,7 +2,7 @@ name: Docs/Build and Publish
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, 'release/*']
   workflow_dispatch:
     inputs:
       ref:
@@ -50,10 +50,10 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: 🚀 Deploy Development Docs
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/develop')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
-        run: uv run mike deploy --push develop
+        run: uv run mike deploy --push preview
 
       - name: 🚀 Deploy Custom Ref Docs
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -11,7 +11,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+.rc[0-9]+"
   workflow_dispatch:
   pull_request:
-    branches: [main, develop]
+    branches: [main, 'release/*']
     paths:
       - '.github/workflows/build-package.yml'
       - '.github/workflows/publish-pre-release.yml'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
   pull_request:
-    branches: [main, develop]
+    branches: [main, 'release/*']
     paths:
       - '.github/workflows/build-package.yml'
       - '.github/workflows/publish-release.yml'


### PR DESCRIPTION
## Summary

- Replace `develop` branch with `release/*` pattern in all CI workflow triggers
- Update docs deployment to publish to `preview` alias instead of `develop`
- Enables short-lived release branches for release preparation work