### PR TITLE
[codex] Add pitch calibration and pitch-space rendering tools

### DIFF
--- a/configs/calibration/pnlcalib/default.toml
+++ b/configs/calibration/pnlcalib/default.toml
@@ -1,0 +1,39 @@
+[provider]
+name = "pnlcalib"
+device = "cpu"
+
+[pitch]
+length_m = 105.0
+width_m = 68.0
+
+[weights]
+keypoints = "weights/SV_kp"
+lines = "weights/SV_lines"
+
+[thresholds]
+keypoints = 0.3434
+lines = 0.7867
+max_reproj_error = 20.0
+vote_threshold = 5.0
+
+[sampling]
+every_n_frames = 1
+
+[smoothing]
+enabled = true
+max_gap_frames = 15
+min_confidence = 0.4
+
+[overlay]
+enabled = true
+path = "overlay.mp4"
+line_color_bgr = [255, 0, 0]
+line_thickness = 2
+
+[inference]
+pnl_refine = true
+
+[output]
+write_camera_jsonl = true
+write_homography_jsonl = true
+write_quality_csv = true

--- a/configs/calibration/pnlcalib/fast.toml
+++ b/configs/calibration/pnlcalib/fast.toml
@@ -1,0 +1,39 @@
+[provider]
+name = "pnlcalib"
+device = "cpu"
+
+[pitch]
+length_m = 105.0
+width_m = 68.0
+
+[weights]
+keypoints = "weights/SV_kp"
+lines = "weights/SV_lines"
+
+[thresholds]
+keypoints = 0.3434
+lines = 0.7867
+max_reproj_error = 20.0
+vote_threshold = 5.0
+
+[sampling]
+every_n_frames = 10
+
+[smoothing]
+enabled = true
+max_gap_frames = 15
+min_confidence = 0.4
+
+[overlay]
+enabled = true
+path = "overlay.mp4"
+line_color_bgr = [255, 0, 0]
+line_thickness = 2
+
+[inference]
+pnl_refine = true
+
+[output]
+write_camera_jsonl = true
+write_homography_jsonl = true
+write_quality_csv = true

--- a/configs/calibration/pnlcalib/homography_fast.toml
+++ b/configs/calibration/pnlcalib/homography_fast.toml
@@ -1,0 +1,37 @@
+[provider]
+name = "pnlcalib"
+device = "cpu"
+
+[pitch]
+length_m = 105.0
+width_m = 68.0
+
+[weights]
+keypoints = "weights/SV_kp"
+lines = "weights/SV_lines"
+
+[thresholds]
+keypoints = 0.3434
+lines = 0.7867
+max_reproj_error = 20.0
+vote_threshold = 5.0
+
+[sampling]
+every_n_frames = 10
+
+[smoothing]
+enabled = true
+max_gap_frames = 15
+min_confidence = 0.4
+
+[overlay]
+enabled = false
+
+[inference]
+mode = "homography"
+pnl_refine = true
+
+[output]
+write_camera_jsonl = false
+write_homography_jsonl = true
+write_quality_csv = true

--- a/configs/calibration/pnlcalib/homography_interpolate_visual.toml
+++ b/configs/calibration/pnlcalib/homography_interpolate_visual.toml
@@ -1,0 +1,42 @@
+[provider]
+name = "pnlcalib"
+device = "cpu"
+
+[pitch]
+length_m = 105.0
+width_m = 68.0
+
+[weights]
+keypoints = "weights/SV_kp"
+lines = "weights/SV_lines"
+
+[thresholds]
+keypoints = 0.3434
+lines = 0.7867
+max_reproj_error = 20.0
+vote_threshold = 5.0
+
+[sampling]
+every_n_frames = 10
+
+[smoothing]
+enabled = true
+mode = "interpolate"
+edge_strategy = "hold"
+max_gap_frames = 15
+min_confidence = 0.4
+
+[overlay]
+enabled = true
+path = "overlay.mp4"
+line_color_bgr = [255, 0, 0]
+line_thickness = 2
+
+[inference]
+mode = "homography"
+pnl_refine = true
+
+[output]
+write_camera_jsonl = false
+write_homography_jsonl = true
+write_quality_csv = true

--- a/configs/pitch/canonical_105x68.toml
+++ b/configs/pitch/canonical_105x68.toml
@@ -1,0 +1,3 @@
+[pitch]
+length_m = 105.0
+width_m = 68.0

--- a/scripts/analyze_calibration.py
+++ b/scripts/analyze_calibration.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CACHE_DIR = _REPO_ROOT / ".cache"
+_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+(_CACHE_DIR / "matplotlib").mkdir(parents=True, exist_ok=True)
+(_CACHE_DIR / "fontconfig").mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("XDG_CACHE_HOME", str(_CACHE_DIR))
+os.environ.setdefault("MPLCONFIGDIR", str(_CACHE_DIR / "matplotlib"))
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from trackers.calibration.export import load_calibration_jsonl
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Summarize calibration coverage and confidence from JSONL output."
+    )
+    parser.add_argument("calibration", help="Calibration JSONL file")
+    return parser.parse_args()
+
+
+def _longest_gap(valid_flags: list[bool]) -> int:
+    longest = 0
+    current = 0
+    for is_valid in valid_flags:
+        if is_valid:
+            current = 0
+            continue
+        current += 1
+        longest = max(longest, current)
+    return longest
+
+
+def main(args: argparse.Namespace) -> int:
+    path = Path(args.calibration).expanduser().resolve()
+    frames = load_calibration_jsonl(path)
+    valid_frames = [frame for frame in frames if frame.has_homography]
+    valid_flags = [frame.has_homography for frame in frames]
+    confidences = [
+        frame.confidence for frame in valid_frames if frame.confidence is not None
+    ]
+
+    summary = {
+        "path": str(path),
+        "num_frames": len(frames),
+        "num_valid_frames": len(valid_frames),
+        "coverage": 0.0 if not frames else len(valid_frames) / len(frames),
+        "mean_confidence": (
+            None if not confidences else sum(confidences) / len(confidences)
+        ),
+        "longest_invalid_gap_frames": _longest_gap(valid_flags),
+    }
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    raise SystemExit(main(args))

--- a/scripts/analyze_calibration.sh
+++ b/scripts/analyze_calibration.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="$ROOT_DIR/.venv/bin/python"
+CACHE_DIR="$ROOT_DIR/.cache"
+MPL_CACHE_DIR="$CACHE_DIR/matplotlib"
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "Missing local virtualenv at $PYTHON_BIN"
+  echo "Run: uv sync --extra detection"
+  exit 1
+fi
+
+mkdir -p "$MPL_CACHE_DIR" "$CACHE_DIR/fontconfig"
+export XDG_CACHE_HOME="$CACHE_DIR"
+export MPLCONFIGDIR="$MPL_CACHE_DIR"
+
+exec "$PYTHON_BIN" "$ROOT_DIR/scripts/analyze_calibration.py" "$@"

--- a/scripts/analyze_mot.py
+++ b/scripts/analyze_mot.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 from __future__ import annotations
 
 import argparse
@@ -110,8 +116,12 @@ def analyze(path: Path) -> dict:
         track_frames[track_id].append(frame)
 
     total_frames = max_frame - min_frame + 1
-    frame_counts = [frame_to_all_count.get(frame, 0) for frame in range(min_frame, max_frame + 1)]
-    confirmed_frame_counts = [len(frame_to_ids.get(frame, set())) for frame in range(min_frame, max_frame + 1)]
+    frame_counts = [
+        frame_to_all_count.get(frame, 0) for frame in range(min_frame, max_frame + 1)
+    ]
+    confirmed_frame_counts = [
+        len(frame_to_ids.get(frame, set())) for frame in range(min_frame, max_frame + 1)
+    ]
 
     adjacent_retention: list[float] = []
     adjacent_jaccard: list[float] = []

--- a/scripts/analyze_mot.py
+++ b/scripts/analyze_mot.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class TrackStats:
+    track_id: int
+    detections: int
+    start_frame: int
+    end_frame: int
+    span_frames: int
+    missing_frames: int
+    density: float
+    segments: int
+    longest_run: int
+
+
+def _safe_mean(values: list[float | int]) -> float:
+    return float(statistics.mean(values)) if values else 0.0
+
+
+def _safe_median(values: list[float | int]) -> float:
+    return float(statistics.median(values)) if values else 0.0
+
+
+def _percentile(values: list[int], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = (len(ordered) - 1) * q
+    lo = int(idx)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = idx - lo
+    return ordered[lo] * (1 - frac) + ordered[hi] * frac
+
+
+def _segment_stats(frames: list[int]) -> tuple[int, int]:
+    if not frames:
+        return 0, 0
+
+    segments = 1
+    longest_run = 1
+    current_run = 1
+
+    for prev_frame, frame in zip(frames, frames[1:]):
+        if frame == prev_frame + 1:
+            current_run += 1
+            longest_run = max(longest_run, current_run)
+        else:
+            segments += 1
+            current_run = 1
+
+    return segments, longest_run
+
+
+def load_rows(path: Path) -> list[dict[str, float]]:
+    rows: list[dict[str, float]] = []
+    with path.open("r", newline="") as handle:
+        reader = csv.reader(handle)
+        for row in reader:
+            if not row:
+                continue
+            rows.append(
+                {
+                    "frame": int(float(row[0])),
+                    "track_id": int(float(row[1])),
+                    "x": float(row[2]),
+                    "y": float(row[3]),
+                    "w": float(row[4]),
+                    "h": float(row[5]),
+                    "confidence": float(row[6]),
+                }
+            )
+    return rows
+
+
+def analyze(path: Path) -> dict:
+    rows = load_rows(path)
+    if not rows:
+        return {
+            "path": str(path),
+            "total_rows": 0,
+        }
+
+    frame_to_ids: dict[int, set[int]] = defaultdict(set)
+    frame_to_all_count: dict[int, int] = defaultdict(int)
+    provisional_rows = 0
+    track_frames: dict[int, list[int]] = defaultdict(list)
+
+    min_frame = min(int(row["frame"]) for row in rows)
+    max_frame = max(int(row["frame"]) for row in rows)
+
+    for row in rows:
+        frame = int(row["frame"])
+        track_id = int(row["track_id"])
+        frame_to_all_count[frame] += 1
+        if track_id == -1:
+            provisional_rows += 1
+            continue
+        frame_to_ids[frame].add(track_id)
+        track_frames[track_id].append(frame)
+
+    total_frames = max_frame - min_frame + 1
+    frame_counts = [frame_to_all_count.get(frame, 0) for frame in range(min_frame, max_frame + 1)]
+    confirmed_frame_counts = [len(frame_to_ids.get(frame, set())) for frame in range(min_frame, max_frame + 1)]
+
+    adjacent_retention: list[float] = []
+    adjacent_jaccard: list[float] = []
+    for frame in range(min_frame, max_frame):
+        ids_now = frame_to_ids.get(frame, set())
+        ids_next = frame_to_ids.get(frame + 1, set())
+        if ids_now:
+            adjacent_retention.append(len(ids_now & ids_next) / len(ids_now))
+        union = ids_now | ids_next
+        if union:
+            adjacent_jaccard.append(len(ids_now & ids_next) / len(union))
+
+    per_track: list[TrackStats] = []
+    for track_id, frames in sorted(track_frames.items()):
+        frames = sorted(set(frames))
+        start_frame = frames[0]
+        end_frame = frames[-1]
+        span_frames = end_frame - start_frame + 1
+        detections = len(frames)
+        missing_frames = span_frames - detections
+        density = detections / span_frames if span_frames else 0.0
+        segments, longest_run = _segment_stats(frames)
+        per_track.append(
+            TrackStats(
+                track_id=track_id,
+                detections=detections,
+                start_frame=start_frame,
+                end_frame=end_frame,
+                span_frames=span_frames,
+                missing_frames=missing_frames,
+                density=density,
+                segments=segments,
+                longest_run=longest_run,
+            )
+        )
+
+    detections_per_track = [track.detections for track in per_track]
+    densities = [track.density for track in per_track]
+    segments = [track.segments for track in per_track]
+    longest_runs = [track.longest_run for track in per_track]
+    single_segment_tracks = [track for track in per_track if track.segments == 1]
+    fragmented_tracks = sorted(
+        [track for track in per_track if track.segments > 1],
+        key=lambda track: (track.segments, track.missing_frames, track.detections),
+        reverse=True,
+    )
+
+    return {
+        "path": str(path),
+        "total_rows": len(rows),
+        "provisional_rows": provisional_rows,
+        "confirmed_rows": len(rows) - provisional_rows,
+        "min_frame": min_frame,
+        "max_frame": max_frame,
+        "total_frames": total_frames,
+        "confirmed_track_count": len(per_track),
+        "detections_per_frame": {
+            "mean": round(_safe_mean(frame_counts), 3),
+            "median": round(_safe_median(frame_counts), 3),
+            "p95": round(_percentile(frame_counts, 0.95), 3),
+        },
+        "confirmed_ids_per_frame": {
+            "mean": round(_safe_mean(confirmed_frame_counts), 3),
+            "median": round(_safe_median(confirmed_frame_counts), 3),
+            "p95": round(_percentile(confirmed_frame_counts, 0.95), 3),
+        },
+        "adjacent_frame_continuity": {
+            "mean_retention": round(_safe_mean(adjacent_retention), 4),
+            "mean_jaccard": round(_safe_mean(adjacent_jaccard), 4),
+        },
+        "per_track": {
+            "mean_detections": round(_safe_mean(detections_per_track), 3),
+            "median_detections": round(_safe_median(detections_per_track), 3),
+            "mean_density": round(_safe_mean(densities), 4),
+            "median_density": round(_safe_median(densities), 4),
+            "mean_segments": round(_safe_mean(segments), 3),
+            "median_segments": round(_safe_median(segments), 3),
+            "mean_longest_run": round(_safe_mean(longest_runs), 3),
+            "median_longest_run": round(_safe_median(longest_runs), 3),
+            "single_segment_fraction": round(
+                len(single_segment_tracks) / len(per_track), 4
+            )
+            if per_track
+            else 0.0,
+        },
+        "most_fragmented_tracks": [asdict(track) for track in fragmented_tracks[:10]],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Summarize continuity-style metrics from a MOT-format tracks file."
+    )
+    parser.add_argument("path", type=Path, help="Path to a MOT-format tracks.txt file.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit JSON instead of a human-readable summary.",
+    )
+    args = parser.parse_args()
+
+    result = analyze(args.path)
+    if args.as_json:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    print(f"path: {result['path']}")
+    print(
+        f"rows: {result['total_rows']} total, "
+        f"{result['confirmed_rows']} confirmed, {result['provisional_rows']} provisional"
+    )
+    print(
+        f"frames: {result['min_frame']}..{result['max_frame']} "
+        f"({result['total_frames']} total)"
+    )
+    print(f"confirmed track ids: {result['confirmed_track_count']}")
+    print(
+        "detections/frame: "
+        f"mean={result['detections_per_frame']['mean']}, "
+        f"median={result['detections_per_frame']['median']}, "
+        f"p95={result['detections_per_frame']['p95']}"
+    )
+    print(
+        "confirmed ids/frame: "
+        f"mean={result['confirmed_ids_per_frame']['mean']}, "
+        f"median={result['confirmed_ids_per_frame']['median']}, "
+        f"p95={result['confirmed_ids_per_frame']['p95']}"
+    )
+    print(
+        "adjacent continuity: "
+        f"retention={result['adjacent_frame_continuity']['mean_retention']}, "
+        f"jaccard={result['adjacent_frame_continuity']['mean_jaccard']}"
+    )
+    print(
+        "per-track continuity: "
+        f"mean_density={result['per_track']['mean_density']}, "
+        f"median_density={result['per_track']['median_density']}, "
+        f"mean_segments={result['per_track']['mean_segments']}, "
+        f"single_segment_fraction={result['per_track']['single_segment_fraction']}"
+    )
+    print("top fragmented tracks:")
+    for track in result["most_fragmented_tracks"][:5]:
+        print(
+            f"  id={track['track_id']} dets={track['detections']} "
+            f"segments={track['segments']} density={track['density']:.4f} "
+            f"longest_run={track['longest_run']} missing={track['missing_frames']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/calibrate_video.py
+++ b/scripts/calibrate_video.py
@@ -11,8 +11,9 @@ import argparse
 import json
 import os
 import sys
-import tomllib
 from pathlib import Path
+
+import tomllib
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CACHE_DIR = _REPO_ROOT / ".cache"
@@ -24,11 +25,11 @@ os.environ.setdefault("MPLCONFIGDIR", str(_CACHE_DIR / "matplotlib"))
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from trackers.calibration.export import write_manifest
 from trackers.calibration.export import (
     write_calibration_jsonl,
     write_calibration_quality_csv,
     write_homography_jsonl,
+    write_manifest,
 )
 from trackers.calibration.providers.pnlcalib import PnLCalibProvider
 from trackers.calibration.types import PitchDimensions
@@ -71,7 +72,9 @@ def _load_toml(path: Path) -> dict[str, object]:
     return tomllib.loads(path.read_text(encoding="utf-8"))
 
 
-def _default_output_dir(source: Path, provider: str, config_path: Path, root: Path) -> Path:
+def _default_output_dir(
+    source: Path, provider: str, config_path: Path, root: Path
+) -> Path:
     return (
         root
         / "runs"

--- a/scripts/calibrate_video.py
+++ b/scripts/calibrate_video.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CACHE_DIR = _REPO_ROOT / ".cache"
+_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+(_CACHE_DIR / "matplotlib").mkdir(parents=True, exist_ok=True)
+(_CACHE_DIR / "fontconfig").mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("XDG_CACHE_HOME", str(_CACHE_DIR))
+os.environ.setdefault("MPLCONFIGDIR", str(_CACHE_DIR / "matplotlib"))
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from trackers.calibration.export import write_manifest
+from trackers.calibration.export import (
+    write_calibration_jsonl,
+    write_calibration_quality_csv,
+    write_homography_jsonl,
+)
+from trackers.calibration.providers.pnlcalib import PnLCalibProvider
+from trackers.calibration.types import PitchDimensions
+
+
+def _repo_root() -> Path:
+    return _REPO_ROOT
+
+
+def _resolve_path(value: str, root: Path) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return root / path
+
+
+def _slugify(value: str) -> str:
+    safe_chars = []
+    for char in value:
+        if char.isalnum():
+            safe_chars.append(char)
+        elif char in {"-", "_", "."}:
+            safe_chars.append(char)
+        else:
+            safe_chars.append("_")
+    slug = "".join(safe_chars).strip("._")
+    return slug or "video"
+
+
+def _load_pitch_dimensions(path: Path) -> PitchDimensions:
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    pitch = data.get("pitch", data)
+    return PitchDimensions(
+        length_m=float(pitch.get("length_m", 105.0)),
+        width_m=float(pitch.get("width_m", 68.0)),
+    )
+
+
+def _load_toml(path: Path) -> dict[str, object]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _default_output_dir(source: Path, provider: str, config_path: Path, root: Path) -> Path:
+    return (
+        root
+        / "runs"
+        / _slugify(source.stem)
+        / "calibration"
+        / f"{provider}__{_slugify(config_path.stem)}"
+    )
+
+
+def _build_provider(
+    provider_name: str,
+    *,
+    pitch_dimensions: PitchDimensions,
+    config_path: Path,
+    upstream_root: Path,
+    config_data: dict[str, object],
+) -> PnLCalibProvider:
+    if provider_name != "pnlcalib":
+        raise ValueError(f"Unsupported calibration provider: {provider_name}")
+    return PnLCalibProvider(
+        pitch_dimensions=pitch_dimensions,
+        config_path=config_path,
+        upstream_root=upstream_root,
+        config_data=config_data,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    root = _repo_root()
+    parser = argparse.ArgumentParser(
+        description="Prepare and run a pitch-calibration backend on a video or clip."
+    )
+    parser.add_argument("source", help="Video or clip to calibrate")
+    parser.add_argument(
+        "--provider",
+        default="pnlcalib",
+        choices=["pnlcalib"],
+        help="Calibration backend to use",
+    )
+    parser.add_argument(
+        "--config",
+        default="configs/calibration/pnlcalib/default.toml",
+        help="Provider config relative to the repo root",
+    )
+    parser.add_argument(
+        "--pitch-config",
+        default="configs/pitch/canonical_105x68.toml",
+        help="Pitch model config relative to the repo root",
+    )
+    parser.add_argument(
+        "--upstream-root",
+        default="third_party/pnlcalib",
+        help="Location of the vendored or checked-out upstream provider",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. Defaults to runs/<clip>/calibration/<provider>__<config>",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the resolved plan without invoking the provider",
+    )
+    parser.add_argument(
+        "--print-manifest",
+        action="store_true",
+        help="Echo the manifest JSON that will be written to disk",
+    )
+    parser.set_defaults(repo_root=root)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root
+
+    source_path = _resolve_path(args.source, repo_root)
+    config_path = _resolve_path(args.config, repo_root)
+    pitch_config_path = _resolve_path(args.pitch_config, repo_root)
+    upstream_root = _resolve_path(args.upstream_root, repo_root)
+
+    if not source_path.exists():
+        raise FileNotFoundError(f"Video not found: {source_path}")
+    if not config_path.exists():
+        raise FileNotFoundError(f"Calibration config not found: {config_path}")
+    if not pitch_config_path.exists():
+        raise FileNotFoundError(f"Pitch config not found: {pitch_config_path}")
+
+    config_data = _load_toml(config_path)
+    pitch_dimensions = _load_pitch_dimensions(pitch_config_path)
+    provider = _build_provider(
+        args.provider,
+        pitch_dimensions=pitch_dimensions,
+        config_path=config_path,
+        upstream_root=upstream_root,
+        config_data=config_data,
+    )
+
+    output_dir = (
+        _resolve_path(args.output_dir, repo_root)
+        if args.output_dir is not None
+        else _default_output_dir(source_path, args.provider, config_path, repo_root)
+    )
+
+    manifest = {
+        "source": str(source_path),
+        "output_dir": str(output_dir),
+        "config_path": str(config_path),
+        "pitch_config_path": str(pitch_config_path),
+        "provider": provider.describe(),
+    }
+
+    if args.print_manifest or args.dry_run:
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+
+    if args.dry_run:
+        return 0
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_manifest(output_dir / "manifest.json", manifest)
+
+    if not provider.is_available():
+        hint = provider.availability_hint()
+        if hint is not None:
+            print(hint, file=sys.stderr)
+        return 2
+
+    try:
+        frames = provider.calibrate_video(source_path, output_dir)
+    except NotImplementedError as error:
+        print(str(error), file=sys.stderr)
+        return 3
+
+    output_config = config_data.get("output", {})
+    if not isinstance(output_config, dict):
+        output_config = {}
+
+    if bool(output_config.get("write_camera_jsonl", True)):
+        write_calibration_jsonl(output_dir / "camera.jsonl", frames)
+    if bool(output_config.get("write_homography_jsonl", True)):
+        write_homography_jsonl(output_dir / "homography.jsonl", frames)
+    if bool(output_config.get("write_quality_csv", True)):
+        write_calibration_quality_csv(output_dir / "quality.csv", frames)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/calibrate_video.sh
+++ b/scripts/calibrate_video.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="$ROOT_DIR/.venv/bin/python"
+CACHE_DIR="$ROOT_DIR/.cache"
+MPL_CACHE_DIR="$CACHE_DIR/matplotlib"
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "Missing local virtualenv at $PYTHON_BIN"
+  echo "Run: uv sync --extra detection"
+  exit 1
+fi
+
+mkdir -p "$MPL_CACHE_DIR" "$CACHE_DIR/fontconfig"
+export XDG_CACHE_HOME="$CACHE_DIR"
+export MPLCONFIGDIR="$MPL_CACHE_DIR"
+
+exec "$PYTHON_BIN" "$ROOT_DIR/scripts/calibrate_video.py" "$@"

--- a/scripts/project_tracks_to_pitch.py
+++ b/scripts/project_tracks_to_pitch.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CACHE_DIR = _REPO_ROOT / ".cache"
+_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+(_CACHE_DIR / "matplotlib").mkdir(parents=True, exist_ok=True)
+(_CACHE_DIR / "fontconfig").mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("XDG_CACHE_HOME", str(_CACHE_DIR))
+os.environ.setdefault("MPLCONFIGDIR", str(_CACHE_DIR / "matplotlib"))
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from trackers.calibration.export import load_calibration_jsonl, write_track_projections_csv
+from trackers.calibration.pitch import PitchModel
+from trackers.calibration.projection import project_image_points_to_pitch
+from trackers.calibration.types import PitchDimensions, TrackProjection
+
+
+def _resolve_path(value: str) -> Path:
+    return Path(value).expanduser().resolve()
+
+
+def _load_track_rows(path: Path) -> list[dict[str, float]]:
+    rows: list[dict[str, float]] = []
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        for raw_row in reader:
+            if not raw_row:
+                continue
+            rows.append(
+                {
+                    "frame_idx": float(raw_row[0]),
+                    "track_id": float(raw_row[1]),
+                    "bb_left": float(raw_row[2]),
+                    "bb_top": float(raw_row[3]),
+                    "bb_width": float(raw_row[4]),
+                    "bb_height": float(raw_row[5]),
+                    "confidence": float(raw_row[6]) if len(raw_row) > 6 else 1.0,
+                }
+            )
+    return rows
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Project MOT tracks into pitch coordinates using calibration JSONL."
+    )
+    parser.add_argument("tracks", help="MOT-format tracks.txt file")
+    parser.add_argument("calibration", help="Calibration JSONL file")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="CSV file for projected pitch coordinates",
+    )
+    parser.add_argument(
+        "--fps",
+        type=float,
+        default=None,
+        help="Optional FPS for deriving timestamps when calibration timestamps are absent",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    tracks_path = _resolve_path(args.tracks)
+    calibration_path = _resolve_path(args.calibration)
+    output_path = _resolve_path(args.output)
+
+    calibration_frames = load_calibration_jsonl(calibration_path)
+    calibration_by_frame = {frame.frame_idx: frame for frame in calibration_frames}
+    if not calibration_frames:
+        raise ValueError(f"No calibration frames found in {calibration_path}")
+
+    pitch_dimensions = calibration_frames[0].pitch_dimensions
+    pitch_model = PitchModel(
+        dimensions=PitchDimensions(
+            length_m=pitch_dimensions.length_m,
+            width_m=pitch_dimensions.width_m,
+        )
+    )
+
+    projections: list[TrackProjection] = []
+    for row in _load_track_rows(tracks_path):
+        frame_idx = int(row["frame_idx"])
+        track_id = int(row["track_id"])
+        if track_id < 0:
+            continue
+
+        calibration = calibration_by_frame.get(frame_idx)
+        if calibration is None or not calibration.has_homography:
+            continue
+
+        image_x = row["bb_left"] + (row["bb_width"] / 2.0)
+        image_y = row["bb_top"] + row["bb_height"]
+        pitch_point = project_image_points_to_pitch([[image_x, image_y]], calibration)[0]
+        normalized_point = pitch_model.metric_to_normalized([pitch_point])[0]
+        in_pitch_bounds = bool(
+            pitch_model.contains_metric_points([pitch_point], tolerance_m=0.0)[0]
+        )
+
+        timestamp_s = calibration.timestamp_s
+        if timestamp_s is None and args.fps:
+            timestamp_s = (frame_idx - 1) / args.fps
+
+        projections.append(
+            TrackProjection(
+                frame_idx=frame_idx,
+                track_id=track_id,
+                image_x=float(image_x),
+                image_y=float(image_y),
+                pitch_x_m=float(pitch_point[0]),
+                pitch_y_m=float(pitch_point[1]),
+                pitch_x_norm=float(normalized_point[0]),
+                pitch_y_norm=float(normalized_point[1]),
+                in_pitch_bounds=in_pitch_bounds,
+                timestamp_s=timestamp_s,
+                calibration_confidence=calibration.confidence,
+                source_confidence=row["confidence"],
+                provider=calibration.provider,
+            )
+        )
+
+    write_track_projections_csv(output_path, projections)
+    print(f"Wrote {len(projections)} projected rows to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/project_tracks_to_pitch.py
+++ b/scripts/project_tracks_to_pitch.py
@@ -23,7 +23,10 @@ os.environ.setdefault("MPLCONFIGDIR", str(_CACHE_DIR / "matplotlib"))
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from trackers.calibration.export import load_calibration_jsonl, write_track_projections_csv
+from trackers.calibration.export import (
+    load_calibration_jsonl,
+    write_track_projections_csv,
+)
 from trackers.calibration.pitch import PitchModel
 from trackers.calibration.projection import project_image_points_to_pitch
 from trackers.calibration.types import PitchDimensions, TrackProjection
@@ -106,7 +109,9 @@ def main() -> int:
 
         image_x = row["bb_left"] + (row["bb_width"] / 2.0)
         image_y = row["bb_top"] + row["bb_height"]
-        pitch_point = project_image_points_to_pitch([[image_x, image_y]], calibration)[0]
+        pitch_point = project_image_points_to_pitch([[image_x, image_y]], calibration)[
+            0
+        ]
         normalized_point = pitch_model.metric_to_normalized([pitch_point])[0]
         in_pitch_bounds = bool(
             pitch_model.contains_metric_points([pitch_point], tolerance_m=0.0)[0]

--- a/scripts/project_tracks_to_pitch.sh
+++ b/scripts/project_tracks_to_pitch.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="$ROOT_DIR/.venv/bin/python"
+CACHE_DIR="$ROOT_DIR/.cache"
+MPL_CACHE_DIR="$CACHE_DIR/matplotlib"
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "Missing local virtualenv at $PYTHON_BIN"
+  echo "Run: uv sync --extra detection"
+  exit 1
+fi
+
+mkdir -p "$MPL_CACHE_DIR" "$CACHE_DIR/fontconfig"
+export XDG_CACHE_HOME="$CACHE_DIR"
+export MPLCONFIGDIR="$MPL_CACHE_DIR"
+
+exec "$PYTHON_BIN" "$ROOT_DIR/scripts/project_tracks_to_pitch.py" "$@"

--- a/scripts/render_pitch_sticky_video.py
+++ b/scripts/render_pitch_sticky_video.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CACHE_DIR = _REPO_ROOT / ".cache"
+_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+(_CACHE_DIR / "matplotlib").mkdir(parents=True, exist_ok=True)
+(_CACHE_DIR / "fontconfig").mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("XDG_CACHE_HOME", str(_CACHE_DIR))
+os.environ.setdefault("MPLCONFIGDIR", str(_CACHE_DIR / "matplotlib"))
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from trackers.calibration.export import load_calibration_jsonl
+from trackers.calibration.projection import project_image_points_to_pitch
+
+
+@dataclass(frozen=True)
+class TrackRow:
+    frame_idx: int
+    track_id: int
+    left: float
+    top: float
+    width: float
+    height: float
+    confidence: float
+
+    @property
+    def bottom_center(self) -> np.ndarray:
+        return np.array(
+            [self.left + (self.width / 2.0), self.top + self.height],
+            dtype=np.float64,
+        )
+
+    @property
+    def xyxy(self) -> tuple[int, int, int, int]:
+        return (
+            int(round(self.left)),
+            int(round(self.top)),
+            int(round(self.left + self.width)),
+            int(round(self.top + self.height)),
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render long pitch-locked streamer trails from tracks and homographies."
+    )
+    parser.add_argument("source", help="Source video clip")
+    parser.add_argument("tracks", help="MOT-format tracks.txt")
+    parser.add_argument("homography", help="Calibration homography JSONL")
+    parser.add_argument("output", help="Output rendered video")
+    parser.add_argument(
+        "--trace-seconds",
+        type=float,
+        default=15.0,
+        help="How many seconds of trail history to keep on screen",
+    )
+    parser.add_argument(
+        "--box-thickness",
+        type=int,
+        default=2,
+        help="Bounding-box thickness",
+    )
+    parser.add_argument(
+        "--trail-thickness",
+        type=int,
+        default=2,
+        help="Trail thickness",
+    )
+    parser.add_argument(
+        "--font-scale",
+        type=float,
+        default=0.6,
+        help="Label font scale",
+    )
+    return parser.parse_args()
+
+
+def _load_tracks(path: Path) -> dict[int, list[TrackRow]]:
+    tracks_by_frame: dict[int, list[TrackRow]] = defaultdict(list)
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        for row in reader:
+            if not row:
+                continue
+            track_id = int(float(row[1]))
+            if track_id < 0:
+                continue
+            track = TrackRow(
+                frame_idx=int(float(row[0])),
+                track_id=track_id,
+                left=float(row[2]),
+                top=float(row[3]),
+                width=float(row[4]),
+                height=float(row[5]),
+                confidence=float(row[6]) if len(row) > 6 else 1.0,
+            )
+            tracks_by_frame[track.frame_idx].append(track)
+    return tracks_by_frame
+
+
+def _color_for_track(track_id: int) -> tuple[int, int, int]:
+    rng = np.random.default_rng(track_id)
+    color = rng.integers(64, 256, size=3, dtype=np.int32)
+    return int(color[0]), int(color[1]), int(color[2])
+
+
+def _draw_label(
+    frame: np.ndarray,
+    text: str,
+    position: tuple[int, int],
+    color: tuple[int, int, int],
+    *,
+    font_scale: float,
+) -> None:
+    font = cv2.FONT_HERSHEY_SIMPLEX
+    thickness = 2
+    text_size, baseline = cv2.getTextSize(text, font, font_scale, thickness)
+    x, y = position
+    x = max(0, x)
+    y = max(text_size[1] + baseline, y)
+    box_tl = (x, y - text_size[1] - baseline - 4)
+    box_br = (x + text_size[0] + 6, y + 2)
+    cv2.rectangle(frame, box_tl, box_br, color, thickness=-1)
+    cv2.putText(
+        frame,
+        text,
+        (x + 3, y - baseline - 1),
+        font,
+        font_scale,
+        (0, 0, 0),
+        thickness,
+        lineType=cv2.LINE_AA,
+    )
+
+
+def _project_pitch_history(
+    pitch_points: list[np.ndarray],
+    pitch_to_image: np.ndarray,
+    width: int,
+    height: int,
+) -> np.ndarray:
+    if len(pitch_points) < 2:
+        return np.empty((0, 2), dtype=np.float64)
+    points = np.asarray(pitch_points, dtype=np.float64)
+    homogeneous = np.concatenate(
+        [points, np.ones((points.shape[0], 1), dtype=np.float64)],
+        axis=1,
+    )
+    projected = homogeneous @ pitch_to_image.T
+    scale = projected[:, 2:3]
+    valid = np.abs(scale[:, 0]) > 1e-9
+    projected = projected[valid]
+    if projected.size == 0:
+        return np.empty((0, 2), dtype=np.float64)
+    projected = projected[:, :2] / projected[:, 2:3]
+    finite = np.isfinite(projected[:, 0]) & np.isfinite(projected[:, 1])
+    projected = projected[finite]
+    if projected.size == 0:
+        return np.empty((0, 2), dtype=np.float64)
+    inside = (
+        (projected[:, 0] >= -50)
+        & (projected[:, 0] <= width + 50)
+        & (projected[:, 1] >= -50)
+        & (projected[:, 1] <= height + 50)
+    )
+    return projected[inside]
+
+
+def main() -> int:
+    args = parse_args()
+    source_path = Path(args.source).expanduser().resolve()
+    tracks_path = Path(args.tracks).expanduser().resolve()
+    homography_path = Path(args.homography).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    tracks_by_frame = _load_tracks(tracks_path)
+    calibration_frames = {
+        frame.frame_idx: frame for frame in load_calibration_jsonl(homography_path)
+    }
+
+    cap = cv2.VideoCapture(str(source_path))
+    if not cap.isOpened():
+        raise ValueError(f"Unable to open source video: {source_path}")
+
+    fps = float(cap.get(cv2.CAP_PROP_FPS))
+    if fps <= 0:
+        fps = 30.0
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    max_history = max(2, int(round(args.trace_seconds * fps)))
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    writer = cv2.VideoWriter(
+        str(output_path),
+        cv2.VideoWriter_fourcc(*"mp4v"),
+        fps,
+        (width, height),
+    )
+
+    trail_history: dict[int, deque[tuple[int, np.ndarray]]] = defaultdict(
+        lambda: deque(maxlen=max_history)
+    )
+
+    frame_idx = 0
+    while cap.isOpened():
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frame_idx += 1
+        calibration = calibration_frames.get(frame_idx)
+        current_tracks = tracks_by_frame.get(frame_idx, [])
+
+        if calibration is not None and calibration.image_to_pitch is not None:
+            for track in current_tracks:
+                pitch_point = project_image_points_to_pitch(
+                    [track.bottom_center],
+                    calibration,
+                )[0]
+                history = trail_history[track.track_id]
+                history.append((frame_idx, pitch_point))
+
+        # Trim any stale history if we skipped frames.
+        oldest_allowed = frame_idx - max_history + 1
+        for track_id, history in trail_history.items():
+            while history and history[0][0] < oldest_allowed:
+                history.popleft()
+
+        rendered = frame.copy()
+        for track in current_tracks:
+            color = _color_for_track(track.track_id)
+            x1, y1, x2, y2 = track.xyxy
+            cv2.rectangle(
+                rendered,
+                (x1, y1),
+                (x2, y2),
+                color,
+                thickness=args.box_thickness,
+            )
+            _draw_label(
+                rendered,
+                f"ID {track.track_id}",
+                (x1, max(18, y1 - 6)),
+                color,
+                font_scale=args.font_scale,
+            )
+
+            if calibration is None or calibration.pitch_to_image is None:
+                continue
+
+            history = trail_history.get(track.track_id)
+            if not history:
+                continue
+            pitch_points = [point for _, point in history]
+            projected = _project_pitch_history(
+                pitch_points,
+                calibration.pitch_to_image,
+                width,
+                height,
+            )
+            if projected.shape[0] >= 2:
+                cv2.polylines(
+                    rendered,
+                    [projected.astype(np.int32)],
+                    isClosed=False,
+                    color=color,
+                    thickness=args.trail_thickness,
+                    lineType=cv2.LINE_AA,
+                )
+
+        writer.write(rendered)
+
+    cap.release()
+    writer.release()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_pitch_sticky_video.sh
+++ b/scripts/render_pitch_sticky_video.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="$ROOT_DIR/.venv/bin/python"
+CACHE_DIR="$ROOT_DIR/.cache"
+MPL_CACHE_DIR="$CACHE_DIR/matplotlib"
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "Missing local virtualenv at $PYTHON_BIN"
+  echo "Run: uv sync --extra detection"
+  exit 1
+fi
+
+mkdir -p "$MPL_CACHE_DIR" "$CACHE_DIR/fontconfig"
+export XDG_CACHE_HOME="$CACHE_DIR"
+export MPLCONFIGDIR="$MPL_CACHE_DIR"
+
+exec "$PYTHON_BIN" "$ROOT_DIR/scripts/render_pitch_sticky_video.py" "$@"

--- a/scripts/track_video.sh
+++ b/scripts/track_video.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="$ROOT_DIR/.venv/bin/python"
+FILM_DIR="$ROOT_DIR/film"
+CACHE_DIR="$ROOT_DIR/.cache"
+MPL_CACHE_DIR="$CACHE_DIR/matplotlib"
+FONTCONFIG_CACHE_DIR="$CACHE_DIR/fontconfig"
+FFMPEG_BIN="${FFMPEG_BIN:-ffmpeg}"
+FFPROBE_BIN="${FFPROBE_BIN:-ffprobe}"
+
+CLIP_START_INPUT=""
+CLIP_DURATION_INPUT="60"
+RANDOM_MIDDLE_MINUTE=0
+CLIP_ONLY=0
+RUN_NAME=""
+FORWARD_ARGS=()
+
+list_videos() {
+  find "$FILM_DIR" -maxdepth 1 -type f \
+    \( -iname "*.mp4" -o -iname "*.mov" -o -iname "*.mkv" -o -iname "*.avi" \) \
+    | sort
+}
+
+usage() {
+  echo "Usage: ./scripts/track_video.sh <video-path> [wrapper args] [extra trackers args]"
+  echo
+  echo "Examples:"
+  echo "  ./scripts/track_video.sh \"film/match.mp4\""
+  echo "  ./scripts/track_video.sh \"film/match.mp4\" --clip-start 00:25:00 --clip-duration 60"
+  echo "  ./scripts/track_video.sh \"film/match.mp4\" --random-middle-minute --clip-only"
+  echo "  ./scripts/track_video.sh \"film/match.mp4\" --run-name my-benchmark"
+  echo "  ./scripts/track_video.sh \"film/match.mp4\" --display"
+  echo "  TRACKERS_MODEL=rfdetr-nano ./scripts/track_video.sh \"film/match.mp4\""
+  echo
+  echo "Wrapper args:"
+  echo "  --clip-start HH:MM:SS|SECONDS   Cut from a specific offset before tracking"
+  echo "  --clip-duration HH:MM:SS|SECONDS Duration of the clip (default: 60)"
+  echo "  --random-middle-minute          Pick a random 60s window from the middle third"
+  echo "  --clip-only                     Create the clip and stop without tracking"
+  echo "  --run-name NAME                Override the output folder name under runs/"
+  echo
+  echo "Defaults:"
+  echo "  model:   \${TRACKERS_MODEL:-rfdetr-medium}"
+  echo "  tracker: \${TRACKERS_TRACKER:-bytetrack}"
+  echo "  classes: \${TRACKERS_CLASSES:-person}"
+  echo
+  echo "Outputs:"
+  echo "  runs/<video-name>/tracked.mp4"
+  echo "  runs/<video-name>/tracks.txt"
+}
+
+parse_seconds() {
+  local input="$1"
+  local hours=0
+  local minutes=0
+  local seconds=0
+  local fractional=""
+
+  if [[ "$input" == *:* ]]; then
+    IFS=":" read -r -a parts <<< "$input"
+    if [[ "${#parts[@]}" -eq 3 ]]; then
+      hours="${parts[0]}"
+      minutes="${parts[1]}"
+      seconds="${parts[2]}"
+    elif [[ "${#parts[@]}" -eq 2 ]]; then
+      minutes="${parts[0]}"
+      seconds="${parts[1]}"
+    elif [[ "${#parts[@]}" -eq 1 ]]; then
+      seconds="${parts[0]}"
+    else
+      echo "Invalid time value: $input" >&2
+      exit 1
+    fi
+  else
+    seconds="$input"
+  fi
+
+  fractional="${seconds#*.}"
+  seconds="${seconds%%.*}"
+
+  if [[ -n "$fractional" && "$fractional" != "$seconds" ]]; then
+    :
+  fi
+
+  if ! [[ "$hours" =~ ^[0-9]+$ && "$minutes" =~ ^[0-9]+$ && "$seconds" =~ ^[0-9]+$ ]]; then
+    echo "Invalid time value: $input" >&2
+    exit 1
+  fi
+
+  echo $((10#$hours * 3600 + 10#$minutes * 60 + 10#$seconds))
+}
+
+format_hhmmss() {
+  local total_seconds="$1"
+  printf "%02d:%02d:%02d" \
+    $((total_seconds / 3600)) \
+    $(((total_seconds % 3600) / 60)) \
+    $((total_seconds % 60))
+}
+
+format_slug_time() {
+  local total_seconds="$1"
+  printf "%02d-%02d-%02d" \
+    $((total_seconds / 3600)) \
+    $(((total_seconds % 3600) / 60)) \
+    $((total_seconds % 60))
+}
+
+get_duration_seconds() {
+  local source_path="$1"
+  local duration_raw
+
+  duration_raw="$("$FFPROBE_BIN" -v error -show_entries format=duration \
+    -of default=noprint_wrappers=1:nokey=1 "$source_path")"
+
+  echo "${duration_raw%.*}"
+}
+
+choose_random_middle_start() {
+  local source_duration="$1"
+  local clip_duration="$2"
+  local max_start=0
+  local lower_bound=0
+  local upper_bound=0
+  local span=0
+
+  if (( source_duration <= clip_duration )); then
+    echo 0
+    return
+  fi
+
+  max_start=$((source_duration - clip_duration))
+  lower_bound=$((source_duration / 3))
+  upper_bound=$((((source_duration * 2) / 3) - clip_duration))
+
+  if (( upper_bound > max_start )); then
+    upper_bound="$max_start"
+  fi
+
+  if (( upper_bound < lower_bound )); then
+    echo $((max_start / 2))
+    return
+  fi
+
+  span=$((upper_bound - lower_bound + 1))
+  echo $((lower_bound + RANDOM % span))
+}
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "Missing local virtualenv at $PYTHON_BIN"
+  echo "Run: uv sync --extra detection"
+  exit 1
+fi
+
+if [[ $# -lt 1 ]]; then
+  usage
+  echo
+  echo "Videos currently in film/:"
+  while IFS= read -r video; do
+    echo "  ${video#$ROOT_DIR/}"
+  done < <(list_videos)
+  exit 1
+fi
+
+SOURCE_INPUT="$1"
+shift
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --clip-start)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --clip-start" >&2
+        exit 1
+      fi
+      CLIP_START_INPUT="$2"
+      shift 2
+      ;;
+    --clip-duration)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --clip-duration" >&2
+        exit 1
+      fi
+      CLIP_DURATION_INPUT="$2"
+      shift 2
+      ;;
+    --random-middle-minute)
+      RANDOM_MIDDLE_MINUTE=1
+      shift
+      ;;
+    --clip-only)
+      CLIP_ONLY=1
+      shift
+      ;;
+    --run-name)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --run-name" >&2
+        exit 1
+      fi
+      RUN_NAME="$2"
+      shift 2
+      ;;
+    *)
+      FORWARD_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "$SOURCE_INPUT" = /* ]]; then
+  SOURCE_PATH="$SOURCE_INPUT"
+else
+  SOURCE_PATH="$ROOT_DIR/$SOURCE_INPUT"
+fi
+
+if [[ ! -f "$SOURCE_PATH" ]]; then
+  echo "Source video not found: $SOURCE_INPUT"
+  exit 1
+fi
+
+SOURCE_BASENAME="$(basename "$SOURCE_PATH")"
+SOURCE_STEM="${SOURCE_BASENAME%.*}"
+SAFE_STEM="$(printf '%s' "$SOURCE_STEM" | tr ' /' '__' | tr -cd '[:alnum:]_.-')"
+if [[ -n "$RUN_NAME" ]]; then
+  SAFE_RUN_NAME="$(printf '%s' "$RUN_NAME" | tr ' /' '__' | tr -cd '[:alnum:]_.-')"
+  RUN_ROOT="$ROOT_DIR/runs/$SAFE_RUN_NAME"
+else
+  RUN_ROOT="$ROOT_DIR/runs/$SAFE_STEM"
+fi
+CLIP_SOURCE_PATH=""
+CLIP_START_SECS=0
+CLIP_DURATION_SECS=0
+SOURCE_DURATION_SECS=0
+
+if [[ -n "$CLIP_START_INPUT" && "$RANDOM_MIDDLE_MINUTE" -eq 1 ]]; then
+  echo "Choose either --clip-start or --random-middle-minute, not both." >&2
+  exit 1
+fi
+
+if [[ -n "$CLIP_START_INPUT" || "$RANDOM_MIDDLE_MINUTE" -eq 1 ]]; then
+  if ! command -v "$FFMPEG_BIN" >/dev/null 2>&1; then
+    echo "ffmpeg is required for clip extraction." >&2
+    exit 1
+  fi
+  if ! command -v "$FFPROBE_BIN" >/dev/null 2>&1; then
+    echo "ffprobe is required for clip extraction." >&2
+    exit 1
+  fi
+
+  SOURCE_DURATION_SECS="$(get_duration_seconds "$SOURCE_PATH")"
+  CLIP_DURATION_SECS="$(parse_seconds "$CLIP_DURATION_INPUT")"
+
+  if (( CLIP_DURATION_SECS <= 0 )); then
+    echo "Clip duration must be greater than 0." >&2
+    exit 1
+  fi
+
+  if (( SOURCE_DURATION_SECS <= CLIP_DURATION_SECS )); then
+    CLIP_DURATION_SECS="$SOURCE_DURATION_SECS"
+    CLIP_START_SECS=0
+  elif [[ -n "$CLIP_START_INPUT" ]]; then
+    CLIP_START_SECS="$(parse_seconds "$CLIP_START_INPUT")"
+    if (( CLIP_START_SECS < 0 )); then
+      CLIP_START_SECS=0
+    fi
+    if (( CLIP_START_SECS + CLIP_DURATION_SECS > SOURCE_DURATION_SECS )); then
+      CLIP_START_SECS=$((SOURCE_DURATION_SECS - CLIP_DURATION_SECS))
+    fi
+  else
+    CLIP_START_SECS="$(choose_random_middle_start "$SOURCE_DURATION_SECS" "$CLIP_DURATION_SECS")"
+  fi
+
+  CLIP_TAG="clip_$(format_slug_time "$CLIP_START_SECS")_d${CLIP_DURATION_SECS}s"
+  CLIP_DIR="$RUN_ROOT/clips"
+  CLIP_SOURCE_PATH="$CLIP_DIR/${CLIP_TAG}.mp4"
+
+  mkdir -p "$CLIP_DIR"
+
+  echo "Creating clip:     ${CLIP_SOURCE_PATH#$ROOT_DIR/}"
+  echo "Clip start:        $(format_hhmmss "$CLIP_START_SECS")"
+  echo "Clip duration:     $(format_hhmmss "$CLIP_DURATION_SECS")"
+  echo
+
+  "$FFMPEG_BIN" -hide_banner -loglevel error \
+    -ss "$(format_hhmmss "$CLIP_START_SECS")" \
+    -i "$SOURCE_PATH" \
+    -t "$(format_hhmmss "$CLIP_DURATION_SECS")" \
+    -c:v libx264 \
+    -preset veryfast \
+    -crf 18 \
+    -c:a aac \
+    -movflags +faststart \
+    -y \
+    "$CLIP_SOURCE_PATH"
+
+  SOURCE_PATH="$CLIP_SOURCE_PATH"
+  RUN_DIR="$RUN_ROOT/$CLIP_TAG"
+else
+  RUN_DIR="$RUN_ROOT"
+fi
+
+VIDEO_OUT="$RUN_DIR/tracked.mp4"
+MOT_OUT="$RUN_DIR/tracks.txt"
+
+mkdir -p "$RUN_DIR"
+mkdir -p "$MPL_CACHE_DIR" "$FONTCONFIG_CACHE_DIR"
+
+echo "Source video:      ${SOURCE_PATH#$ROOT_DIR/}"
+echo "Annotated output:  ${VIDEO_OUT#$ROOT_DIR/}"
+echo "Raw MOT output:    ${MOT_OUT#$ROOT_DIR/}"
+echo
+
+export XDG_CACHE_HOME="$CACHE_DIR"
+export MPLCONFIGDIR="$MPL_CACHE_DIR"
+
+if (( CLIP_ONLY == 1 )); then
+  if [[ -n "$CLIP_SOURCE_PATH" ]]; then
+    echo "Clip ready:        ${CLIP_SOURCE_PATH#$ROOT_DIR/}"
+  else
+    echo "--clip-only requires --clip-start or --random-middle-minute" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+TRACK_CMD=(
+  "$PYTHON_BIN" -m trackers.scripts.__main__ track
+  --source "$SOURCE_PATH"
+  --output "$VIDEO_OUT"
+  --mot-output "$MOT_OUT"
+  --model "${TRACKERS_MODEL:-rfdetr-medium}"
+  --tracker "${TRACKERS_TRACKER:-bytetrack}"
+  --classes "${TRACKERS_CLASSES:-person}"
+  --model.confidence "${TRACKERS_CONFIDENCE:-0.3}"
+  --model.device "${TRACKERS_DEVICE:-auto}"
+  --tracker.lost_track_buffer "${TRACKERS_LOST_TRACK_BUFFER:-60}"
+  --show-labels
+  --show-trajectories
+  --overwrite
+)
+
+if (( ${#FORWARD_ARGS[@]} > 0 )); then
+  TRACK_CMD+=("${FORWARD_ARGS[@]}")
+fi
+
+"${TRACK_CMD[@]}"
+
+echo
+echo "Finished."
+echo "Annotated video: ${VIDEO_OUT#$ROOT_DIR/}"
+echo "Raw MOT track data: ${MOT_OUT#$ROOT_DIR/}"

--- a/test/calibration/test_pitch.py
+++ b/test/calibration/test_pitch.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 from __future__ import annotations
 
 import numpy as np

--- a/test/calibration/test_pitch.py
+++ b/test/calibration/test_pitch.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import numpy as np
+
+from trackers.calibration.pitch import PitchModel
+from trackers.calibration.types import PitchDimensions
+
+
+def test_pitch_metric_and_normalized_round_trip() -> None:
+    pitch = PitchModel(dimensions=PitchDimensions(length_m=105.0, width_m=68.0))
+    metric_points = np.array([[0.0, 0.0], [52.5, 34.0], [105.0, 68.0]])
+
+    normalized = pitch.metric_to_normalized(metric_points)
+    restored = pitch.normalized_to_metric(normalized)
+
+    np.testing.assert_allclose(normalized[1], np.array([0.5, 0.5]))
+    np.testing.assert_allclose(restored, metric_points)

--- a/test/calibration/test_projection.py
+++ b/test/calibration/test_projection.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 from __future__ import annotations
 
 import numpy as np

--- a/test/calibration/test_projection.py
+++ b/test/calibration/test_projection.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import numpy as np
+
+from trackers.calibration.projection import (
+    apply_homography,
+    bottom_center_from_xywh,
+)
+
+
+def test_apply_homography_with_identity_matrix() -> None:
+    points = np.array([[10.0, 20.0], [30.0, 40.0]])
+    homography = np.eye(3)
+
+    projected = apply_homography(points, homography)
+
+    np.testing.assert_allclose(projected, points)
+
+
+def test_bottom_center_from_xywh() -> None:
+    boxes = np.array([[10.0, 20.0, 30.0, 40.0]])
+
+    anchors = bottom_center_from_xywh(boxes)
+
+    np.testing.assert_allclose(anchors, np.array([[25.0, 60.0]]))

--- a/test/calibration/test_smoothing.py
+++ b/test/calibration/test_smoothing.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 from __future__ import annotations
 
 import numpy as np

--- a/test/calibration/test_smoothing.py
+++ b/test/calibration/test_smoothing.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import numpy as np
+
+from trackers.calibration.smoothing import fill_calibration_gaps
+from trackers.calibration.types import CalibrationFrame, PitchDimensions
+
+
+def test_fill_calibration_gaps_interpolates_between_neighbors() -> None:
+    pitch = PitchDimensions()
+    first = CalibrationFrame(
+        frame_idx=1,
+        timestamp_s=0.0,
+        image_to_pitch=np.eye(3),
+        pitch_to_image=np.eye(3),
+        confidence=1.0,
+        provider="test",
+        pitch_dimensions=pitch,
+    )
+    gap = CalibrationFrame(
+        frame_idx=2,
+        timestamp_s=1 / 30.0,
+        confidence=0.0,
+        provider="test",
+        pitch_dimensions=pitch,
+        diagnostics={"sampled": False},
+    )
+    translated = np.array(
+        [
+            [1.0, 0.0, 10.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    last = CalibrationFrame(
+        frame_idx=3,
+        timestamp_s=2 / 30.0,
+        image_to_pitch=np.linalg.inv(translated),
+        pitch_to_image=translated,
+        confidence=1.0,
+        provider="test",
+        pitch_dimensions=pitch,
+    )
+
+    frames = fill_calibration_gaps(
+        [first, gap, last],
+        max_gap_frames=5,
+        min_confidence=0.4,
+        mode="interpolate",
+        edge_strategy="hold",
+    )
+
+    assert frames[1].has_homography
+    assert frames[1].diagnostics["interpolated_from_frame_idx"] == 1
+    assert frames[1].diagnostics["interpolated_to_frame_idx"] == 3
+    np.testing.assert_allclose(
+        frames[1].pitch_to_image,
+        np.array(
+            [
+                [1.0, 0.0, 5.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        ),
+        atol=1e-5,
+    )

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,12 @@
+# Third-Party Integrations
+
+Vendor or check out external calibration systems here so their code stays
+isolated from the `trackers/` package.
+
+Recommended layout:
+
+- `third_party/pnlcalib`
+
+The local wrappers in `trackers/calibration/providers/` should stay thin:
+resolve paths, normalize outputs, and translate provider-specific camera or
+homography data into the repo's shared `CalibrationFrame` schema.

--- a/trackers/__init__.py
+++ b/trackers/__init__.py
@@ -19,7 +19,11 @@ from trackers.calibration.projection import (
 )
 from trackers.calibration.providers.pnlcalib import PnLCalibProvider
 from trackers.calibration.smoothing import HoldLastCalibration, fill_calibration_gaps
-from trackers.calibration.types import CalibrationFrame, PitchDimensions, TrackProjection
+from trackers.calibration.types import (
+    CalibrationFrame,
+    PitchDimensions,
+    TrackProjection,
+)
 from trackers.core.bytetrack.tracker import ByteTrackTracker
 from trackers.core.ocsort.tracker import OCSORTTracker
 from trackers.core.sort.tracker import SORTTracker

--- a/trackers/calibration/__init__.py
+++ b/trackers/calibration/__init__.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-from trackers.annotators.trace import MotionAwareTraceAnnotator
 from trackers.calibration.base import PitchCalibrator
 from trackers.calibration.pitch import PitchModel
 from trackers.calibration.projection import (
@@ -20,48 +19,20 @@ from trackers.calibration.projection import (
 from trackers.calibration.providers.pnlcalib import PnLCalibProvider
 from trackers.calibration.smoothing import HoldLastCalibration, fill_calibration_gaps
 from trackers.calibration.types import CalibrationFrame, PitchDimensions, TrackProjection
-from trackers.core.bytetrack.tracker import ByteTrackTracker
-from trackers.core.ocsort.tracker import OCSORTTracker
-from trackers.core.sort.tracker import SORTTracker
-from trackers.datasets.download import download_dataset
-from trackers.datasets.manifest import Dataset, DatasetAsset, DatasetSplit
-from trackers.io.video import frames_from_source
-from trackers.motion.estimator import MotionEstimator
-from trackers.motion.transformation import (
-    CoordinatesTransformation,
-    HomographyTransformation,
-    IdentityTransformation,
-)
-from trackers.utils.converters import xcycsr_to_xyxy, xyxy_to_xcycsr
 
 __all__ = [
-    "ByteTrackTracker",
     "CalibrationFrame",
-    "CoordinatesTransformation",
-    "Dataset",
-    "DatasetAsset",
-    "DatasetSplit",
     "HoldLastCalibration",
-    "HomographyTransformation",
-    "IdentityTransformation",
-    "MotionAwareTraceAnnotator",
-    "MotionEstimator",
-    "OCSORTTracker",
     "PitchCalibrator",
     "PitchDimensions",
     "PitchModel",
     "PnLCalibProvider",
-    "SORTTracker",
     "TrackProjection",
     "apply_homography",
     "bottom_center_from_xywh",
     "bottom_center_from_xyxy",
-    "download_dataset",
     "fill_calibration_gaps",
-    "frames_from_source",
     "invert_homography",
     "project_image_points_to_pitch",
     "project_pitch_points_to_image",
-    "xcycsr_to_xyxy",
-    "xyxy_to_xcycsr",
 ]

--- a/trackers/calibration/__init__.py
+++ b/trackers/calibration/__init__.py
@@ -18,7 +18,11 @@ from trackers.calibration.projection import (
 )
 from trackers.calibration.providers.pnlcalib import PnLCalibProvider
 from trackers.calibration.smoothing import HoldLastCalibration, fill_calibration_gaps
-from trackers.calibration.types import CalibrationFrame, PitchDimensions, TrackProjection
+from trackers.calibration.types import (
+    CalibrationFrame,
+    PitchDimensions,
+    TrackProjection,
+)
 
 __all__ = [
     "CalibrationFrame",

--- a/trackers/calibration/base.py
+++ b/trackers/calibration/base.py
@@ -1,0 +1,53 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from trackers.calibration.types import CalibrationFrame, PitchDimensions
+
+
+class PitchCalibrator(ABC):
+    """Common interface for pitch-calibration backends.
+
+    Calibrators are responsible for producing per-frame field geometry that can
+    later be used to project tracked players into pitch coordinates.
+    """
+
+    def __init__(self, pitch_dimensions: PitchDimensions | None = None) -> None:
+        self.pitch_dimensions = pitch_dimensions or PitchDimensions()
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable provider name."""
+
+    def is_available(self) -> bool:
+        """Return whether the backing implementation is installed."""
+        return True
+
+    def availability_hint(self) -> str | None:
+        """Return an optional install hint when `is_available` is false."""
+        return None
+
+    def describe(self) -> dict[str, object]:
+        """Return serializable provider metadata for manifests and logs."""
+        return {
+            "provider": self.name,
+            "pitch_dimensions": self.pitch_dimensions.to_dict(),
+            "available": self.is_available(),
+            "availability_hint": self.availability_hint(),
+        }
+
+    @abstractmethod
+    def calibrate_video(
+        self,
+        source: str | Path,
+        output_dir: str | Path,
+    ) -> list[CalibrationFrame]:
+        """Run calibration on a video or clip and return per-frame results."""

--- a/trackers/calibration/export.py
+++ b/trackers/calibration/export.py
@@ -1,0 +1,138 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Iterable
+
+from trackers.calibration.types import CalibrationFrame, TrackProjection
+
+
+def write_manifest(path: str | Path, data: dict[str, object]) -> Path:
+    """Write a JSON manifest file."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    return output_path
+
+
+def write_calibration_jsonl(
+    path: str | Path,
+    frames: Iterable[CalibrationFrame],
+) -> Path:
+    """Write calibration frames as JSON Lines."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        for frame in frames:
+            handle.write(json.dumps(frame.to_dict(), sort_keys=True))
+            handle.write("\n")
+    return output_path
+
+
+def write_homography_jsonl(
+    path: str | Path,
+    frames: Iterable[CalibrationFrame],
+) -> Path:
+    """Write only per-frame homography data as JSON Lines."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        for frame in frames:
+            payload = {
+                "frame_idx": frame.frame_idx,
+                "timestamp_s": frame.timestamp_s,
+                "image_to_pitch": (
+                    None
+                    if frame.image_to_pitch is None
+                    else frame.image_to_pitch.tolist()
+                ),
+                "pitch_to_image": (
+                    None
+                    if frame.pitch_to_image is None
+                    else frame.pitch_to_image.tolist()
+                ),
+                "confidence": frame.confidence,
+                "provider": frame.provider,
+                "pitch_dimensions": frame.pitch_dimensions.to_dict(),
+                "diagnostics": frame.diagnostics,
+            }
+            handle.write(json.dumps(payload, sort_keys=True))
+            handle.write("\n")
+    return output_path
+
+
+def load_calibration_jsonl(path: str | Path) -> list[CalibrationFrame]:
+    """Load calibration frames from JSON Lines."""
+    input_path = Path(path)
+    frames: list[CalibrationFrame] = []
+    with input_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            frames.append(CalibrationFrame.from_dict(json.loads(stripped)))
+    return frames
+
+
+def write_calibration_quality_csv(
+    path: str | Path,
+    frames: Iterable[CalibrationFrame],
+) -> Path:
+    """Write frame-level calibration diagnostics as CSV."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "frame_idx",
+        "timestamp_s",
+        "has_homography",
+        "confidence",
+        "rep_err",
+        "mode",
+        "use_ransac",
+        "calib_plane",
+        "held_from_frame_idx",
+        "held_frame_gap",
+    ]
+    with output_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for frame in frames:
+            diagnostics = frame.diagnostics
+            writer.writerow(
+                {
+                    "frame_idx": frame.frame_idx,
+                    "timestamp_s": frame.timestamp_s,
+                    "has_homography": frame.has_homography,
+                    "confidence": frame.confidence,
+                    "rep_err": diagnostics.get("rep_err"),
+                    "mode": diagnostics.get("mode"),
+                    "use_ransac": diagnostics.get("use_ransac"),
+                    "calib_plane": diagnostics.get("calib_plane"),
+                    "held_from_frame_idx": diagnostics.get("held_from_frame_idx"),
+                    "held_frame_gap": diagnostics.get("held_frame_gap"),
+                }
+            )
+    return output_path
+
+
+def write_track_projections_csv(
+    path: str | Path,
+    projections: Iterable[TrackProjection],
+) -> Path:
+    """Write projected track positions as CSV."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(TrackProjection.__dataclass_fields__.keys())
+    with output_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for projection in projections:
+            writer.writerow(projection.to_dict())
+    return output_path

--- a/trackers/calibration/export.py
+++ b/trackers/calibration/export.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import csv
 import json
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 from trackers.calibration.types import CalibrationFrame, TrackProjection
 

--- a/trackers/calibration/pitch.py
+++ b/trackers/calibration/pitch.py
@@ -13,7 +13,9 @@ import numpy as np
 from trackers.calibration.types import PitchDimensions
 
 
-def _as_points(points: np.ndarray | list[list[float]] | list[tuple[float, float]]) -> np.ndarray:
+def _as_points(
+    points: np.ndarray | list[list[float]] | list[tuple[float, float]],
+) -> np.ndarray:
     array = np.asarray(points, dtype=np.float64)
     if array.ndim == 1:
         if array.shape[0] != 2:
@@ -30,14 +32,18 @@ class PitchModel:
 
     dimensions: PitchDimensions = field(default_factory=PitchDimensions)
 
-    def metric_to_normalized(self, points: np.ndarray | list[list[float]]) -> np.ndarray:
+    def metric_to_normalized(
+        self, points: np.ndarray | list[list[float]]
+    ) -> np.ndarray:
         metric_points = _as_points(points)
         normalized = metric_points.copy()
         normalized[:, 0] /= self.dimensions.length_m
         normalized[:, 1] /= self.dimensions.width_m
         return normalized
 
-    def normalized_to_metric(self, points: np.ndarray | list[list[float]]) -> np.ndarray:
+    def normalized_to_metric(
+        self, points: np.ndarray | list[list[float]]
+    ) -> np.ndarray:
         normalized_points = _as_points(points)
         metric = normalized_points.copy()
         metric[:, 0] *= self.dimensions.length_m

--- a/trackers/calibration/pitch.py
+++ b/trackers/calibration/pitch.py
@@ -1,0 +1,59 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from trackers.calibration.types import PitchDimensions
+
+
+def _as_points(points: np.ndarray | list[list[float]] | list[tuple[float, float]]) -> np.ndarray:
+    array = np.asarray(points, dtype=np.float64)
+    if array.ndim == 1:
+        if array.shape[0] != 2:
+            raise ValueError("Expected a single point with shape (2,)")
+        return array.reshape(1, 2)
+    if array.ndim != 2 or array.shape[1] != 2:
+        raise ValueError(f"Expected points with shape (N, 2), got {array.shape}")
+    return array
+
+
+@dataclass(frozen=True)
+class PitchModel:
+    """Canonical pitch coordinate system."""
+
+    dimensions: PitchDimensions = field(default_factory=PitchDimensions)
+
+    def metric_to_normalized(self, points: np.ndarray | list[list[float]]) -> np.ndarray:
+        metric_points = _as_points(points)
+        normalized = metric_points.copy()
+        normalized[:, 0] /= self.dimensions.length_m
+        normalized[:, 1] /= self.dimensions.width_m
+        return normalized
+
+    def normalized_to_metric(self, points: np.ndarray | list[list[float]]) -> np.ndarray:
+        normalized_points = _as_points(points)
+        metric = normalized_points.copy()
+        metric[:, 0] *= self.dimensions.length_m
+        metric[:, 1] *= self.dimensions.width_m
+        return metric
+
+    def contains_metric_points(
+        self,
+        points: np.ndarray | list[list[float]],
+        *,
+        tolerance_m: float = 0.0,
+    ) -> np.ndarray:
+        metric_points = _as_points(points)
+        return (
+            (metric_points[:, 0] >= -tolerance_m)
+            & (metric_points[:, 0] <= self.dimensions.length_m + tolerance_m)
+            & (metric_points[:, 1] >= -tolerance_m)
+            & (metric_points[:, 1] <= self.dimensions.width_m + tolerance_m)
+        )

--- a/trackers/calibration/projection.py
+++ b/trackers/calibration/projection.py
@@ -1,0 +1,96 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import numpy as np
+
+from trackers.calibration.types import CalibrationFrame
+
+
+def _as_points(points: np.ndarray | list[list[float]] | list[tuple[float, float]]) -> np.ndarray:
+    array = np.asarray(points, dtype=np.float64)
+    if array.ndim == 1:
+        if array.shape[0] != 2:
+            raise ValueError("Expected a single point with shape (2,)")
+        return array.reshape(1, 2)
+    if array.ndim != 2 or array.shape[1] != 2:
+        raise ValueError(f"Expected points with shape (N, 2), got {array.shape}")
+    return array
+
+
+def invert_homography(homography: np.ndarray) -> np.ndarray:
+    """Invert a 3x3 homography matrix."""
+    matrix = np.asarray(homography, dtype=np.float64)
+    if matrix.shape != (3, 3):
+        raise ValueError(f"Expected a 3x3 homography matrix, got {matrix.shape}")
+    return np.linalg.inv(matrix)
+
+
+def apply_homography(
+    points: np.ndarray | list[list[float]] | list[tuple[float, float]],
+    homography: np.ndarray,
+) -> np.ndarray:
+    """Project 2D points through a homography matrix."""
+    points_array = _as_points(points)
+    matrix = np.asarray(homography, dtype=np.float64)
+    if matrix.shape != (3, 3):
+        raise ValueError(f"Expected a 3x3 homography matrix, got {matrix.shape}")
+
+    homogeneous = np.concatenate(
+        [points_array, np.ones((points_array.shape[0], 1), dtype=np.float64)],
+        axis=1,
+    )
+    transformed = homogeneous @ matrix.T
+    scale = transformed[:, 2:3]
+    safe_scale = np.where(np.abs(scale) < 1e-9, 1e-9, scale)
+    return transformed[:, :2] / safe_scale
+
+
+def project_image_points_to_pitch(
+    points: np.ndarray | list[list[float]] | list[tuple[float, float]],
+    calibration: CalibrationFrame,
+) -> np.ndarray:
+    """Project image-space points into pitch metric coordinates."""
+    if calibration.image_to_pitch is None:
+        raise ValueError("Calibration frame is missing image_to_pitch homography")
+    return apply_homography(points, calibration.image_to_pitch)
+
+
+def project_pitch_points_to_image(
+    points: np.ndarray | list[list[float]] | list[tuple[float, float]],
+    calibration: CalibrationFrame,
+) -> np.ndarray:
+    """Project pitch metric coordinates back into image space."""
+    if calibration.pitch_to_image is None:
+        raise ValueError("Calibration frame is missing pitch_to_image homography")
+    return apply_homography(points, calibration.pitch_to_image)
+
+
+def bottom_center_from_xyxy(boxes: np.ndarray | list[list[float]]) -> np.ndarray:
+    """Return bottom-center anchor points for xyxy boxes."""
+    boxes_array = np.asarray(boxes, dtype=np.float64)
+    if boxes_array.ndim != 2 or boxes_array.shape[1] != 4:
+        raise ValueError(f"Expected boxes with shape (N, 4), got {boxes_array.shape}")
+    return np.column_stack(
+        (
+            (boxes_array[:, 0] + boxes_array[:, 2]) / 2.0,
+            boxes_array[:, 3],
+        )
+    )
+
+
+def bottom_center_from_xywh(boxes: np.ndarray | list[list[float]]) -> np.ndarray:
+    """Return bottom-center anchor points for xywh boxes."""
+    boxes_array = np.asarray(boxes, dtype=np.float64)
+    if boxes_array.ndim != 2 or boxes_array.shape[1] != 4:
+        raise ValueError(f"Expected boxes with shape (N, 4), got {boxes_array.shape}")
+    return np.column_stack(
+        (
+            boxes_array[:, 0] + (boxes_array[:, 2] / 2.0),
+            boxes_array[:, 1] + boxes_array[:, 3],
+        )
+    )

--- a/trackers/calibration/projection.py
+++ b/trackers/calibration/projection.py
@@ -11,7 +11,9 @@ import numpy as np
 from trackers.calibration.types import CalibrationFrame
 
 
-def _as_points(points: np.ndarray | list[list[float]] | list[tuple[float, float]]) -> np.ndarray:
+def _as_points(
+    points: np.ndarray | list[list[float]] | list[tuple[float, float]],
+) -> np.ndarray:
     array = np.asarray(points, dtype=np.float64)
     if array.ndim == 1:
         if array.shape[0] != 2:

--- a/trackers/calibration/providers/__init__.py
+++ b/trackers/calibration/providers/__init__.py
@@ -1,0 +1,11 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from trackers.calibration.providers.pnlcalib import PnLCalibProvider
+
+__all__ = ["PnLCalibProvider"]

--- a/trackers/calibration/providers/pnlcalib.py
+++ b/trackers/calibration/providers/pnlcalib.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 import importlib.util
 import os
 import sys
-import tomllib
 from pathlib import Path
 from typing import Any
 
 import cv2
 import numpy as np
+import tomllib
 
 from trackers.calibration.base import PitchCalibrator
 from trackers.calibration.projection import invert_homography
@@ -71,9 +71,8 @@ class PnLCalibProvider(PitchCalibrator):
         if not self._weights_line_path().exists():
             missing_weights.append(str(self._weights_line_path()))
         if missing_weights:
-            return (
-                "PnLCalib weights are missing. Expected: "
-                + ", ".join(missing_weights)
+            return "PnLCalib weights are missing. Expected: " + ", ".join(
+                missing_weights
             )
         return (
             "PnLCalib is not ready in the current environment. Check the "
@@ -84,7 +83,9 @@ class PnLCalibProvider(PitchCalibrator):
         data = super().describe()
         data.update(
             {
-                "config_path": None if self.config_path is None else str(self.config_path),
+                "config_path": None
+                if self.config_path is None
+                else str(self.config_path),
                 "upstream_root": str(self.upstream_root),
                 "weights_kp": str(self._weights_kp_path()),
                 "weights_line": str(self._weights_line_path()),
@@ -273,7 +274,7 @@ class PnLCalibProvider(PitchCalibrator):
         )
         os.environ.setdefault(
             "MPLCONFIGDIR",
-            str((self.upstream_root.parent.parent / ".cache" / "matplotlib")),
+            str(self.upstream_root.parent.parent / ".cache" / "matplotlib"),
         )
 
         upstream_path = str(self.upstream_root.resolve())
@@ -284,10 +285,9 @@ class PnLCalibProvider(PitchCalibrator):
         import torchvision.transforms as T
         import torchvision.transforms.functional as f
         import yaml
-        from PIL import Image
-
         from model.cls_hrnet import get_cls_net
         from model.cls_hrnet_l import get_cls_net as get_cls_net_l
+        from PIL import Image
         from utils.utils_calib import FramebyFrameCalib
         from utils.utils_heatmap import (
             complete_keypoints,
@@ -306,7 +306,9 @@ class PnLCalibProvider(PitchCalibrator):
             device = torch.device(device_name)
 
         cfg = yaml.safe_load(
-            (self.upstream_root / "config" / "hrnetv2_w48.yaml").read_text(encoding="utf-8")
+            (self.upstream_root / "config" / "hrnetv2_w48.yaml").read_text(
+                encoding="utf-8"
+            )
         )
         cfg_l = yaml.safe_load(
             (self.upstream_root / "config" / "hrnetv2_w48_l.yaml").read_text(
@@ -458,8 +460,14 @@ class PnLCalibProvider(PitchCalibrator):
             **camera_params,
             "world_origin": "pitch_center",
             "position_meters_top_left_origin": [
-                float(camera_params["position_meters"][0] + (self.pitch_dimensions.length_m / 2.0)),
-                float(camera_params["position_meters"][1] + (self.pitch_dimensions.width_m / 2.0)),
+                float(
+                    camera_params["position_meters"][0]
+                    + (self.pitch_dimensions.length_m / 2.0)
+                ),
+                float(
+                    camera_params["position_meters"][1]
+                    + (self.pitch_dimensions.width_m / 2.0)
+                ),
                 float(camera_params["position_meters"][2]),
             ],
         }
@@ -612,7 +620,9 @@ class PnLCalibProvider(PitchCalibrator):
             if calibration.pitch_to_image is not None:
                 overlay = frame.copy()
                 for polyline in polylines:
-                    projected = self._project_polyline(polyline, calibration.pitch_to_image)
+                    projected = self._project_polyline(
+                        polyline, calibration.pitch_to_image
+                    )
                     if projected.shape[0] < 2:
                         continue
                     overlay = cv2.polylines(
@@ -630,7 +640,9 @@ class PnLCalibProvider(PitchCalibrator):
         cap.release()
         writer.release()
 
-    def _project_polyline(self, polyline: np.ndarray, homography: np.ndarray) -> np.ndarray:
+    def _project_polyline(
+        self, polyline: np.ndarray, homography: np.ndarray
+    ) -> np.ndarray:
         homogeneous = np.concatenate(
             [polyline, np.ones((polyline.shape[0], 1), dtype=np.float64)],
             axis=1,
@@ -657,7 +669,9 @@ class PnLCalibProvider(PitchCalibrator):
                 dtype=np.float64,
             )
 
-        def circle(cx: float, cy: float, radius: float, samples: int = 180) -> np.ndarray:
+        def circle(
+            cx: float, cy: float, radius: float, samples: int = 180
+        ) -> np.ndarray:
             angles = np.linspace(0.0, 2.0 * np.pi, samples)
             return np.column_stack(
                 [cx + (radius * np.cos(angles)), cy + (radius * np.sin(angles))]

--- a/trackers/calibration/providers/pnlcalib.py
+++ b/trackers/calibration/providers/pnlcalib.py
@@ -1,0 +1,674 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+
+from trackers.calibration.base import PitchCalibrator
+from trackers.calibration.projection import invert_homography
+from trackers.calibration.smoothing import fill_calibration_gaps
+from trackers.calibration.types import CalibrationFrame, PitchDimensions
+
+
+class PnLCalibProvider(PitchCalibrator):
+    """Adapter for the upstream PnLCalib inference pipeline."""
+
+    def __init__(
+        self,
+        *,
+        pitch_dimensions: PitchDimensions | None = None,
+        config_path: str | Path | None = None,
+        config_data: dict[str, object] | None = None,
+        upstream_root: str | Path = "third_party/pnlcalib",
+    ) -> None:
+        super().__init__(pitch_dimensions=pitch_dimensions)
+        self.config_path = None if config_path is None else Path(config_path)
+        self.config_data = config_data or self._load_config_data()
+        self.upstream_root = Path(upstream_root)
+        self._runtime: dict[str, Any] | None = None
+        self._models: tuple[Any, Any] | None = None
+
+    @property
+    def name(self) -> str:
+        return "pnlcalib"
+
+    def is_available(self) -> bool:
+        return (
+            self.upstream_root.exists()
+            and self._weights_kp_path().exists()
+            and self._weights_line_path().exists()
+            and importlib.util.find_spec("ellipse") is not None
+        )
+
+    def availability_hint(self) -> str | None:
+        if self.is_available():
+            return None
+        if not self.upstream_root.exists():
+            return (
+                "Expected an upstream checkout at "
+                f"{self.upstream_root}. Clone or vendor PnLCalib there first."
+            )
+        if importlib.util.find_spec("ellipse") is None:
+            return (
+                "PnLCalib needs the `lsq-ellipse` package in the current "
+                "environment. Install it with `pip install lsq-ellipse==2.2.1`."
+            )
+        missing_weights = []
+        if not self._weights_kp_path().exists():
+            missing_weights.append(str(self._weights_kp_path()))
+        if not self._weights_line_path().exists():
+            missing_weights.append(str(self._weights_line_path()))
+        if missing_weights:
+            return (
+                "PnLCalib weights are missing. Expected: "
+                + ", ".join(missing_weights)
+            )
+        return (
+            "PnLCalib is not ready in the current environment. Check the "
+            "upstream checkout, weights, and Python dependencies."
+        )
+
+    def describe(self) -> dict[str, object]:
+        data = super().describe()
+        data.update(
+            {
+                "config_path": None if self.config_path is None else str(self.config_path),
+                "upstream_root": str(self.upstream_root),
+                "weights_kp": str(self._weights_kp_path()),
+                "weights_line": str(self._weights_line_path()),
+            }
+        )
+        return data
+
+    def calibrate_video(
+        self,
+        source: str | Path,
+        output_dir: str | Path,
+    ) -> list[CalibrationFrame]:
+        runtime = self._ensure_runtime()
+        model_kp, model_line = self._ensure_models()
+        source_path = Path(source)
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        cap = cv2.VideoCapture(str(source_path))
+        if not cap.isOpened():
+            raise ValueError(f"Unable to open video source: {source_path}")
+
+        frame_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        frame_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        fps = float(cap.get(cv2.CAP_PROP_FPS))
+        if fps <= 0:
+            fps = 30.0
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+
+        sampling_every_n = max(1, int(self._sampling_config().get("every_n_frames", 1)))
+        cam = runtime["FramebyFrameCalib"](
+            iwidth=frame_width,
+            iheight=frame_height,
+            denormalize=True,
+        )
+
+        frames: list[CalibrationFrame] = []
+        frame_number = 0
+        while cap.isOpened():
+            ret, frame = cap.read()
+            if not ret:
+                break
+            frame_number += 1
+            timestamp_s = (frame_number - 1) / fps
+
+            if (frame_number - 1) % sampling_every_n == 0:
+                calibration = self._run_frame_inference(
+                    frame=frame,
+                    frame_idx=frame_number,
+                    timestamp_s=timestamp_s,
+                    cam=cam,
+                    runtime=runtime,
+                    model_kp=model_kp,
+                    model_line=model_line,
+                )
+            else:
+                calibration = CalibrationFrame(
+                    frame_idx=frame_number,
+                    timestamp_s=timestamp_s,
+                    confidence=0.0,
+                    provider=self.name,
+                    pitch_dimensions=self.pitch_dimensions,
+                    diagnostics={"sampled": False},
+                )
+            frames.append(calibration)
+
+        cap.release()
+
+        smoothing_config = self._smoothing_config()
+        if bool(smoothing_config.get("enabled", True)):
+            frames = fill_calibration_gaps(
+                frames,
+                max_gap_frames=int(smoothing_config.get("max_gap_frames", 15)),
+                min_confidence=float(smoothing_config.get("min_confidence", 0.4)),
+                mode=str(smoothing_config.get("mode", "hold")),
+                edge_strategy=str(smoothing_config.get("edge_strategy", "hold")),
+            )
+
+        overlay_config = self._overlay_config()
+        if bool(overlay_config.get("enabled", False)):
+            overlay_name = str(overlay_config.get("path", "overlay.mp4"))
+            self._render_overlay_video(
+                source=source_path,
+                frames=frames,
+                fps=fps,
+                frame_width=frame_width,
+                frame_height=frame_height,
+                output_path=output_path / overlay_name,
+                line_color_bgr=tuple(overlay_config.get("line_color_bgr", [255, 0, 0])),
+                line_thickness=int(overlay_config.get("line_thickness", 2)),
+            )
+
+        if total_frames and len(frames) != total_frames:
+            diagnostics_path = output_path / "provider_diagnostics.json"
+            diagnostics_path.write_text(
+                (
+                    "{\n"
+                    f'  "expected_frames": {total_frames},\n'
+                    f'  "produced_frames": {len(frames)}\n'
+                    "}\n"
+                ),
+                encoding="utf-8",
+            )
+
+        return frames
+
+    def _load_config_data(self) -> dict[str, object]:
+        if self.config_path is None or not self.config_path.exists():
+            return {}
+        return tomllib.loads(self.config_path.read_text(encoding="utf-8"))
+
+    def _provider_config(self) -> dict[str, Any]:
+        section = self.config_data.get("provider", {})
+        return section if isinstance(section, dict) else {}
+
+    def _weights_config(self) -> dict[str, Any]:
+        section = self.config_data.get("weights", {})
+        return section if isinstance(section, dict) else {}
+
+    def _threshold_config(self) -> dict[str, Any]:
+        section = self.config_data.get("thresholds", {})
+        return section if isinstance(section, dict) else {}
+
+    def _sampling_config(self) -> dict[str, Any]:
+        section = self.config_data.get("sampling", {})
+        return section if isinstance(section, dict) else {}
+
+    def _smoothing_config(self) -> dict[str, Any]:
+        section = self.config_data.get("smoothing", {})
+        return section if isinstance(section, dict) else {}
+
+    def _overlay_config(self) -> dict[str, Any]:
+        section = self.config_data.get("overlay", {})
+        return section if isinstance(section, dict) else {}
+
+    def _inference_config(self) -> dict[str, Any]:
+        section = self.config_data.get("inference", {})
+        return section if isinstance(section, dict) else {}
+
+    def _solve_mode(self) -> str:
+        mode = str(self._inference_config().get("mode", "camera"))
+        if mode not in {"camera", "homography"}:
+            raise ValueError(f"Unsupported PnLCalib solve mode: {mode}")
+        return mode
+
+    def _resolve_relative_path(self, value: str | Path, *, root: Path) -> Path:
+        path = Path(value)
+        if path.is_absolute():
+            return path
+        return root / path
+
+    def _weights_kp_path(self) -> Path:
+        return self._resolve_relative_path(
+            self._weights_config().get("keypoints", "weights/SV_kp"),
+            root=self.upstream_root,
+        )
+
+    def _weights_line_path(self) -> Path:
+        return self._resolve_relative_path(
+            self._weights_config().get("lines", "weights/SV_lines"),
+            root=self.upstream_root,
+        )
+
+    def _kp_threshold(self) -> float:
+        return float(self._threshold_config().get("keypoints", 0.3434))
+
+    def _line_threshold(self) -> float:
+        return float(self._threshold_config().get("lines", 0.7867))
+
+    def _max_reproj_error(self) -> float:
+        return float(self._threshold_config().get("max_reproj_error", 20.0))
+
+    def _vote_threshold(self) -> float:
+        return float(self._threshold_config().get("vote_threshold", 5.0))
+
+    def _pnl_refine(self) -> bool:
+        return bool(self._inference_config().get("pnl_refine", True))
+
+    def _ensure_runtime(self) -> dict[str, Any]:
+        if self._runtime is not None:
+            return self._runtime
+
+        os.environ.setdefault(
+            "XDG_CACHE_HOME",
+            str(self.upstream_root.parent.parent / ".cache"),
+        )
+        os.environ.setdefault(
+            "MPLCONFIGDIR",
+            str((self.upstream_root.parent.parent / ".cache" / "matplotlib")),
+        )
+
+        upstream_path = str(self.upstream_root.resolve())
+        if upstream_path not in sys.path:
+            sys.path.insert(0, upstream_path)
+
+        import torch
+        import torchvision.transforms as T
+        import torchvision.transforms.functional as f
+        import yaml
+        from PIL import Image
+
+        from model.cls_hrnet import get_cls_net
+        from model.cls_hrnet_l import get_cls_net as get_cls_net_l
+        from utils.utils_calib import FramebyFrameCalib
+        from utils.utils_heatmap import (
+            complete_keypoints,
+            coords_to_dict,
+            get_keypoints_from_heatmap_batch_maxpool,
+            get_keypoints_from_heatmap_batch_maxpool_l,
+        )
+
+        device_name = str(self._provider_config().get("device", "auto"))
+        if device_name == "auto":
+            if torch.cuda.is_available():
+                device = torch.device("cuda:0")
+            else:
+                device = torch.device("cpu")
+        else:
+            device = torch.device(device_name)
+
+        cfg = yaml.safe_load(
+            (self.upstream_root / "config" / "hrnetv2_w48.yaml").read_text(encoding="utf-8")
+        )
+        cfg_l = yaml.safe_load(
+            (self.upstream_root / "config" / "hrnetv2_w48_l.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        self._runtime = {
+            "Image": Image,
+            "FramebyFrameCalib": FramebyFrameCalib,
+            "T": T,
+            "f": f,
+            "cfg": cfg,
+            "cfg_l": cfg_l,
+            "device": device,
+            "torch": torch,
+            "get_cls_net": get_cls_net,
+            "get_cls_net_l": get_cls_net_l,
+            "get_keypoints_from_heatmap_batch_maxpool": get_keypoints_from_heatmap_batch_maxpool,
+            "get_keypoints_from_heatmap_batch_maxpool_l": get_keypoints_from_heatmap_batch_maxpool_l,
+            "coords_to_dict": coords_to_dict,
+            "complete_keypoints": complete_keypoints,
+            "transform": T.Resize((540, 960)),
+        }
+        return self._runtime
+
+    def _ensure_models(self) -> tuple[Any, Any]:
+        if self._models is not None:
+            return self._models
+
+        runtime = self._ensure_runtime()
+        torch = runtime["torch"]
+        device = runtime["device"]
+        get_cls_net = runtime["get_cls_net"]
+        get_cls_net_l = runtime["get_cls_net_l"]
+
+        loaded_state = torch.load(self._weights_kp_path(), map_location=device)
+        model_kp = get_cls_net(runtime["cfg"])
+        model_kp.load_state_dict(loaded_state)
+        model_kp.to(device)
+        model_kp.eval()
+
+        loaded_state_l = torch.load(self._weights_line_path(), map_location=device)
+        model_line = get_cls_net_l(runtime["cfg_l"])
+        model_line.load_state_dict(loaded_state_l)
+        model_line.to(device)
+        model_line.eval()
+
+        self._models = (model_kp, model_line)
+        return self._models
+
+    def _run_frame_inference(
+        self,
+        *,
+        frame: np.ndarray,
+        frame_idx: int,
+        timestamp_s: float,
+        cam: Any,
+        runtime: dict[str, Any],
+        model_kp: Any,
+        model_line: Any,
+    ) -> CalibrationFrame:
+        torch = runtime["torch"]
+        image = runtime["Image"].fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+        frame_tensor = runtime["f"].to_tensor(image).float().unsqueeze(0)
+        if frame_tensor.size()[-1] != 960:
+            frame_tensor = runtime["transform"](frame_tensor)
+        frame_tensor = frame_tensor.to(runtime["device"])
+        _, _, h, w = frame_tensor.size()
+
+        with torch.no_grad():
+            heatmaps = model_kp(frame_tensor)
+            heatmaps_l = model_line(frame_tensor)
+
+        kp_coords = runtime["get_keypoints_from_heatmap_batch_maxpool"](
+            heatmaps[:, :-1, :, :]
+        )
+        line_coords = runtime["get_keypoints_from_heatmap_batch_maxpool_l"](
+            heatmaps_l[:, :-1, :, :]
+        )
+        kp_dict = runtime["coords_to_dict"](kp_coords, threshold=self._kp_threshold())
+        lines_dict = runtime["coords_to_dict"](
+            line_coords, threshold=self._line_threshold()
+        )
+        kp_dict, lines_dict = runtime["complete_keypoints"](
+            kp_dict[0],
+            lines_dict[0],
+            w=w,
+            h=h,
+            normalize=True,
+        )
+
+        cam.update(kp_dict, lines_dict)
+        if self._solve_mode() == "homography":
+            return self._solve_homography_only(
+                cam=cam,
+                frame_idx=frame_idx,
+                timestamp_s=timestamp_s,
+            )
+
+        result = cam.heuristic_voting(
+            refine=False,
+            refine_lines=self._pnl_refine(),
+            th=self._vote_threshold(),
+        )
+        if result is None:
+            return CalibrationFrame(
+                frame_idx=frame_idx,
+                timestamp_s=timestamp_s,
+                confidence=0.0,
+                provider=self.name,
+                pitch_dimensions=self.pitch_dimensions,
+                diagnostics={"sampled": True, "reason": "no_solution"},
+            )
+
+        rep_err = float(result["rep_err"])
+        if rep_err > self._max_reproj_error():
+            return CalibrationFrame(
+                frame_idx=frame_idx,
+                timestamp_s=timestamp_s,
+                confidence=0.0,
+                provider=self.name,
+                pitch_dimensions=self.pitch_dimensions,
+                diagnostics={
+                    "sampled": True,
+                    "reason": "reprojection_error_too_high",
+                    "rep_err": rep_err,
+                    "mode": result.get("mode"),
+                    "use_ransac": result.get("use_ransac"),
+                    "calib_plane": result.get("calib_plane"),
+                },
+            )
+
+        camera_params = dict(result["cam_params"])
+        pitch_to_image = self._pitch_to_image_homography(camera_params)
+        image_to_pitch = invert_homography(pitch_to_image)
+        confidence = max(
+            0.0,
+            min(1.0, 1.0 - (rep_err / self._max_reproj_error())),
+        )
+        diagnostics = {
+            "sampled": True,
+            "rep_err": rep_err,
+            "mode": result.get("mode"),
+            "use_ransac": result.get("use_ransac"),
+            "calib_plane": result.get("calib_plane"),
+        }
+        camera_parameters = {
+            **camera_params,
+            "world_origin": "pitch_center",
+            "position_meters_top_left_origin": [
+                float(camera_params["position_meters"][0] + (self.pitch_dimensions.length_m / 2.0)),
+                float(camera_params["position_meters"][1] + (self.pitch_dimensions.width_m / 2.0)),
+                float(camera_params["position_meters"][2]),
+            ],
+        }
+        return CalibrationFrame(
+            frame_idx=frame_idx,
+            timestamp_s=timestamp_s,
+            image_to_pitch=image_to_pitch,
+            pitch_to_image=pitch_to_image,
+            confidence=confidence,
+            provider=self.name,
+            pitch_dimensions=self.pitch_dimensions,
+            camera_parameters=camera_parameters,
+            diagnostics=diagnostics,
+        )
+
+    def _solve_homography_only(
+        self,
+        *,
+        cam: Any,
+        frame_idx: int,
+        timestamp_s: float,
+    ) -> CalibrationFrame:
+        result = cam.heuristic_voting_ground(
+            refine_lines=self._pnl_refine(),
+            th=self._vote_threshold(),
+        )
+        if result is None:
+            return CalibrationFrame(
+                frame_idx=frame_idx,
+                timestamp_s=timestamp_s,
+                confidence=0.0,
+                provider=self.name,
+                pitch_dimensions=self.pitch_dimensions,
+                diagnostics={
+                    "sampled": True,
+                    "reason": "no_solution",
+                    "solve_mode": "homography",
+                },
+            )
+
+        rep_err = float(result["rep_err"])
+        if rep_err > self._max_reproj_error():
+            return CalibrationFrame(
+                frame_idx=frame_idx,
+                timestamp_s=timestamp_s,
+                confidence=0.0,
+                provider=self.name,
+                pitch_dimensions=self.pitch_dimensions,
+                diagnostics={
+                    "sampled": True,
+                    "reason": "reprojection_error_too_high",
+                    "solve_mode": "homography",
+                    "rep_err": rep_err,
+                    "use_ransac": result.get("use_ransac"),
+                },
+            )
+
+        centered_image_to_pitch = np.asarray(result["homography"], dtype=np.float64)
+        centered_to_canonical = np.array(
+            [
+                [1.0, 0.0, self.pitch_dimensions.length_m / 2.0],
+                [0.0, 1.0, self.pitch_dimensions.width_m / 2.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        image_to_pitch = centered_to_canonical @ centered_image_to_pitch
+        image_to_pitch /= image_to_pitch[-1, -1]
+        pitch_to_image = invert_homography(image_to_pitch)
+        confidence = max(
+            0.0,
+            min(1.0, 1.0 - (rep_err / self._max_reproj_error())),
+        )
+        return CalibrationFrame(
+            frame_idx=frame_idx,
+            timestamp_s=timestamp_s,
+            image_to_pitch=image_to_pitch,
+            pitch_to_image=pitch_to_image,
+            confidence=confidence,
+            provider=self.name,
+            pitch_dimensions=self.pitch_dimensions,
+            camera_parameters={},
+            diagnostics={
+                "sampled": True,
+                "solve_mode": "homography",
+                "rep_err": rep_err,
+                "use_ransac": result.get("use_ransac"),
+            },
+        )
+
+    def _pitch_to_image_homography(self, camera_params: dict[str, Any]) -> np.ndarray:
+        x_focal_length = float(camera_params["x_focal_length"])
+        y_focal_length = float(camera_params["y_focal_length"])
+        principal_point = np.asarray(camera_params["principal_point"], dtype=np.float64)
+        position = np.asarray(camera_params["position_meters"], dtype=np.float64)
+        rotation = np.asarray(camera_params["rotation_matrix"], dtype=np.float64)
+
+        intrinsic = np.array(
+            [
+                [x_focal_length, 0.0, principal_point[0]],
+                [0.0, y_focal_length, principal_point[1]],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        it_matrix = np.eye(4, dtype=np.float64)[:-1]
+        it_matrix[:, -1] = -position
+        projection = intrinsic @ (rotation @ it_matrix)
+        centered_pitch_to_image = projection[:, [0, 1, 3]]
+
+        canonical_to_centered = np.array(
+            [
+                [1.0, 0.0, -(self.pitch_dimensions.length_m / 2.0)],
+                [0.0, 1.0, -(self.pitch_dimensions.width_m / 2.0)],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        homography = centered_pitch_to_image @ canonical_to_centered
+        return homography / homography[-1, -1]
+
+    def _render_overlay_video(
+        self,
+        *,
+        source: Path,
+        frames: list[CalibrationFrame],
+        fps: float,
+        frame_width: int,
+        frame_height: int,
+        output_path: Path,
+        line_color_bgr: tuple[int, int, int],
+        line_thickness: int,
+    ) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        cap = cv2.VideoCapture(str(source))
+        writer = cv2.VideoWriter(
+            str(output_path),
+            cv2.VideoWriter_fourcc(*"mp4v"),
+            fps,
+            (frame_width, frame_height),
+        )
+
+        frame_idx = 0
+        polylines = self._pitch_overlay_polylines()
+        while cap.isOpened() and frame_idx < len(frames):
+            ret, frame = cap.read()
+            if not ret:
+                break
+            calibration = frames[frame_idx]
+            if calibration.pitch_to_image is not None:
+                overlay = frame.copy()
+                for polyline in polylines:
+                    projected = self._project_polyline(polyline, calibration.pitch_to_image)
+                    if projected.shape[0] < 2:
+                        continue
+                    overlay = cv2.polylines(
+                        overlay,
+                        [projected.astype(np.int32)],
+                        isClosed=False,
+                        color=line_color_bgr,
+                        thickness=line_thickness,
+                    )
+                writer.write(overlay)
+            else:
+                writer.write(frame)
+            frame_idx += 1
+
+        cap.release()
+        writer.release()
+
+    def _project_polyline(self, polyline: np.ndarray, homography: np.ndarray) -> np.ndarray:
+        homogeneous = np.concatenate(
+            [polyline, np.ones((polyline.shape[0], 1), dtype=np.float64)],
+            axis=1,
+        )
+        projected = homogeneous @ homography.T
+        valid_scale = np.abs(projected[:, 2]) > 1e-9
+        projected = projected[valid_scale]
+        if projected.size == 0:
+            return np.empty((0, 2), dtype=np.float64)
+        projected = projected[:, :2] / projected[:, 2:3]
+        finite = np.isfinite(projected[:, 0]) & np.isfinite(projected[:, 1])
+        return projected[finite]
+
+    def _pitch_overlay_polylines(self) -> list[np.ndarray]:
+        def rect(x0: float, y0: float, x1: float, y1: float) -> np.ndarray:
+            return np.array(
+                [
+                    [x0, y0],
+                    [x1, y0],
+                    [x1, y1],
+                    [x0, y1],
+                    [x0, y0],
+                ],
+                dtype=np.float64,
+            )
+
+        def circle(cx: float, cy: float, radius: float, samples: int = 180) -> np.ndarray:
+            angles = np.linspace(0.0, 2.0 * np.pi, samples)
+            return np.column_stack(
+                [cx + (radius * np.cos(angles)), cy + (radius * np.sin(angles))]
+            ).astype(np.float64)
+
+        return [
+            rect(0.0, 0.0, 105.0, 68.0),
+            np.array([[52.5, 0.0], [52.5, 68.0]], dtype=np.float64),
+            rect(0.0, 13.84, 16.5, 54.16),
+            rect(88.5, 13.84, 105.0, 54.16),
+            rect(0.0, 24.84, 5.5, 43.16),
+            rect(99.5, 24.84, 105.0, 43.16),
+            circle(52.5, 34.0, 9.15),
+        ]

--- a/trackers/calibration/smoothing.py
+++ b/trackers/calibration/smoothing.py
@@ -111,12 +111,13 @@ def _interpolate_between_frames(
 
     alpha = (target_frame.frame_idx - previous_frame.frame_idx) / total_gap
     control_points = _control_points(previous_frame)
-    previous_image_points = _apply_homography(control_points, previous_frame.pitch_to_image)
+    previous_image_points = _apply_homography(
+        control_points, previous_frame.pitch_to_image
+    )
     next_image_points = _apply_homography(control_points, next_frame.pitch_to_image)
     interpolated_image_points = (
-        (1.0 - alpha) * previous_image_points
-        + alpha * next_image_points
-    )
+        1.0 - alpha
+    ) * previous_image_points + alpha * next_image_points
 
     pitch_to_image, _ = cv2.findHomography(
         control_points.astype(np.float32),

--- a/trackers/calibration/smoothing.py
+++ b/trackers/calibration/smoothing.py
@@ -1,0 +1,218 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import cv2
+import numpy as np
+
+from trackers.calibration.types import CalibrationFrame
+
+
+class HoldLastCalibration:
+    """Carry forward the last trustworthy calibration across short gaps.
+
+    This is intentionally conservative: it does not attempt to optimize the
+    homography itself, it only prevents short calibration dropouts from causing
+    immediate loss of pitch coordinates. A more advanced backend can replace
+    this with model-aware smoothing later.
+    """
+
+    def __init__(self, max_gap_frames: int = 15, min_confidence: float = 0.4) -> None:
+        self.max_gap_frames = max_gap_frames
+        self.min_confidence = min_confidence
+        self._last_good_frame: CalibrationFrame | None = None
+
+    def update(self, frame: CalibrationFrame) -> CalibrationFrame:
+        confidence = frame.confidence if frame.confidence is not None else 1.0
+        is_good = frame.has_homography and confidence >= self.min_confidence
+
+        if is_good:
+            self._last_good_frame = frame
+            return frame
+
+        if self._last_good_frame is None:
+            return frame
+
+        frame_gap = frame.frame_idx - self._last_good_frame.frame_idx
+        if frame_gap > self.max_gap_frames:
+            return frame
+
+        diagnostics = dict(frame.diagnostics)
+        diagnostics.update(
+            {
+                "held_from_frame_idx": self._last_good_frame.frame_idx,
+                "held_frame_gap": frame_gap,
+            }
+        )
+        return replace(
+            frame,
+            image_to_pitch=self._last_good_frame.image_to_pitch,
+            pitch_to_image=self._last_good_frame.pitch_to_image,
+            confidence=self._last_good_frame.confidence,
+            provider=self._last_good_frame.provider,
+            camera_parameters=dict(self._last_good_frame.camera_parameters),
+            diagnostics=diagnostics,
+        )
+
+
+def _is_good_frame(frame: CalibrationFrame, min_confidence: float) -> bool:
+    confidence = frame.confidence if frame.confidence is not None else 1.0
+    return frame.has_homography and confidence >= min_confidence
+
+
+def _apply_homography(points: np.ndarray, homography: np.ndarray) -> np.ndarray:
+    homogeneous = np.concatenate(
+        [points, np.ones((points.shape[0], 1), dtype=np.float64)],
+        axis=1,
+    )
+    projected = homogeneous @ homography.T
+    projected = projected[:, :2] / projected[:, 2:3]
+    return projected
+
+
+def _control_points(frame: CalibrationFrame) -> np.ndarray:
+    length_m = frame.pitch_dimensions.length_m
+    width_m = frame.pitch_dimensions.width_m
+    return np.array(
+        [
+            [0.0, 0.0],
+            [length_m / 2.0, 0.0],
+            [length_m, 0.0],
+            [0.0, width_m / 2.0],
+            [length_m / 2.0, width_m / 2.0],
+            [length_m, width_m / 2.0],
+            [0.0, width_m],
+            [length_m / 2.0, width_m],
+            [length_m, width_m],
+            [11.0, width_m / 2.0],
+            [length_m - 11.0, width_m / 2.0],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _interpolate_between_frames(
+    previous_frame: CalibrationFrame,
+    next_frame: CalibrationFrame,
+    target_frame: CalibrationFrame,
+) -> CalibrationFrame:
+    if previous_frame.pitch_to_image is None or next_frame.pitch_to_image is None:
+        return target_frame
+
+    total_gap = next_frame.frame_idx - previous_frame.frame_idx
+    if total_gap <= 1:
+        return target_frame
+
+    alpha = (target_frame.frame_idx - previous_frame.frame_idx) / total_gap
+    control_points = _control_points(previous_frame)
+    previous_image_points = _apply_homography(control_points, previous_frame.pitch_to_image)
+    next_image_points = _apply_homography(control_points, next_frame.pitch_to_image)
+    interpolated_image_points = (
+        (1.0 - alpha) * previous_image_points
+        + alpha * next_image_points
+    )
+
+    pitch_to_image, _ = cv2.findHomography(
+        control_points.astype(np.float32),
+        interpolated_image_points.astype(np.float32),
+        0,
+    )
+    if pitch_to_image is None:
+        return target_frame
+
+    image_to_pitch = np.linalg.inv(pitch_to_image)
+    image_to_pitch /= image_to_pitch[-1, -1]
+    pitch_to_image /= pitch_to_image[-1, -1]
+    previous_confidence = previous_frame.confidence or 0.0
+    next_confidence = next_frame.confidence or 0.0
+    diagnostics = dict(target_frame.diagnostics)
+    diagnostics.update(
+        {
+            "interpolated_from_frame_idx": previous_frame.frame_idx,
+            "interpolated_to_frame_idx": next_frame.frame_idx,
+            "interpolation_alpha": alpha,
+        }
+    )
+    return replace(
+        target_frame,
+        image_to_pitch=image_to_pitch,
+        pitch_to_image=pitch_to_image,
+        confidence=((1.0 - alpha) * previous_confidence) + (alpha * next_confidence),
+        provider=previous_frame.provider,
+        camera_parameters={},
+        diagnostics=diagnostics,
+    )
+
+
+def interpolate_calibration_gaps(
+    frames: list[CalibrationFrame],
+    *,
+    max_gap_frames: int = 15,
+    min_confidence: float = 0.4,
+    edge_strategy: str = "hold",
+) -> list[CalibrationFrame]:
+    """Interpolate homographies between valid neighbors and optionally hold edges."""
+    if not frames:
+        return []
+
+    interpolated_frames = list(frames)
+    valid_indices = [
+        index
+        for index, frame in enumerate(frames)
+        if _is_good_frame(frame, min_confidence=min_confidence)
+    ]
+    for previous_index, next_index in zip(valid_indices, valid_indices[1:]):
+        previous_frame = frames[previous_index]
+        next_frame = frames[next_index]
+        gap_size = next_frame.frame_idx - previous_frame.frame_idx - 1
+        if gap_size <= 0 or gap_size > max_gap_frames:
+            continue
+
+        for target_index in range(previous_index + 1, next_index):
+            if interpolated_frames[target_index].has_homography:
+                continue
+            interpolated_frames[target_index] = _interpolate_between_frames(
+                previous_frame=previous_frame,
+                next_frame=next_frame,
+                target_frame=interpolated_frames[target_index],
+            )
+
+    if edge_strategy == "hold":
+        holder = HoldLastCalibration(
+            max_gap_frames=max_gap_frames,
+            min_confidence=min_confidence,
+        )
+        interpolated_frames = [holder.update(frame) for frame in interpolated_frames]
+
+    return interpolated_frames
+
+
+def fill_calibration_gaps(
+    frames: list[CalibrationFrame],
+    *,
+    max_gap_frames: int = 15,
+    min_confidence: float = 0.4,
+    mode: str = "hold",
+    edge_strategy: str = "hold",
+) -> list[CalibrationFrame]:
+    """Apply the configured gap-filling strategy to a calibration sequence."""
+    if mode == "interpolate":
+        return interpolate_calibration_gaps(
+            frames,
+            max_gap_frames=max_gap_frames,
+            min_confidence=min_confidence,
+            edge_strategy=edge_strategy,
+        )
+    if mode != "hold":
+        raise ValueError(f"Unsupported calibration smoothing mode: {mode}")
+    smoother = HoldLastCalibration(
+        max_gap_frames=max_gap_frames,
+        min_confidence=min_confidence,
+    )
+    return [smoother.update(frame) for frame in frames]

--- a/trackers/calibration/types.py
+++ b/trackers/calibration/types.py
@@ -1,0 +1,141 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+def _matrix_from_value(value: object) -> np.ndarray | None:
+    if value is None:
+        return None
+    matrix = np.asarray(value, dtype=np.float64)
+    if matrix.shape != (3, 3):
+        raise ValueError(f"Expected a 3x3 homography matrix, got {matrix.shape}")
+    return matrix
+
+
+def _matrix_to_value(matrix: np.ndarray | None) -> list[list[float]] | None:
+    if matrix is None:
+        return None
+    return np.asarray(matrix, dtype=np.float64).tolist()
+
+
+@dataclass(frozen=True)
+class PitchDimensions:
+    """Physical pitch dimensions in meters."""
+
+    length_m: float = 105.0
+    width_m: float = 68.0
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "length_m": self.length_m,
+            "width_m": self.width_m,
+        }
+
+
+@dataclass(slots=True)
+class CalibrationFrame:
+    """Calibration output for a single video frame.
+
+    The canonical convention in this scaffold is that pitch coordinates are in
+    metric space using a top-left pitch origin:
+    - x grows along the pitch length
+    - y grows across the pitch width
+    """
+
+    frame_idx: int
+    timestamp_s: float
+    image_to_pitch: np.ndarray | None = None
+    pitch_to_image: np.ndarray | None = None
+    confidence: float | None = None
+    provider: str | None = None
+    pitch_dimensions: PitchDimensions = field(default_factory=PitchDimensions)
+    camera_parameters: dict[str, Any] = field(default_factory=dict)
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.image_to_pitch = _matrix_from_value(self.image_to_pitch)
+        self.pitch_to_image = _matrix_from_value(self.pitch_to_image)
+
+    @property
+    def has_homography(self) -> bool:
+        return self.image_to_pitch is not None and self.pitch_to_image is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "frame_idx": self.frame_idx,
+            "timestamp_s": self.timestamp_s,
+            "image_to_pitch": _matrix_to_value(self.image_to_pitch),
+            "pitch_to_image": _matrix_to_value(self.pitch_to_image),
+            "confidence": self.confidence,
+            "provider": self.provider,
+            "pitch_dimensions": self.pitch_dimensions.to_dict(),
+            "camera_parameters": self.camera_parameters,
+            "diagnostics": self.diagnostics,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CalibrationFrame":
+        pitch_data = data.get("pitch_dimensions", {})
+        return cls(
+            frame_idx=int(data["frame_idx"]),
+            timestamp_s=float(data["timestamp_s"]),
+            image_to_pitch=data.get("image_to_pitch"),
+            pitch_to_image=data.get("pitch_to_image"),
+            confidence=(
+                None
+                if data.get("confidence") is None
+                else float(data.get("confidence"))
+            ),
+            provider=data.get("provider"),
+            pitch_dimensions=PitchDimensions(
+                length_m=float(pitch_data.get("length_m", 105.0)),
+                width_m=float(pitch_data.get("width_m", 68.0)),
+            ),
+            camera_parameters=dict(data.get("camera_parameters", {})),
+            diagnostics=dict(data.get("diagnostics", {})),
+        )
+
+
+@dataclass(frozen=True)
+class TrackProjection:
+    """Pitch-space position for a tracked object on a single frame."""
+
+    frame_idx: int
+    track_id: int
+    image_x: float
+    image_y: float
+    pitch_x_m: float
+    pitch_y_m: float
+    pitch_x_norm: float
+    pitch_y_norm: float
+    in_pitch_bounds: bool
+    timestamp_s: float | None = None
+    calibration_confidence: float | None = None
+    source_confidence: float | None = None
+    provider: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "frame_idx": self.frame_idx,
+            "track_id": self.track_id,
+            "image_x": self.image_x,
+            "image_y": self.image_y,
+            "pitch_x_m": self.pitch_x_m,
+            "pitch_y_m": self.pitch_y_m,
+            "pitch_x_norm": self.pitch_x_norm,
+            "pitch_y_norm": self.pitch_y_norm,
+            "in_pitch_bounds": self.in_pitch_bounds,
+            "timestamp_s": self.timestamp_s,
+            "calibration_confidence": self.calibration_confidence,
+            "source_confidence": self.source_confidence,
+            "provider": self.provider,
+        }

--- a/trackers/calibration/types.py
+++ b/trackers/calibration/types.py
@@ -83,7 +83,7 @@ class CalibrationFrame:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "CalibrationFrame":
+    def from_dict(cls, data: dict[str, Any]) -> CalibrationFrame:
         pitch_data = data.get("pitch_dimensions", {})
         return cls(
             frame_idx=int(data["frame_idx"]),

--- a/trackers/scripts/track.py
+++ b/trackers/scripts/track.py
@@ -16,10 +16,12 @@ import numpy as np
 import supervision as sv
 
 from trackers import frames_from_source
+from trackers.annotators.trace import MotionAwareTraceAnnotator
 from trackers.core.base import BaseTracker
 from trackers.io.mot import _load_mot_file, _mot_frame_to_detections, _MOTOutput
 from trackers.io.paths import _resolve_video_output_path, _validate_output_path
 from trackers.io.video import _DEFAULT_OUTPUT_FPS, _DisplayWindow, _VideoOutput
+from trackers.motion.estimator import MotionEstimator
 from trackers.scripts.progress import _classify_source, _SourceInfo, _TrackingProgress
 from trackers.utils.device import _best_device
 
@@ -28,6 +30,7 @@ DEFAULT_MODEL = "rfdetr-nano"
 DEFAULT_TRACKER = "bytetrack"
 DEFAULT_CONFIDENCE = 0.5
 DEFAULT_DEVICE = "auto"
+DEFAULT_TRAJECTORY_SECONDS = 1.0
 
 # Visualization
 COLOR_PALETTE = sv.ColorPalette.from_hex(
@@ -227,6 +230,26 @@ def add_track_subparser(subparsers: argparse._SubParsersAction) -> None:
         dest="show_trajectories",
         help="Draw track trajectories.",
     )
+    vis_group.add_argument(
+        "--motion-aware-trajectories",
+        action="store_true",
+        dest="motion_aware_trajectories",
+        help=(
+            "Use camera-motion-compensated trajectories when drawing traces. "
+            "Requires --show-trajectories."
+        ),
+    )
+    vis_group.add_argument(
+        "--trajectory-seconds",
+        type=float,
+        default=DEFAULT_TRAJECTORY_SECONDS,
+        dest="trajectory_seconds",
+        metavar="SECONDS",
+        help=(
+            "How many seconds of trajectory history to keep on screen. "
+            f"Default: {DEFAULT_TRAJECTORY_SECONDS}"
+        ),
+    )
 
     parser.set_defaults(func=run_track)
 
@@ -393,6 +416,10 @@ def _run_with_source(
     """Run tracking with a frame source (video, webcam, images)."""
     frame_gen = frames_from_source(args.source)
     source_info = _classify_source(args.source)
+    trajectory_trace_length = _trajectory_trace_length(
+        source_info.fps or _DEFAULT_OUTPUT_FPS,
+        args.trajectory_seconds,
+    )
 
     # Setup annotators
     annotators, label_annotator = _init_annotators(
@@ -403,11 +430,23 @@ def _run_with_source(
         show_confidence=args.show_confidence,
     )
     trace_annotator = None
+    motion_estimator = None
     if args.show_trajectories:
-        trace_annotator = sv.TraceAnnotator(
-            color=COLOR_PALETTE,
-            color_lookup=sv.ColorLookup.TRACK,
-        )
+        if args.motion_aware_trajectories:
+            trace_annotator = MotionAwareTraceAnnotator(
+                color=COLOR_PALETTE,
+                position=sv.Position.BOTTOM_CENTER,
+                trace_length=trajectory_trace_length,
+                color_lookup=sv.ColorLookup.TRACK,
+            )
+            motion_estimator = MotionEstimator()
+        else:
+            trace_annotator = sv.TraceAnnotator(
+                color=COLOR_PALETTE,
+                position=sv.Position.BOTTOM_CENTER,
+                trace_length=trajectory_trace_length,
+                color_lookup=sv.ColorLookup.TRACK,
+            )
 
     display_ctx = _DisplayWindow() if args.display else nullcontext()
 
@@ -454,7 +493,15 @@ def _run_with_source(
                 if args.display or args.output:
                     annotated = frame.copy()
                     if trace_annotator is not None:
-                        annotated = trace_annotator.annotate(annotated, tracked)
+                        if motion_estimator is not None:
+                            coord_transform = motion_estimator.update(frame)
+                            annotated = trace_annotator.annotate(
+                                annotated,
+                                tracked,
+                                coord_transform=coord_transform,
+                            )
+                        else:
+                            annotated = trace_annotator.annotate(annotated, tracked)
                     for annotator in annotators:
                         annotated = annotator.annotate(annotated, tracked)
                     if label_annotator is not None:
@@ -482,6 +529,13 @@ def _run_with_source(
         pass
 
     return 0
+
+
+def _trajectory_trace_length(fps: float, seconds: float) -> int:
+    """Convert a trajectory duration in seconds to a frame-history length."""
+    safe_seconds = max(seconds, 0.0)
+    safe_fps = fps if fps > 0 else _DEFAULT_OUTPUT_FPS
+    return max(2, int(round(safe_fps * safe_seconds)))
 
 
 def _resolve_track_id_filter(track_ids_arg: str | None) -> list[int] | None:


### PR DESCRIPTION
## What changed

This adds a pitch calibration and pitch-space rendering toolkit on top of the existing tracking workflow.

- add a calibration package with shared types, projection helpers, smoothing, export helpers, and a PnLCalib provider
- add CLI/scripts for video calibration, MOT analysis, track projection into pitch coordinates, sticky pitch-space rendering, and easier tracking runs
- expose the calibration primitives from the package root and add motion-aware trajectory options in the tracking CLI
- add calibration configs and focused tests for pitch geometry, projection, and smoothing

## Why

We needed a practical path from broadcast soccer video to usable pitch homographies and player pitch coordinates, plus a way to render pitch-sticky visual overlays for evaluation.

## Validation

- `pytest test/calibration -q`
- compile checks for `trackers/calibration`, `trackers/scripts/track.py`, and `scripts/`
