### PR TITLE
Revert "Refactor CLI with `jsonargparse`; simplify `eval` and `track` commands (#276)

### DIFF
--- a/docs/javascripts/command_builder.js
+++ b/docs/javascripts/command_builder.js
@@ -84,10 +84,10 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (state.showModelOptions) {
       if (state.confidence !== defaults.confidence && isValidDecimal01(state.confidence, 0.05)) {
-        parts.push(`--model_confidence ${state.confidence}`);
+        parts.push(`--model.confidence ${state.confidence}`);
       }
       if (state.device !== "auto") {
-        parts.push(`--model_device ${state.device}`);
+        parts.push(`--model.device ${state.device}`);
       }
       if (state.classes && isValidClasses(state.classes)) {
         parts.push(`--classes ${state.classes}`);
@@ -96,41 +96,37 @@ document.addEventListener("DOMContentLoaded", function () {
 
     parts.push(`--tracker ${state.tracker}`);
 
-    const trackerParams = {};
     if (state.showTrackerOptions) {
       if (state.lostTrackBuffer !== defaults.lostTrackBuffer && isValidPositiveInt(state.lostTrackBuffer)) {
-        trackerParams.lost_track_buffer = parseInt(state.lostTrackBuffer, 10);
+        parts.push(`--tracker.lost_track_buffer ${state.lostTrackBuffer}`);
       }
       if (
         state.trackActivationThreshold !== defaults.trackActivationThreshold &&
         isValidDecimal01(state.trackActivationThreshold, 0.05)
       ) {
-        trackerParams.track_activation_threshold = parseFloat(state.trackActivationThreshold);
+        parts.push(`--tracker.track_activation_threshold ${state.trackActivationThreshold}`);
       }
       if (
         state.minimumConsecutiveFrames !== defaults.minimumConsecutiveFrames &&
         isValidPositiveInt(state.minimumConsecutiveFrames)
       ) {
-        trackerParams.minimum_consecutive_frames = parseInt(state.minimumConsecutiveFrames, 10);
+        parts.push(`--tracker.minimum_consecutive_frames ${state.minimumConsecutiveFrames}`);
       }
       if (
         state.minimumIouThreshold !== defaults.minimumIouThreshold &&
         isValidDecimal01(state.minimumIouThreshold, 0.05)
       ) {
-        trackerParams.minimum_iou_threshold = parseFloat(state.minimumIouThreshold);
+        parts.push(`--tracker.minimum_iou_threshold ${state.minimumIouThreshold}`);
       }
-    }
-    if (Object.keys(trackerParams).length > 0) {
-      parts.push(`--tracker_params '${JSON.stringify(trackerParams)}'`);
     }
 
     if (state.display) parts.push("--display");
-    if (!state.showBoxes) parts.push("--show_boxes false");
-    if (state.showMasks) parts.push("--show_masks");
-    if (state.showConfidence) parts.push("--show_confidence");
-    if (state.showLabels) parts.push("--show_labels");
-    if (!state.showIds) parts.push("--show_ids false");
-    if (state.showTrajectories) parts.push("--show_trajectories");
+    if (!state.showBoxes) parts.push("--no-boxes");
+    if (state.showMasks) parts.push("--show-masks");
+    if (state.showConfidence) parts.push("--show-confidence");
+    if (state.showLabels) parts.push("--show-labels");
+    if (!state.showIds) parts.push("--no-ids");
+    if (state.showTrajectories) parts.push("--show-trajectories");
 
     const outputValue = state.output.trim();
     if (outputValue) {

--- a/docs/learn/track.md
+++ b/docs/learn/track.md
@@ -84,11 +84,12 @@ Trackers assign stable IDs to detections across frames, maintaining object ident
 
 === "CLI"
 
-    Select a tracker with `--tracker` and tune its behavior with `--tracker_params` JSON.
+    Select a tracker with `--tracker` and tune its behavior with `--tracker.*` arguments.
 
     ```text
     trackers track --source source.mp4 --tracker bytetrack \
-        --tracker_params '{"lost_track_buffer": 60, "minimum_consecutive_frames": 5}'
+        --tracker.lost_track_buffer 60 \
+        --tracker.minimum_consecutive_frames 5
     ```
 
     <table>
@@ -111,9 +112,24 @@ Trackers assign stable IDs to detections across frames, maintaining object ident
           <td><code>bytetrack</code></td>
         </tr>
         <tr>
-          <td><code>--tracker_params</code></td>
-          <td>JSON object with tracker constructor arguments. Example keys: <code>lost_track_buffer</code>, <code>track_activation_threshold</code>, <code>minimum_consecutive_frames</code>, <code>minimum_iou_threshold</code>. For ByteTrack, you can also pass <code>high_conf_det_threshold</code>.</td>
-          <td><code>{}</code></td>
+          <td><code>--tracker.lost_track_buffer</code></td>
+          <td>Frames to retain a track without detections. Higher values improve occlusion handling but risk ID drift.</td>
+          <td><code>30</code></td>
+        </tr>
+        <tr>
+          <td><code>--tracker.track_activation_threshold</code></td>
+          <td>Minimum confidence to start a new track. Lower values catch more objects but increase false positives.</td>
+          <td><code>0.25</code></td>
+        </tr>
+        <tr>
+          <td><code>--tracker.minimum_consecutive_frames</code></td>
+          <td>Consecutive detections required before a track is confirmed. Suppresses spurious detections.</td>
+          <td><code>3</code></td>
+        </tr>
+        <tr>
+          <td><code>--tracker.minimum_iou_threshold</code></td>
+          <td>Minimum IoU overlap to match a detection to an existing track. Higher values require tighter alignment.</td>
+          <td><code>0.3</code></td>
         </tr>
       </tbody>
     </table>
@@ -154,12 +170,12 @@ Trackers don't detect objects—they link detections across frames. A detection 
 
 === "CLI"
 
-    Configure detection with model arguments. Filter by confidence and class before tracking.
+    Configure detection with `--model.*` arguments. Filter by confidence and class before tracking.
 
     ```text
     trackers track --source source.mp4 --model rfdetr-medium \
-        --model_confidence 0.3 \
-        --model_device cuda \
+        --model.confidence 0.3 \
+        --model.device cuda \
         --classes person,car
     ```
 
@@ -183,12 +199,12 @@ Trackers don't detect objects—they link detections across frames. A detection 
           <td><code>rfdetr-nano</code></td>
         </tr>
         <tr>
-          <td><code>--model_confidence</code></td>
+          <td><code>--model.confidence</code></td>
           <td>Minimum confidence threshold. Lower values increase recall but may add noise.</td>
           <td><code>0.5</code></td>
         </tr>
         <tr>
-          <td><code>--model_device</code></td>
+          <td><code>--model.device</code></td>
           <td>Compute device. Options: <code>auto</code>, <code>cpu</code>, <code>cuda</code>, <code>cuda:0</code>, <code>mps</code>.</td>
           <td><code>auto</code></td>
         </tr>
@@ -198,7 +214,7 @@ Trackers don't detect objects—they link detections across frames. A detection 
           <td>all</td>
         </tr>
         <tr>
-          <td><code>--model_api_key</code></td>
+          <td><code>--model.api_key</code></td>
           <td>Roboflow API key for custom hosted models.</td>
           <td>none</td>
         </tr>

--- a/docs/learn/track.md
+++ b/docs/learn/track.md
@@ -108,7 +108,7 @@ Trackers assign stable IDs to detections across frames, maintaining object ident
       <tbody>
         <tr>
           <td><code>--tracker</code></td>
-          <td>Tracking algorithm. Options: <code>bytetrack</code>, <code>sort</code>.</td>
+          <td>Tracking algorithm. Options: <code>bytetrack</code>, <code>sort</code>, <code>ocsort</code>.</td>
           <td><code>bytetrack</code></td>
         </tr>
         <tr>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ dependencies = [
     "supervision>=0.26.1",
     "scipy>=1.13.1",
     "opencv-python>=4.8.0",
-    "rich>=13.0.0",
-    "jsonargparse[signatures]>=4.18.0",
+    "rich>=13.0.0"
 ]
 
 [project.optional-dependencies]

--- a/test/scripts/test_track.py
+++ b/test/scripts/test_track.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import ClassVar
 
 import numpy as np

--- a/test/scripts/test_track.py
+++ b/test/scripts/test_track.py
@@ -17,7 +17,6 @@ from trackers.scripts.track import (
     _init_annotators,
     _resolve_class_filter,
     _resolve_track_id_filter,
-    track,
 )
 
 
@@ -197,13 +196,3 @@ class TestResolveTrackIdFilter:
         result = _resolve_track_id_filter("abc,def")
         assert result is None
         assert "abc" in capsys.readouterr().err
-
-
-class TestTrackCliValidation:
-    def test_model_and_detections_are_mutually_exclusive(self, tmp_path: Path) -> None:
-        with pytest.raises(ValueError, match="mutually exclusive"):
-            track(
-                source="0",
-                model="rfdetr-nano",
-                detections=tmp_path / "detections.txt",
-            )

--- a/trackers/scripts/__main__.py
+++ b/trackers/scripts/__main__.py
@@ -5,24 +5,62 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from __future__ import annotations
+
+import argparse
+import sys
 import warnings
 
 
-def main() -> None:
+def main() -> int:
     """Main entry point for the trackers CLI."""
+    # Beta warning
     warnings.warn(
         "The trackers CLI is in beta. APIs may change in future releases.",
         UserWarning,
         stacklevel=2,
     )
 
-    from jsonargparse import auto_cli
+    parser = argparse.ArgumentParser(
+        prog="trackers",
+        description="Command-line tools for multi-object tracking.",
+        epilog="For more information, visit: https://github.com/roboflow/trackers",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Show version and exit.",
+    )
 
-    from trackers.scripts.eval import evaluate
-    from trackers.scripts.track import track
+    subparsers = parser.add_subparsers(
+        dest="command",
+        title="commands",
+        description="Available commands:",
+    )
 
-    auto_cli([track, evaluate], as_positional=False)
+    # Import and register subcommands
+    from trackers.scripts.eval import add_eval_subparser
+    from trackers.scripts.track import add_track_subparser
+
+    add_eval_subparser(subparsers)
+    add_track_subparser(subparsers)
+
+    # Parse arguments
+    args = parser.parse_args()
+
+    if args.version:
+        from importlib.metadata import version
+
+        print(f"trackers {version('trackers')}")
+        return 0
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    # Execute the command
+    return args.func(args)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/trackers/scripts/eval.py
+++ b/trackers/scripts/eval.py
@@ -5,40 +5,99 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from __future__ import annotations
+
+import argparse
 import logging
 import sys
 from pathlib import Path
 
 
-def evaluate(
-    gt: Path | None = None,
-    tracker: Path | None = None,
-    gt_dir: Path | None = None,
-    tracker_dir: Path | None = None,
-    seqmap: Path | None = None,
-    metrics: list[str] | None = None,
-    threshold: float = 0.5,
-    columns: list[str] | None = None,
-    output: Path | None = None,
-) -> int:
-    """Evaluate tracker predictions against ground truth.
+def add_eval_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the eval subcommand to the argument parser."""
+    parser = subparsers.add_parser(
+        "eval",
+        help="Evaluate tracker predictions against ground truth.",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
 
-    Args:
-        gt: Path to ground truth file (MOT format).
-        tracker: Path to tracker predictions file (MOT format).
-        gt_dir: Directory containing ground truth files.
-        tracker_dir: Directory containing tracker prediction files.
-        seqmap: Sequence map file listing sequences to evaluate.
-        metrics: Metrics to compute. Options: CLEAR, HOTA, Identity.
-            Default: CLEAR.
-        threshold: IoU threshold for CLEAR and Identity matching.
-        columns: Metric columns to display. Default: auto-selected based on
-            metrics. CLEAR: MOTA, MOTP, MODA, CLR_Re, CLR_Pr, MTR, PTR, MLR,
-            sMOTA, CLR_TP, CLR_FN, CLR_FP, IDSW, MT, PT, ML, Frag. HOTA:
-            HOTA, DetA, AssA, DetRe, DetPr, AssRe, AssPr, LocA. Identity:
-            IDF1, IDR, IDP, IDTP, IDFN, IDFP.
-        output: Output file for results (JSON format).
-    """
+    # Single sequence mode
+    single_group = parser.add_argument_group("single sequence evaluation")
+    single_group.add_argument(
+        "--gt",
+        type=Path,
+        metavar="PATH",
+        help="Path to ground truth file (MOT format).",
+    )
+    single_group.add_argument(
+        "--tracker",
+        type=Path,
+        metavar="PATH",
+        help="Path to tracker predictions file (MOT format).",
+    )
+
+    # Benchmark mode
+    bench_group = parser.add_argument_group("benchmark evaluation")
+    bench_group.add_argument(
+        "--gt-dir",
+        type=Path,
+        metavar="DIR",
+        help="Directory containing ground truth files.",
+    )
+    bench_group.add_argument(
+        "--tracker-dir",
+        type=Path,
+        metavar="DIR",
+        help="Directory containing tracker prediction files.",
+    )
+    bench_group.add_argument(
+        "--seqmap",
+        type=Path,
+        metavar="PATH",
+        help="Sequence map file listing sequences to evaluate.",
+    )
+
+    # Common options
+    parser.add_argument(
+        "--metrics",
+        nargs="+",
+        default=["CLEAR"],
+        choices=["CLEAR", "HOTA", "Identity"],
+        help="Metrics to compute. Default: CLEAR. Options: CLEAR, HOTA, Identity",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="IoU threshold for CLEAR and Identity matching. Default: 0.5",
+    )
+    parser.add_argument(
+        "--columns",
+        nargs="+",
+        default=None,
+        metavar="COL",
+        help=(
+            "Metric columns to display. Default: auto-selected based on metrics. "
+            "CLEAR: MOTA, MOTP, MODA, CLR_Re, CLR_Pr, MTR, PTR, MLR, sMOTA, "
+            "CLR_TP, CLR_FN, CLR_FP, IDSW, MT, PT, ML, Frag. "
+            "HOTA: HOTA, DetA, AssA, DetRe, DetPr, AssRe, AssPr, LocA. "
+            "Identity: IDF1, IDR, IDP, IDTP, IDFN, IDFP"
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        metavar="PATH",
+        help="Output file for results (JSON format).",
+    )
+
+    parser.set_defaults(func=run_eval)
+
+
+def run_eval(args: argparse.Namespace) -> int:
+    """Execute the eval command."""
     # Configure logging to show detection info
     logging.basicConfig(
         level=logging.INFO,
@@ -46,16 +105,13 @@ def evaluate(
         handlers=[logging.StreamHandler(sys.stderr)],
     )
 
-    if metrics is None:
-        metrics = ["CLEAR"]
-
     # Validate arguments
-    single_mode = gt is not None and tracker is not None
-    benchmark_mode = gt_dir is not None and tracker_dir is not None
+    single_mode = args.gt is not None and args.tracker is not None
+    benchmark_mode = args.gt_dir is not None and args.tracker_dir is not None
 
     if not single_mode and not benchmark_mode:
         print(
-            "Error: Must specify either --gt/--tracker or --gt_dir/--tracker_dir",
+            "Error: Must specify either --gt/--tracker or --gt-dir/--tracker-dir",
             file=sys.stderr,
         )
         return 1
@@ -67,35 +123,41 @@ def evaluate(
         )
         return 1
 
+    # Columns: None means auto-select based on available metrics
+    columns = args.columns
+
     # Import evaluation functions
     from trackers.eval import evaluate_mot_sequence, evaluate_mot_sequences
 
     try:
         if single_mode:
             seq_result = evaluate_mot_sequence(
-                gt_path=gt, tracker_path=tracker, metrics=metrics, threshold=threshold
+                gt_path=args.gt,
+                tracker_path=args.tracker,
+                metrics=args.metrics,
+                threshold=args.threshold,
             )
             print(seq_result.table(columns=columns))
 
             # Save results if output specified
-            if output:
-                output.parent.mkdir(parents=True, exist_ok=True)
-                output.write_text(seq_result.json())
-                print(f"\nResults saved to: {output}")
+            if args.output:
+                args.output.parent.mkdir(parents=True, exist_ok=True)
+                args.output.write_text(seq_result.json())
+                print(f"\nResults saved to: {args.output}")
         else:
             bench_result = evaluate_mot_sequences(
-                gt_dir=gt_dir,
-                tracker_dir=tracker_dir,
-                seqmap=seqmap,
-                metrics=metrics,
-                threshold=threshold,
+                gt_dir=args.gt_dir,
+                tracker_dir=args.tracker_dir,
+                seqmap=args.seqmap,
+                metrics=args.metrics,
+                threshold=args.threshold,
             )
             print(bench_result.table(columns=columns))
 
             # Save results if output specified
-            if output:
-                bench_result.save(output)
-                print(f"\nResults saved to: {output}")
+            if args.output:
+                bench_result.save(args.output)
+                print(f"\nResults saved to: {args.output}")
 
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/trackers/scripts/track.py
+++ b/trackers/scripts/track.py
@@ -5,10 +5,12 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from __future__ import annotations
+
+import argparse
 import sys
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import supervision as sv
@@ -46,138 +48,303 @@ COLOR_PALETTE = sv.ColorPalette.from_hex(
 )
 
 
-def track(
-    source: str,
-    model: str | None = None,
-    detections: Path | None = None,
-    model_confidence: float = DEFAULT_CONFIDENCE,
-    model_device: str = DEFAULT_DEVICE,
-    model_api_key: str | None = None,
-    classes: str | None = None,
-    track_ids: str | None = None,
-    tracker: str = DEFAULT_TRACKER,
-    tracker_params: dict[str, Any] | None = None,
-    output: Path | None = None,
-    mot_output: Path | None = None,
-    overwrite: bool = False,
-    display: bool = False,
-    show_boxes: bool = True,
-    show_masks: bool = False,
-    show_labels: bool = False,
-    show_ids: bool = True,
-    show_confidence: bool = False,
-    show_trajectories: bool = False,
-) -> int:
-    """Track objects in video using detection and tracking.
+def add_track_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the track subcommand to the argument parser."""
+    parser = subparsers.add_parser(
+        "track",
+        help="Track objects in video using detection and tracking.",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
 
-    Args:
-        source: Video file, webcam index (0), RTSP URL, or image directory.
-        model: Model ID for detection. Pretrained: rfdetr-nano, rfdetr-base, etc.
-            Custom: workspace/project/version. Defaults to rfdetr-nano when
-            --detections is not provided.
-        detections: Load pre-computed detections from MOT format file.
-        model_confidence: Detection confidence threshold.
-        model_device: Device: auto, cpu, cuda, cuda:0, mps.
-        model_api_key: Roboflow API key for custom models.
-        classes: Filter by class names or IDs (comma-separated, e.g., person,car).
-        track_ids: Filter output by track IDs (comma-separated, e.g., 1,3,5).
-        tracker: Tracking algorithm.
-        tracker_params: Tracker-specific parameters as key-value pairs.
-        output: Output video file path.
-        mot_output: Output MOT format file path.
-        overwrite: Overwrite existing output files.
-        display: Show preview window.
-        show_boxes: Draw bounding boxes.
-        show_masks: Draw segmentation masks (seg models only).
-        show_labels: Show class labels.
-        show_ids: Show track IDs.
-        show_confidence: Show confidence scores.
-        show_trajectories: Draw track trajectories.
-    """
-    if detections is not None and model is not None:
-        raise ValueError(
-            "Arguments --model and --detections are mutually exclusive. "
-            "Provide only one."
-        )
+    # Source options
+    source_group = parser.add_argument_group("source")
+    source_group.add_argument(
+        "--source",
+        type=str,
+        required=True,
+        metavar="PATH",
+        help="Video file, webcam index (0), RTSP URL, or image directory.",
+    )
 
+    # Detection options (mutually exclusive)
+    detection_group = parser.add_argument_group("detection")
+    det_mutex = detection_group.add_mutually_exclusive_group(required=False)
+    det_mutex.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_MODEL,
+        metavar="ID",
+        help=(
+            "Model ID for detection. Pretrained: rfdetr-nano, rfdetr-base, etc. "
+            f"Custom: workspace/project/version. Default: {DEFAULT_MODEL}"
+        ),
+    )
+    det_mutex.add_argument(
+        "--detections",
+        type=Path,
+        metavar="PATH",
+        help="Load pre-computed detections from MOT format file.",
+    )
+
+    # Model options
+    model_group = parser.add_argument_group("model options")
+    model_group.add_argument(
+        "--model.confidence",
+        type=float,
+        default=DEFAULT_CONFIDENCE,
+        dest="model_confidence",
+        metavar="FLOAT",
+        help=f"Detection confidence threshold. Default: {DEFAULT_CONFIDENCE}",
+    )
+    model_group.add_argument(
+        "--model.device",
+        type=str,
+        default=DEFAULT_DEVICE,
+        dest="model_device",
+        metavar="DEVICE",
+        help=f"Device: auto, cpu, cuda, cuda:0, mps. Default: {DEFAULT_DEVICE}",
+    )
+    model_group.add_argument(
+        "--model.api_key",
+        type=str,
+        default=None,
+        dest="model_api_key",
+        metavar="KEY",
+        help="Roboflow API key for custom models.",
+    )
+
+    # Filtering options
+    filter_group = parser.add_argument_group("filtering")
+    filter_group.add_argument(
+        "--classes",
+        type=str,
+        default=None,
+        metavar="NAMES_OR_IDS",
+        help="Filter by class names or IDs (comma-separated, e.g., person,car).",
+    )
+    filter_group.add_argument(
+        "--track_ids",
+        type=str,
+        default=None,
+        metavar="IDS",
+        help="Filter output by track IDs (comma-separated, e.g., 1,3,5)",
+    )
+
+    # Tracker options
+    tracker_group = parser.add_argument_group("tracker options")
+    available_trackers = BaseTracker._registered_trackers()
+    tracker_group.add_argument(
+        "--tracker",
+        type=str,
+        default=DEFAULT_TRACKER,
+        choices=available_trackers if available_trackers else [DEFAULT_TRACKER, "sort"],
+        metavar="ID",
+        help=f"Tracking algorithm. Default: {DEFAULT_TRACKER}",
+    )
+
+    # Add dynamic tracker parameters
+    _add_tracker_params(tracker_group)
+
+    # Output options
+    output_group = parser.add_argument_group("output")
+    output_group.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Output video file path.",
+    )
+    output_group.add_argument(
+        "--mot-output",
+        type=Path,
+        default=None,
+        dest="mot_output",
+        metavar="PATH",
+        help="Output MOT format file path.",
+    )
+    output_group.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing output files.",
+    )
+
+    # Visualization options
+    vis_group = parser.add_argument_group("visualization")
+    vis_group.add_argument(
+        "--display",
+        action="store_true",
+        help="Show preview window.",
+    )
+    vis_group.add_argument(
+        "--show-boxes",
+        action="store_true",
+        default=True,
+        dest="show_boxes",
+        help="Draw bounding boxes. Default: True",
+    )
+    vis_group.add_argument(
+        "--no-boxes",
+        action="store_false",
+        dest="show_boxes",
+        help="Disable bounding boxes.",
+    )
+    vis_group.add_argument(
+        "--show-masks",
+        action="store_true",
+        dest="show_masks",
+        help="Draw segmentation masks (seg models only).",
+    )
+    vis_group.add_argument(
+        "--show-labels",
+        action="store_true",
+        dest="show_labels",
+        help="Show class labels.",
+    )
+    vis_group.add_argument(
+        "--show-ids",
+        action="store_true",
+        default=True,
+        dest="show_ids",
+        help="Show track IDs. Default: True",
+    )
+    vis_group.add_argument(
+        "--no-ids",
+        action="store_false",
+        dest="show_ids",
+        help="Disable track IDs.",
+    )
+    vis_group.add_argument(
+        "--show-confidence",
+        action="store_true",
+        dest="show_confidence",
+        help="Show confidence scores.",
+    )
+    vis_group.add_argument(
+        "--show-trajectories",
+        action="store_true",
+        dest="show_trajectories",
+        help="Draw track trajectories.",
+    )
+
+    parser.set_defaults(func=run_track)
+
+
+def _add_tracker_params(group: argparse._ArgumentGroup) -> None:
+    """Add tracker-specific parameters from registry to argument group."""
+    for tracker_id in BaseTracker._registered_trackers():
+        info = BaseTracker._lookup_tracker(tracker_id)
+        if info is None:
+            continue
+
+        for param_name, param_info in info.parameters.items():
+            arg_name = f"--tracker.{param_name}"
+            dest_name = f"tracker_{param_name}"
+
+            kwargs: dict = {
+                "dest": dest_name,
+                "default": param_info.default_value,
+                "help": f"{param_info.description} Default: {param_info.default_value}",
+            }
+
+            if param_info.param_type is bool:
+                kwargs["action"] = (
+                    "store_false" if param_info.default_value else "store_true"
+                )
+            else:
+                kwargs["type"] = param_info.param_type
+                kwargs["metavar"] = param_info.param_type.__name__.upper()
+
+            try:
+                group.add_argument(arg_name, **kwargs)
+            except argparse.ArgumentError:
+                # Parameter already added by another tracker
+                pass
+
+
+def run_track(args: argparse.Namespace) -> int:
+    """Execute the track command."""
     # Validate output paths
-    if output:
-        _validate_output_path(_resolve_video_output_path(output), overwrite=overwrite)
-    if mot_output:
-        _validate_output_path(mot_output, overwrite=overwrite)
+    if args.output:
+        _validate_output_path(
+            _resolve_video_output_path(args.output), overwrite=args.overwrite
+        )
+    if args.mot_output:
+        _validate_output_path(args.mot_output, overwrite=args.overwrite)
 
     # Create detection source
-    if detections is not None:
-        model_obj = None
-        detections_data = _load_mot_file(detections)
+    if args.detections:
+        model = None
+        detections_data = _load_mot_file(args.detections)
         class_names: list[str] = []
     else:
-        model_id = model or DEFAULT_MODEL
-        model_obj = _init_model(
-            model_id,
-            device=model_device,
-            api_key=model_api_key,
+        model = _init_model(
+            args.model,
+            device=args.model_device,
+            api_key=args.model_api_key,
         )
         detections_data = None
-        class_names = getattr(model_obj, "class_names", [])
+        class_names = getattr(model, "class_names", [])
 
     # Resolve class filter (names and/or integer IDs)
-    class_filter = _resolve_class_filter(classes, class_names)
+    class_filter = _resolve_class_filter(args.classes, class_names)
 
-    track_id_filter = _resolve_track_id_filter(track_ids)
+    track_id_filter = _resolve_track_id_filter(args.track_ids)
 
     # Create tracker
-    tracker_obj = _init_tracker(tracker, **(tracker_params or {}))
+    tracker_params = _extract_tracker_params(args.tracker, args)
+    tracker = _init_tracker(args.tracker, **tracker_params)
 
     # Create frame generator
-    frame_gen = frames_from_source(source)
+    frame_gen = frames_from_source(args.source)
 
-    source_info = _classify_source(source)
+    source_info = _classify_source(args.source)
 
     # Setup annotators
     annotators, label_annotator = _init_annotators(
-        show_boxes=show_boxes,
-        show_masks=show_masks,
-        show_labels=show_labels,
-        show_ids=show_ids,
-        show_confidence=show_confidence,
+        show_boxes=args.show_boxes,
+        show_masks=args.show_masks,
+        show_labels=args.show_labels,
+        show_ids=args.show_ids,
+        show_confidence=args.show_confidence,
     )
     trace_annotator = None
-    if show_trajectories:
+    if args.show_trajectories:
         trace_annotator = sv.TraceAnnotator(
             color=COLOR_PALETTE,
             color_lookup=sv.ColorLookup.TRACK,
         )
 
-    display_ctx = _DisplayWindow() if display else nullcontext()
+    display_ctx = _DisplayWindow() if args.display else nullcontext()
 
     try:
         with (
             _VideoOutput(
-                output,
+                args.output,
                 fps=source_info.fps or _DEFAULT_OUTPUT_FPS,
             ) as video,
-            _MOTOutput(mot_output) as mot,
-            display_ctx as display_win,
+            _MOTOutput(args.mot_output) as mot,
+            display_ctx as display,
             _TrackingProgress(source_info) as progress,
         ):
             interrupted = False
             for frame_idx, frame in frame_gen:
                 # Get detections
-                if model_obj is not None:
-                    dets = _run_model(model_obj, frame, model_confidence)
+                if model is not None:
+                    detections = _run_model(model, frame, args.model_confidence)
                 elif detections_data is not None and frame_idx in detections_data:
-                    dets = _mot_frame_to_detections(detections_data[frame_idx])
+                    detections = _mot_frame_to_detections(detections_data[frame_idx])
                 else:
-                    dets = sv.Detections.empty()
+                    detections = sv.Detections.empty()
 
                 # Filter by class
-                if class_filter is not None and len(dets) > 0:
-                    mask = np.isin(dets.class_id, class_filter)
-                    dets = dets[mask]  # type: ignore[assignment]
+                if class_filter is not None and len(detections) > 0:
+                    mask = np.isin(detections.class_id, class_filter)
+                    detections = detections[mask]  # type: ignore[assignment]
 
                 # Run tracker
-                tracked = tracker_obj.update(dets)
+                tracked = tracker.update(detections)
 
                 # Filter by track ID
                 if track_id_filter is not None and len(tracked) > 0:
@@ -191,7 +358,7 @@ def track(
                 progress.update()
 
                 # Annotate and display/save frame
-                if display or output:
+                if args.display or args.output:
                     annotated = frame.copy()
                     if trace_annotator is not None:
                         annotated = trace_annotator.annotate(annotated, tracked)
@@ -202,17 +369,17 @@ def track(
                         labels = _format_labels(
                             labeled,
                             class_names,
-                            show_ids=show_ids,
-                            show_labels=show_labels,
-                            show_confidence=show_confidence,
+                            show_ids=args.show_ids,
+                            show_labels=args.show_labels,
+                            show_confidence=args.show_confidence,
                         )
                         annotated = label_annotator.annotate(annotated, labeled, labels)
 
                     video.write(annotated)
 
-                    if display_win is not None:
-                        display_win.show(annotated)
-                        if display_win.quit_requested:
+                    if display is not None:
+                        display.show(annotated)
+                        if display.quit_requested:
                             interrupted = True
                             break
 
@@ -339,6 +506,32 @@ def _run_model(model, frame: np.ndarray, confidence: float) -> sv.Detections:
         detections = detections[mask]
 
     return detections
+
+
+def _extract_tracker_params(
+    tracker_id: str, args: argparse.Namespace
+) -> dict[str, object]:
+    """Extract tracker parameters from CLI args.
+
+    Args:
+        tracker_id: Registered tracker name.
+        args: Parsed CLI arguments.
+
+    Returns:
+        Dictionary of tracker parameters with non-None values.
+    """
+    info = BaseTracker._lookup_tracker(tracker_id)
+    if info is None:
+        return {}
+
+    params = {}
+    for param_name in info.parameters:
+        dest_name = f"tracker_{param_name}"
+        if hasattr(args, dest_name):
+            value = getattr(args, dest_name)
+            if value is not None:
+                params[param_name] = value
+    return params
 
 
 def _init_tracker(tracker_id: str, **kwargs) -> BaseTracker:

--- a/uv.lock
+++ b/uv.lock
@@ -440,33 +440,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
     { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
     { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
-    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
     { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
     { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
     { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
     { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
     { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
     { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
     { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
     { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
     { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
     { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
     { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
     { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
     { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
     { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
     { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
     { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
     { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
     { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
     { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
     { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
     { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
-    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
     { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
     { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
     { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
@@ -539,15 +533,6 @@ name = "docopt"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
-
-[[package]]
-name = "docstring-parser"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
-]
 
 [[package]]
 name = "docutils"
@@ -1015,24 +1000,6 @@ name = "jsmin"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
-
-[[package]]
-name = "jsonargparse"
-version = "4.46.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/0f/333d4aa9c62edf3cf2c11f5bac8f487ece29b94be7ea2c6acb1a9265a723/jsonargparse-4.46.0.tar.gz", hash = "sha256:4c331448841fea9cb2b41bf99adbea70a63f82cac516f2f13030378b3d93c329", size = 222042, upload-time = "2026-02-02T10:29:13.837Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/6d/55e0db968193fcb12a3b4a9d823f6f9c8a39df1e28345daa3772b61f4389/jsonargparse-4.46.0-py3-none-any.whl", hash = "sha256:1f218fc2af1190c6425860e40af2003c8ca1f59e10d656fc67bbc32380a25ec3", size = 246093, upload-time = "2026-02-02T10:29:11.837Z" },
-]
-
-[package.optional-dependencies]
-signatures = [
-    { name = "docstring-parser" },
-    { name = "typeshed-client" },
-]
 
 [[package]]
 name = "keyring"
@@ -3717,7 +3684,6 @@ name = "trackers"
 version = "2.3.0rc0"
 source = { editable = "." }
 dependencies = [
-    { name = "jsonargparse", extra = ["signatures"] },
     { name = "numpy" },
     { name = "opencv-python" },
     { name = "rich" },
@@ -3758,7 +3724,6 @@ mypy-types = [
 [package.metadata]
 requires-dist = [
     { name = "inference-models", marker = "extra == 'detection'", specifier = ">=0.19.0" },
-    { name = "jsonargparse", extras = ["signatures"], specifier = ">=4.18.0" },
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "opencv-python", specifier = ">=4.8.0" },
     { name = "rich", specifier = ">=13.0.0" },
@@ -3878,19 +3843,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/53/46/790b9872523a48163bdda87d47849b4466017640e5259d06eed539340afd/types_tqdm-4.67.3.20260205.tar.gz", hash = "sha256:f3023682d4aa3bbbf908c8c6bb35f35692d319460d9bbd3e646e8852f3dd9f85", size = 17597, upload-time = "2026-02-05T04:03:19.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/da/7f761868dbaa328392356fab30c18ab90d14cce86b269e7e63328f29d4a3/types_tqdm-4.67.3.20260205-py3-none-any.whl", hash = "sha256:85c31731e81dc3c5cecc34c6c8b2e5166fafa722468f58840c2b5ac6a8c5c173", size = 23894, upload-time = "2026-02-05T04:03:18.48Z" },
-]
-
-[[package]]
-name = "typeshed-client"
-version = "2.8.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-resources" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/4074d3505b4700a6bf13cb1bb2d1848bb8c78e902e3f9fe5916274c5d284/typeshed_client-2.8.2.tar.gz", hash = "sha256:9d8e29fb74574d87bf9a719f77131dc40f2aeea20e97d25d4a3dc2cc30debd31", size = 501617, upload-time = "2025-07-16T01:49:49.299Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/db/e7474719e90062df673057e865f94f67da2d0b4f671d8051020c74962c77/typeshed_client-2.8.2-py3-none-any.whl", hash = "sha256:4cf886d976c777689cd31889f13abf5bfb7797c82519b07e5969e541380c75ee", size = 760467, upload-time = "2025-07-16T01:49:47.758Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a major CLI refactor and updates argument conventions for the trackers project. The most important changes are the migration from `jsonargparse` to `argparse`, the adoption of dot notation for CLI arguments, and updates to documentation and scripts to match the new interface.

**CLI Refactor and Argument Handling**

* Migrated the CLI from `jsonargparse` to standard `argparse`, simplifying dependencies and making command parsing more explicit. The CLI now uses subcommands for `track` and `eval`, and the main entry point returns an exit code for better integration. (`trackers/scripts/__main__.py`, `trackers/scripts/eval.py`, `trackers/scripts/track.py`, `pyproject.toml`) [[1]](diffhunk://#diff-25deba888fb588cc8033c5b4224a0e97b96123e09631b1620d2d91bc11608b2fR8-R66) [[2]](diffhunk://#diff-9f4fd43160ac86b8c83d6df41c5df0a475da13b630c801e86095f4613da6baffR8-R114) [[3]](diffhunk://#diff-34eb43ad4f8b750d5cdfb1879a366f6876e2740006324ae28f5fe4a37acfc9a2R8-L11) [[4]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L42-R42)
* Refactored the `eval` command to use subparsers and explicit argument groups for single sequence and benchmark evaluation modes, improving usability and clarity. (`trackers/scripts/eval.py`)

**CLI Argument Convention Updates**

* Changed CLI argument names to use dot notation (e.g., `--model.confidence`, `--tracker.lost_track_buffer`) instead of snake_case and removed JSON parameter aggregation, making arguments more consistent and easier to parse. (`docs/javascripts/command_builder.js`, `docs/learn/track.md`) [[1]](diffhunk://#diff-ef964a19851f7046a6ec0d837b6457fbc77f63be82b6a9bcdbf26cbbd25156f0L87-R90) [[2]](diffhunk://#diff-ef964a19851f7046a6ec0d837b6457fbc77f63be82b6a9bcdbf26cbbd25156f0L99-R129) [[3]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL87-R92) [[4]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL114-R132) [[5]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL157-R178) [[6]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL186-R207) [[7]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL201-R217)

**Documentation and Usability Improvements**

* Updated documentation and web command builder to reflect new argument conventions and provide clearer explanations of tracker and model options. (`docs/learn/track.md`, `docs/javascripts/command_builder.js`) [[1]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL87-R92) [[2]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL114-R132) [[3]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL157-R178) [[4]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL186-R207) [[5]](diffhunk://#diff-ac4643810d7f77683608666c51121290f68ff80e7e6d8f39fb3988c5e45eaf8dL201-R217) [[6]](diffhunk://#diff-ef964a19851f7046a6ec0d837b6457fbc77f63be82b6a9bcdbf26cbbd25156f0L87-R90) [[7]](diffhunk://#diff-ef964a19851f7046a6ec0d837b6457fbc77f63be82b6a9bcdbf26cbbd25156f0L99-R129)
* Improved CLI flag naming for display options (e.g., `--no-boxes`, `--show-masks`) to increase clarity and consistency. (`docs/javascripts/command_builder.js`)

**Miscellaneous**

* Added `from __future__ import annotations` for better type hinting and removed unused imports for code cleanliness. (`trackers/scripts/__main__.py`, `trackers/scripts/eval.py`, `trackers/scripts/track.py`, `test/scripts/test_track.py`) [[1]](diffhunk://#diff-25deba888fb588cc8033c5b4224a0e97b96123e09631b1620d2d91bc11608b2fR8-R66) [[2]](diffhunk://#diff-9f4fd43160ac86b8c83d6df41c5df0a475da13b630c801e86095f4613da6baffR8-R114) [[3]](diffhunk://#diff-34eb43ad4f8b750d5cdfb1879a366f6876e2740006324ae28f5fe4a37acfc9a2R8-L11) [[4]](diffhunk://#diff-62d6a977eb8c206d31ea394e51a3235ea70df2e37c6c55bdff03393e2fc06a8cL9)

---

following request...