### PR TITLE
Add dataset videos, paper links, and DanceTrack section to tracker comparison page

### DIFF
--- a/docs/trackers/comparison.md
+++ b/docs/trackers/comparison.md
@@ -11,7 +11,7 @@ Pedestrian tracking with crowded scenes and frequent occlusions. Strongly tests 
 </video>
 
 |  Tracker  |   HOTA   |   IDF1   |   MOTA   |
-|:---------:|:--------:|:--------:|:--------:|
+| :-------: | :------: | :------: | :------: |
 |   SORT    |   58.4   |   69.9   |   67.2   |
 | ByteTrack |   60.1   |   73.2   |   74.1   |
 |  OC-SORT  | **61.9** | **76.1** | **76.7** |
@@ -25,7 +25,7 @@ Sports broadcast tracking with fast motion, camera pans, and similar-looking tar
 </video>
 
 |  Tracker  |   HOTA   |   IDF1   |   MOTA   |
-|:---------:|:--------:|:--------:|:--------:|
+| :-------: | :------: | :------: | :------: |
 |   SORT    |   70.9   |   68.9   |   95.7   |
 | ByteTrack | **73.0** | **72.5** | **96.4** |
 |  OC-SORT  |   71.5   |   71.2   |   95.2   |
@@ -39,7 +39,7 @@ Long sequences with dense interactions and partial occlusions. Tests long-term I
 </video>
 
 |  Tracker  |   HOTA   |   IDF1   |   MOTA   |
-|:---------:|:--------:|:--------:|:--------:|
+| :-------: | :------: | :------: | :------: |
 |   SORT    |   81.6   |   76.2   |   95.1   |
 | ByteTrack | **84.0** | **78.1** | **97.8** |
 |  OC-SORT  |   78.6   |   72.7   |   94.5   |

--- a/docs/trackers/comparison.md
+++ b/docs/trackers/comparison.md
@@ -2,32 +2,56 @@
 
 This page shows head-to-head performance of SORT and ByteTrack on standard MOT benchmarks.
 
-## MOT17
+## [MOT17](https://arxiv.org/abs/1603.00831)
 
 Pedestrian tracking with crowded scenes and frequent occlusions. Strongly tests re-identification and identity stability.
 
-|  Tracker  | HOTA | IDF1 | MOTA |
-| :-------: | :--: | :--: | :--: |
-|   SORT    | 58.4 | 69.9 | 67.2 |
-| ByteTrack | 60.1 | 73.2 | 74.1 |
-|  OC-SORT  | 61.9 | 76.1 | 76.7 |
+<video width="100%" controls autoplay muted loop>
+  <source src="https://storage.googleapis.com/com-roboflow-marketing/trackers/docs/datasets/MOT17_MOT17-04-DPM-1280x720.mp4" type="video/mp4">
+</video>
 
-## SportsMOT
+|  Tracker  |   HOTA   |   IDF1   |   MOTA   |
+|:---------:|:--------:|:--------:|:--------:|
+|   SORT    |   58.4   |   69.9   |   67.2   |
+| ByteTrack |   60.1   |   73.2   |   74.1   |
+|  OC-SORT  | **61.9** | **76.1** | **76.7** |
+
+## [SportsMOT](https://arxiv.org/abs/2304.05170)
 
 Sports broadcast tracking with fast motion, camera pans, and similar-looking targets. Tests association under speed and appearance ambiguity.
 
-|  Tracker  | HOTA | IDF1 | MOTA |
-| :-------: | :--: | :--: | :--: |
-|   SORT    | 70.9 | 68.9 | 95.7 |
-| ByteTrack | 73.0 | 72.5 | 96.4 |
-|  OC-SORT  | 71.5 | 71.2 | 95.2 |
+<video width="100%" controls autoplay muted loop>
+  <source src="https://storage.googleapis.com/com-roboflow-marketing/trackers/docs/datasets/SportsMOT_v_-6Os86HzwCs_c001-1280x720.mp4" type="video/mp4">
+</video>
 
-## SoccerNet-tracking
+|  Tracker  |   HOTA   |   IDF1   |   MOTA   |
+|:---------:|:--------:|:--------:|:--------:|
+|   SORT    |   70.9   |   68.9   |   95.7   |
+| ByteTrack | **73.0** | **72.5** | **96.4** |
+|  OC-SORT  |   71.5   |   71.2   |   95.2   |
+
+## [SoccerNet-tracking](https://arxiv.org/abs/2204.06918)
 
 Long sequences with dense interactions and partial occlusions. Tests long-term ID consistency.
 
-|  Tracker  | HOTA | IDF1 | MOTA |
-| :-------: | :--: | :--: | :--: |
-|   SORT    | 81.6 | 76.2 | 95.1 |
-| ByteTrack | 84.0 | 78.1 | 97.8 |
-|  OC-SORT  | 78.6 | 72.7 | 94.5 |
+<video width="100%" controls autoplay muted loop>
+  <source src="https://storage.googleapis.com/com-roboflow-marketing/trackers/docs/datasets/SoccerNet-tracking_SNMOT-060-1280x720.mp4" type="video/mp4">
+</video>
+
+|  Tracker  |   HOTA   |   IDF1   |   MOTA   |
+|:---------:|:--------:|:--------:|:--------:|
+|   SORT    |   81.6   |   76.2   |   95.1   |
+| ByteTrack | **84.0** | **78.1** | **97.8** |
+|  OC-SORT  |   78.6   |   72.7   |   94.5   |
+
+## [DanceTrack](https://arxiv.org/abs/2111.14690)
+
+Group dancing tracking with uniform appearance, diverse motions, and extreme articulation. Tests motion-based association without relying on visual discrimination.
+
+<video width="100%" controls autoplay muted loop>
+  <source src="https://storage.googleapis.com/com-roboflow-marketing/trackers/docs/datasets/DanceTrack_dancetrack0052-1280x720.mp4" type="video/mp4">
+</video>
+
+!!! tip "Stay Tuned"
+
+    We're actively benchmarking trackers on DanceTrack. Results will be added here shortly.

--- a/uv.lock
+++ b/uv.lock
@@ -3714,7 +3714,7 @@ wheels = [
 
 [[package]]
 name = "trackers"
-version = "2.2.0"
+version = "2.3.0rc0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonargparse", extra = ["signatures"] },
@@ -3757,7 +3757,7 @@ mypy-types = [
 
 [package.metadata]
 requires-dist = [
-    { name = "inference-models", marker = "extra == 'detection'", specifier = "==0.19.0" },
+    { name = "inference-models", marker = "extra == 'detection'", specifier = ">=0.19.0" },
     { name = "jsonargparse", extras = ["signatures"], specifier = ">=4.18.0" },
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "opencv-python", specifier = ">=4.8.0" },


### PR DESCRIPTION
## Summary

- Add ground truth visualization videos for MOT17, SportsMOT, SoccerNet-tracking,
and DanceTrack datasets
- Link each dataset heading to its corresponding arxiv paper
- Add new DanceTrack section with dataset description (benchmark numbers coming
soon)
- Bold the highest HOTA, IDF1, and MOTA values in each benchmark table