### PR TITLE
Exclude demo requirements from Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,5 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: ⬆️
+    exclude-paths:
+      - "demo"

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,3 +1,4 @@
+# pinned dependencies for the demo app. do not update.
 gradio>=6.3.0,<6.4.0
 inference-models==0.18.6rc14
 trackers==2.2.0rc1


### PR DESCRIPTION
## Summary

  - Add `exclude-paths: ["demo"]` to the `uv` ecosystem entry in `dependabot.yml` to prevent Dependabot from
  scanning `demo/requirements.txt`
  - Add a comment to `demo/requirements.txt` clarifying the dependencies are pinned and should not be updated
  - Dependencies in `demo/requirements.txt` are pinned to specific versions for Hugging Face Spaces
  deployment and must not be auto-updated
  - All `pyproject.toml` dependencies (including `inference-models`) continue to receive Dependabot updates
  as before