### PR TITLE
Adopt release/stable branching strategy

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -2,7 +2,7 @@ name: Docs Test WorkFlow 📚
 
 on:
   pull_request:
-    branches: ['release/stable', 'release/*', develop]
+    branches: ['release/*', 'develop']
 
 # Restrict permissions by default
 permissions:

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -2,7 +2,7 @@ name: Docs Test WorkFlow 📚
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: ['release/stable', 'release/*', develop]
 
 # Restrict permissions by default
 permissions:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,7 +2,7 @@ name: Pytest/Test Workflow
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: ['release/stable', 'release/*', develop]
 
 jobs:
   run-tests:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,7 +2,7 @@ name: Pytest/Test Workflow
 
 on:
   pull_request:
-    branches: ['release/stable', 'release/*', develop]
+    branches: ['release/*', 'develop']
 
 jobs:
   run-tests:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,13 +2,13 @@ name: Docs/Build and Publish
 
 on:
   push:
-    branches: [main, develop]
+    branches: ['release/stable', 'release/*', develop]
   workflow_dispatch:
     inputs:
       ref:
         description: 'Branch or tag to deploy'
         required: false
-        default: 'main'
+        default: 'release/stable'
   release:
     types: [published]
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,7 +2,7 @@ name: Docs/Build and Publish
 
 on:
   push:
-    branches: ['release/stable', 'release/*', develop]
+    branches: ['release/*', 'develop']
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -11,7 +11,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+.rc[0-9]+"
   workflow_dispatch:
   pull_request:
-    branches: [main, develop]
+    branches: ['release/stable', 'release/*', develop]
     paths:
       - '.github/workflows/build-package.yml'
       - '.github/workflows/publish-pre-release.yml'

--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -11,7 +11,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+.rc[0-9]+"
   workflow_dispatch:
   pull_request:
-    branches: ['release/stable', 'release/*', develop]
+    branches: ['release/*', 'develop']
     paths:
       - '.github/workflows/build-package.yml'
       - '.github/workflows/publish-pre-release.yml'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
   pull_request:
-    branches: ['release/stable', 'release/*', develop]
+    branches: ['release/*', 'develop']
     paths:
       - '.github/workflows/build-package.yml'
       - '.github/workflows/publish-release.yml'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
   pull_request:
-    branches: [main, develop]
+    branches: ['release/stable', 'release/*', develop]
     paths:
       - '.github/workflows/build-package.yml'
       - '.github/workflows/publish-release.yml'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,14 @@ Thank you for your interest in contributing to the Trackers library! Your helpâ€
 ## Table of Contents
 
 1. [How to Contribute](#how-to-contribute)
-2. [Running Tests](#running-tests)
-3. [CLA Signing](#cla-signing)
-4. [Clean Room Requirements](#clean-room-requirements)
-5. [Google-Style Docstrings and Type Hints](#google-style-docstrings-and-type-hints)
-6. [Reporting Bugs](#reporting-bugs)
-7. [License](#license)
+2. [Branching Strategy](#branching-strategy)
+3. [Releasing](#releasing)
+4. [Running Tests](#running-tests)
+5. [CLA Signing](#cla-signing)
+6. [Clean Room Requirements](#clean-room-requirements)
+7. [Google-Style Docstrings and Type Hints](#google-style-docstrings-and-type-hints)
+8. [Reporting Bugs](#reporting-bugs)
+9. [License](#license)
 
 ## How to Contribute
 
@@ -36,9 +38,56 @@ Contributions come in many forms: improving features, fixing bugs, suggesting id
     git push -u origin your-descriptive-name
     ```
 
-6. [Open a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request): Submit your pull request against the main development branch. Please detail your changes and link any related issues.
+6. [Open a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request): Submit your pull request targeting the `develop` branch. Please detail your changes and link any related issues.
 
 Before merging, check that all tests pass and that your changes adhere to our development and documentation standards.
+
+## Branching Strategy
+
+We use a structured branching model to manage development and releases:
+
+| Branch           | Purpose                                                                     |
+|------------------|-----------------------------------------------------------------------------|
+| `develop`        | Default branch for ongoing development. All feature PRs target this branch. |
+| `release/stable` | Always reflects the latest stable release.                                  |
+| `release/X.Y.Z`  | Short-lived branches for preparing bugfix releases.                         |
+
+## Releasing
+
+**Feature Releases (e.g., 2.3.0)**
+
+When ready to release a new feature version:
+
+1. Ensure `develop` is stable and all CI passes
+
+2. Hard reset `release/stable` to `develop` HEAD:
+
+    ```bash
+    git checkout release/stable
+    git reset --hard origin/develop
+    git push --force origin release/stable
+    ```
+
+3. Tag the release and push
+
+**Bugfix Releases (e.g., 2.2.1)**
+
+When releasing a patch with only specific fixes:
+
+1. Create a release branch from `release/stable`:
+
+    ```bash
+    git checkout release/stable
+    git checkout -b release/2.2.1
+    ```
+
+2. Cherry-pick the specific fix commits from `develop`
+
+3. Open a PR from `release/2.2.1` to `release/stable`
+
+4. Use **rebase merge** (not squash) to preserve individual commits
+
+5. Tag the release and delete the temporary branch
 
 ## Running Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Before merging, check that all tests pass and that your changes adhere to our de
 We use a structured branching model to manage development and releases:
 
 | Branch           | Purpose                                                                     |
-|------------------|-----------------------------------------------------------------------------|
+| ---------------- | --------------------------------------------------------------------------- |
 | `develop`        | Default branch for ongoing development. All feature PRs target this branch. |
 | `release/stable` | Always reflects the latest stable release.                                  |
 | `release/X.Y.Z`  | Short-lived branches for preparing bugfix releases.                         |

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <div align="center">
-    <img width="200" src="https://raw.githubusercontent.com/roboflow/trackers/refs/heads/main/docs/assets/logo-trackers-violet.svg" alt="trackers logo">
+    <img width="200" src="https://raw.githubusercontent.com/roboflow/trackers/refs/heads/release/stable/docs/assets/logo-trackers-violet.svg" alt="trackers logo">
     <h1>trackers</h1>
     <p>Plug-and-play multi-object tracking for any detection model.</p>
 
 [![version](https://badge.fury.io/py/trackers.svg)](https://badge.fury.io/py/trackers)
 [![downloads](https://img.shields.io/pypi/dm/trackers)](https://pypistats.org/packages/trackers)
-[![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/trackers/blob/main/LICENSE.md)
+[![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/trackers/blob/release/stable/LICENSE.md)
 [![python-version](https://img.shields.io/pypi/pyversions/trackers)](https://badge.fury.io/py/trackers)
 [![hf space](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/Roboflow/Trackers)
 [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-track-objects-with-bytetrack-tracker.ipynb)
@@ -114,8 +114,8 @@ Clean, modular implementations of leading trackers. See the [tracker comparison]
 
 ## Contributing
 
-We welcome contributions. Read our [contributor guidelines](https://github.com/roboflow/trackers/blob/main/CONTRIBUTING.md) to get started.
+We welcome contributions. Read our [contributor guidelines](https://github.com/roboflow/trackers/blob/release/stable/CONTRIBUTING.md) to get started.
 
 ## License
 
-The code is released under the [Apache 2.0 license](https://github.com/roboflow/trackers/blob/main/LICENSE).
+The code is released under the [Apache 2.0 license](https://github.com/roboflow/trackers/blob/release/stable/LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ You can install and use `trackers` in a [**Python>=3.10**](https://www.python.or
 
     [![version](https://badge.fury.io/py/trackers.svg)](https://badge.fury.io/py/trackers)
     [![downloads](https://img.shields.io/pypi/dm/trackers)](https://pypistats.org/packages/trackers)
-    [![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/trackers/blob/main/LICENSE.md)
+    [![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/trackers/blob/release/stable/LICENSE.md)
     [![python-version](https://img.shields.io/pypi/pyversions/trackers)](https://badge.fury.io/py/trackers)
 
     === "pip"


### PR DESCRIPTION
## Summary

- Rename `main` branch references to `release/stable` across CI workflows
- Add `release/*` pattern to workflow triggers for bugfix release branches
- Update documentation links (README, docs) to point to `release/stable`
- Document branching strategy and release process in CONTRIBUTING.md