### PR TITLE
Remove ruff and mypy from dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,6 @@ trackers = "trackers.scripts.__main__:main"
 dev = [
     "uv>=0.4.20",
     "pytest>=8.3.3",
-    "ruff>=0.6.9",
-    "mypy>=1.15.0",
     "pre-commit>=4.2.0",
 ]
 docs = [


### PR DESCRIPTION
This pull request makes a minor change to the development dependencies in `pyproject.toml` by removing two tools from the list.

* Removed `ruff` and `mypy` from the `dev` dependencies, which means these linting and type-checking tools are no longer required for development.

---

They are used in pre-commit, which hasits  own version/dependency setup