### PR TITLE
fix demo with CLI passing explicit bool

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -204,17 +204,12 @@ def track(
     cmd = [
         "trackers",
         "track",
-        "--source",
-        video_path,
-        "--output",
-        output_path,
-        "--overwrite",
-        "--model",
-        model,
-        "--tracker",
-        tracker,
-        "--model_confidence",
-        str(confidence),
+        f"--source={video_path}",
+        f"--output={output_path}",
+        f"--overwrite=true",
+        f"--model={model}",
+        f"--tracker={tracker}",
+        f"--model_confidence={confidence}",
     ]
 
     tracker_params: dict[str, float | int] = {

--- a/demo/app.py
+++ b/demo/app.py
@@ -206,7 +206,7 @@ def track(
         "track",
         f"--source={video_path}",
         f"--output={output_path}",
-        f"--overwrite=true",
+        "--overwrite=true",
         f"--model={model}",
         f"--tracker={tracker}",
         f"--model_confidence={confidence}",


### PR DESCRIPTION
This pull request makes a minor update to the way command-line arguments are constructed in the `track` function within `demo/app.py`. The change switches from using separate argument and value pairs to using the `--arg=value` format for each parameter.

- Updated the `track` function in `demo/app.py` to construct command-line arguments using the `--arg=value` format instead of passing arguments and values as separate list items.