### PR TITLE
Enable pyupgrade (UP) rules in Ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ select = [
     "W",   # pycodestyle warnings (https://docs.astral.sh/ruff/rules/#warning-w)
     "RUF", # Ruff-specific rules (https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf)
     "S",   # security rules (https://docs.astral.sh/ruff/rules/#flake8-bandit-s)
+    "UP",  # pyupgrade rules (https://docs.astral.sh/ruff/rules/#pyupgrade-up)
 ]
 ignore = []
 unfixable = []

--- a/test/core/test_registration.py
+++ b/test/core/test_registration.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-from typing import Any, Optional, Union
+from typing import Any
 
 import pytest
 
@@ -144,16 +144,16 @@ class TestNormalizeType:
             (str, None, str),
             (float, None, float),
             # Optional types
-            (Optional[int], None, int),
-            (Optional[str], None, str),
+            (int | None, None, int),
+            (str | None, None, str),
             # Union with None
-            (Union[int, None], None, int),
-            (Union[str, None], None, str),
+            (int | None, None, int),
+            (str | None, None, str),
             # List and dict
             (list[int], None, list),
             (dict[str, int], None, dict),
             # Nested optional list
-            (Optional[list[int]], None, list),
+            (list[int] | None, None, list),
             # Tuple types
             (tuple[int, ...], None, tuple),
             (tuple[int, str], None, tuple),

--- a/test/io_tests/test_video.py
+++ b/test/io_tests/test_video.py
@@ -6,8 +6,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import cv2
 import numpy as np

--- a/test/scripts/test_progress.py
+++ b/test/scripts/test_progress.py
@@ -7,9 +7,9 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from io import StringIO
 from pathlib import Path
-from typing import Callable
 from unittest.mock import MagicMock, patch
 
 import cv2

--- a/trackers/annotators/trace.py
+++ b/trackers/annotators/trace.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
@@ -82,13 +81,13 @@ class MotionAwareTraceAnnotator:
 
     def __init__(
         self,
-        color: Union[Color, ColorPalette, None] = None,
-        position: Optional[Position] = None,
+        color: Color | ColorPalette | None = None,
+        position: Position | None = None,
         trace_length: int = 30,
         thickness: int = 2,
-        color_lookup: Optional[ColorLookup] = None,
+        color_lookup: ColorLookup | None = None,
     ) -> None:
-        self.color: Union[Color, ColorPalette] = (
+        self.color: Color | ColorPalette = (
             color if color is not None else ColorPalette.DEFAULT
         )
         self.position: Position = position if position is not None else Position.CENTER
@@ -98,7 +97,7 @@ class MotionAwareTraceAnnotator:
             color_lookup if color_lookup is not None else ColorLookup.TRACK
         )
 
-        self._trajectories: Dict[int, List[Tuple[float, float]]] = defaultdict(list)
+        self._trajectories: dict[int, list[tuple[float, float]]] = defaultdict(list)
 
     def _get_anchor_points(self, detections: sv.Detections) -> np.ndarray:
         """Extract anchor points from detections based on position setting.
@@ -115,8 +114,8 @@ class MotionAwareTraceAnnotator:
         self,
         scene: np.ndarray,
         detections: sv.Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
-        coord_transform: Optional[CoordinatesTransformation] = None,
+        custom_color_lookup: np.ndarray | None = None,
+        coord_transform: CoordinatesTransformation | None = None,
     ) -> np.ndarray:
         """Draw motion-compensated trace paths on the scene.
 

--- a/trackers/core/sort/utils.py
+++ b/trackers/core/sort/utils.py
@@ -4,8 +4,9 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from collections.abc import Sequence
 from copy import deepcopy
-from typing import List, Sequence, Set, TypeVar, Union
+from typing import TypeVar
 
 import numpy as np
 import supervision as sv
@@ -14,7 +15,7 @@ from trackers.core.bytetrack.kalman import ByteTrackKalmanBoxTracker
 from trackers.core.sort.kalman import SORTKalmanBoxTracker
 
 KalmanBoxTrackerType = TypeVar(
-    "KalmanBoxTrackerType", bound=Union[SORTKalmanBoxTracker, ByteTrackKalmanBoxTracker]
+    "KalmanBoxTrackerType", bound=SORTKalmanBoxTracker | ByteTrackKalmanBoxTracker
 )
 
 
@@ -22,7 +23,7 @@ def get_alive_trackers(
     trackers: Sequence[KalmanBoxTrackerType],
     minimum_consecutive_frames: int,
     maximum_frames_without_update: int,
-) -> List[KalmanBoxTrackerType]:
+) -> list[KalmanBoxTrackerType]:
     """
     Remove dead or immature lost tracklets and get alive trackers
     that are within `maximum_frames_without_update` AND (it's mature OR
@@ -123,8 +124,8 @@ def update_detections_with_track_ids(
         key=lambda x: iou_matrix_final[x[0], x[1]],
         reverse=True,
     )
-    used_rows: Set[int] = set()
-    used_cols: Set[int] = set()
+    used_rows: set[int] = set()
+    used_cols: set[int] = set()
     for row, col in sorted_pairs:
         # Double check index is in range
         if row < len(trackers):

--- a/trackers/io/video.py
+++ b/trackers/io/video.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Union
 
 import cv2
 import numpy as np
@@ -20,7 +19,7 @@ _DEFAULT_OUTPUT_FPS = 30.0
 
 
 def frames_from_source(
-    source: Union[str, Path, int],
+    source: str | Path | int,
 ) -> Iterator[tuple[int, np.ndarray]]:
     """Yield numbered BGR frames from video files, webcams, network streams, or image
     directories.
@@ -46,7 +45,7 @@ def frames_from_source(
 
 
 def _iter_capture_frames(
-    src: Union[str, int, Path],
+    src: str | int | Path,
 ) -> Iterator[tuple[int, np.ndarray]]:
     # Convert numeric strings to int for webcam indices
     if isinstance(src, str) and src.isdigit():

--- a/trackers/motion/estimator.py
+++ b/trackers/motion/estimator.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 import cv2
 import numpy as np
 
@@ -89,8 +87,8 @@ class MotionEstimator:
             ),
         )
 
-        self._previous_grayscale: Optional[np.ndarray] = None
-        self._previous_features: Optional[np.ndarray] = None
+        self._previous_grayscale: np.ndarray | None = None
+        self._previous_features: np.ndarray | None = None
         self._accumulated_homography: np.ndarray = np.eye(3, dtype=np.float64)
 
     def update(self, frame: np.ndarray) -> CoordinatesTransformation:
@@ -160,7 +158,7 @@ class MotionEstimator:
 
         return transform
 
-    def _find_features(self, grayscale: np.ndarray) -> Optional[np.ndarray]:
+    def _find_features(self, grayscale: np.ndarray) -> np.ndarray | None:
         """Detect good features to track in the grayscale image.
 
         Args:
@@ -180,7 +178,7 @@ class MotionEstimator:
 
     def _estimate_homography(
         self, previous_points: np.ndarray, current_points: np.ndarray
-    ) -> Optional[CoordinatesTransformation]:
+    ) -> CoordinatesTransformation | None:
         """Estimate homography transformation between point sets.
 
         Args:

--- a/trackers/scripts/progress.py
+++ b/trackers/scripts/progress.py
@@ -11,7 +11,7 @@ import itertools
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal
 
 import cv2
 from rich.console import Console
@@ -43,7 +43,7 @@ class _SourceInfo:
     fps: float | None = None
 
 
-def _classify_source(source: Union[str, Path, int]) -> _SourceInfo:
+def _classify_source(source: str | Path | int) -> _SourceInfo:
     """Classify a frame source and extract metadata.
 
     The function inspects *source* without consuming any frames so it can be


### PR DESCRIPTION
This pull request makes a minor update to the linting configuration by enabling an additional set of rules.

- **Linting configuration:**
  * Added `"UP"` to the `select` list in `pyproject.toml` to enable pyupgrade rules, which help keep the codebase up-to-date with the latest Python features and syntax.