### PR TITLE
Add license header insertion pre-commit hook

### DIFF
--- a/.github/LICENSE_HEADER.txt
+++ b/.github/LICENSE_HEADER.txt
@@ -1,0 +1,5 @@
+------------------------------------------------------------------------
+Trackers
+Copyright (c) 2026 Roboflow. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+------------------------------------------------------------------------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,6 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
-        types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
@@ -52,3 +51,14 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [numpy,types-aiofiles]
+
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.6
+    hooks:
+      - id: insert-license
+        files: \.py$
+        args:
+          - --license-filepath
+          - .github/LICENSE_HEADER.txt
+          - --comment-style
+          - "#"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,17 @@ ci:
   autoupdate_commit_msg: "chore(pre_commit): ⬆ pre_commit autoupdate"
 
 repos:
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.6
+    hooks:
+      - id: insert-license
+        files: \.py$
+        args:
+          - --license-filepath
+          - .github/LICENSE_HEADER.txt
+          - --comment-style
+          - "#"
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -51,14 +62,3 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [numpy,types-aiofiles]
-
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.6
-    hooks:
-      - id: insert-license
-        files: \.py$
-        args:
-          - --license-filepath
-          - .github/LICENSE_HEADER.txt
-          - --comment-style
-          - "#"

--- a/demo/app.py
+++ b/demo/app.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 """Gradio app for the trackers library — run object tracking on uploaded videos."""
 
 from __future__ import annotations

--- a/docs/hooks/doctest_filter.py
+++ b/docs/hooks/doctest_filter.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 """
 MkDocs hook to strip doctest directives from rendered documentation.
 

--- a/test/core/__init__.py
+++ b/test/core/__init__.py
@@ -1,0 +1,6 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+

--- a/test/core/__init__.py
+++ b/test/core/__init__.py
@@ -3,4 +3,3 @@
 # Copyright (c) 2026 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-


### PR DESCRIPTION
This pull request introduces an automated license header insertion for Python files and updates pre-commit hooks configuration. The most significant changes are the addition of a license header template and the integration of a new pre-commit hook to ensure compliance.

**License management improvements:**

* Added `.github/LICENSE_HEADER.txt` containing the Apache license header for RF-DETR, which will be used for automated insertion into Python files.
* Integrated the `insert-license` hook from `Lucas-C/pre-commit-hooks` into `.pre-commit-config.yaml`, configured to use the new license header template and apply it to all `.py` files with the specified comment style.

**Pre-commit configuration updates:**

* Removed the `types_or` argument from the `ruff-format` hook configuration, simplifying its setup.