### PR TITLE
geo: fix all audit findings from GEO-AUDIT-REPORT

### DIFF
--- a/docs/hooks/schema_inject.py
+++ b/docs/hooks/schema_inject.py
@@ -9,6 +9,10 @@
 Reads page.meta.description and page.title to build a TechArticle schema object,
 then stores the serialized JSON string in page.meta['json_ld_article'] so that
 docs/overrides/main.html can emit it inside <script type="application/ld+json">.
+
+Also injects:
+- FAQPage JSON-LD on the homepage (index.md)
+- BreadcrumbList JSON-LD for pages with navigation ancestors
 """
 
 import json
@@ -17,6 +21,100 @@ import json
 # Must match the Organization @id in docs/overrides/main.html.
 ORG_ID = "https://roboflow.com/#organization"
 
+# Fixed FAQ entries for the homepage FAQPage schema.
+_HOMEPAGE_FAQ = [
+    {
+        "question": "Which tracker should I use?",
+        "answer": (
+            "Start with ByteTrack — it performs best across two out of four benchmarks "
+            "and handles variable-confidence detectors well. Use SORT if speed or device "
+            "constraints require the lightest possible tracker. Use OC-SORT when camera "
+            "motion is significant or objects follow non-linear paths."
+        ),
+    },
+    {
+        "question": "What is multi-object tracking?",
+        "answer": (
+            "Multi-object tracking assigns a persistent ID to each detected object across "
+            "video frames, maintaining continuity through occlusions, re-entries, and "
+            "camera motion. Trackers use a detect-then-track approach: a detector runs on "
+            "each frame, and the tracker links detections across time using motion models "
+            "and spatial matching."
+        ),
+    },
+    {
+        "question": "Do I need a specific detector?",
+        "answer": (
+            "No. Roboflow Trackers works with any detector that outputs "
+            "supervision.Detections objects. The library ships example pipelines using "
+            "RF-DETR but is compatible with YOLO, Detectron2, and any custom model."
+        ),
+    },
+    {
+        "question": "How do I evaluate my tracker?",
+        "answer": (
+            "Run trackers eval against a directory of ground-truth MOT-format text files. "
+            "The evaluation pipeline computes HOTA, IDF1, and MOTA and prints a "
+            "per-sequence and combined score table."
+        ),
+    },
+    {
+        "question": "What MOT datasets does the library support?",
+        "answer": (
+            "MOT17, MOT20, SportsMOT, SoccerNet-tracking, and DanceTrack are supported "
+            "for download and evaluation. Use trackers download <dataset> to pull frames, "
+            "annotations, and pre-computed detections."
+        ),
+    },
+]
+
+
+def _build_breadcrumbs(page, config, nav):
+    """Build BreadcrumbList JSON-LD from navigation hierarchy.
+
+    Returns None if the page is at the root level (no meaningful breadcrumb).
+    """
+    site_url = config.get("site_url", "https://trackers.roboflow.com").rstrip("/")
+
+    # Walk the nav tree to find the path of sections leading to this page.
+    crumbs = [{"name": "Home", "url": site_url + "/"}]
+
+    def _find_in_nav(items, path):
+        """Recursively search nav for the page, building the path of sections."""
+        for item in items:
+            if hasattr(item, "children") and item.children:
+                path.append({"name": item.title, "url": ""})
+                if _find_in_nav(item.children, path):
+                    return True
+                path.pop()
+            elif hasattr(item, "file") and item.file and item.file.src_path == page.file.src_path:
+                return True
+        return False
+
+    section_path = []
+    _find_in_nav(nav.items, section_path)
+
+    if not section_path:
+        return None
+
+    crumbs.extend(section_path)
+    crumbs.append({"name": page.title or "", "url": page.canonical_url or ""})
+
+    items = []
+    for i, crumb in enumerate(crumbs, start=1):
+        items.append({
+            "@type": "ListItem",
+            "position": i,
+            "name": crumb["name"],
+            **({"item": crumb["url"]} if crumb["url"] else {}),
+        })
+
+    return {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": items,
+    }
+
 
 def on_page_context(context, page, config, nav):  # type: ignore[no-untyped-def]
     """Build TechArticle + speakable JSON-LD for the page and store in page.meta."""
@@ -24,41 +122,88 @@ def on_page_context(context, page, config, nav):  # type: ignore[no-untyped-def]
     title = page.title or ""
     canonical = page.canonical_url or ""
 
-    if not description:
-        return context
+    if page.meta is None:
+        page.meta = {}  # type: ignore[assignment]
 
     # Derive base URL from mkdocs.yml site_url so this hook stays in sync with
     # deployment configuration and never drifts from the actual canonical base.
     site_url = config.get("site_url", "https://trackers.roboflow.com").rstrip("/")
 
-    article = {
-        "@context": "https://schema.org",
-        "@type": "TechArticle",
-        "headline": title,
-        "description": description,
-        "url": canonical,
-        "author": {
-            "@type": "Organization",
-            "@id": ORG_ID,
-            "name": "Roboflow",
-        },
-        "publisher": {
-            "@type": "Organization",
-            "@id": ORG_ID,
-            "name": "Roboflow",
-            "logo": {
+    # ── TechArticle JSON-LD (pages with description only) ──
+    if description:
+        article = {
+            "@context": "https://schema.org",
+            "@type": "TechArticle",
+            "headline": title,
+            "description": description,
+            "url": canonical,
+            "mainEntityOfPage": {
+                "@type": "WebPage",
+                "@id": canonical,
+            },
+            "image": {
                 "@type": "ImageObject",
                 "url": f"{site_url}/assets/logo-trackers-violet.svg",
             },
-        },
-        "speakable": {
-            "@type": "SpeakableSpecification",
-            "cssSelector": ["h1", ".md-content p:first-of-type"],
-        },
-    }
+            "author": {
+                "@type": "Organization",
+                "@id": ORG_ID,
+                "name": "Roboflow",
+            },
+            "publisher": {
+                "@type": "Organization",
+                "@id": ORG_ID,
+                "name": "Roboflow",
+                "logo": {
+                    "@type": "ImageObject",
+                    "url": f"{site_url}/assets/logo-trackers-violet.svg",
+                },
+            },
+            "speakable": {
+                "@type": "SpeakableSpecification",
+                "cssSelector": ["h1", ".md-content p:first-of-type"],
+            },
+        }
 
-    if page.meta is None:
-        page.meta = {}  # type: ignore[assignment]
-    page.meta["json_ld_article"] = json.dumps(article, ensure_ascii=False, indent=2)
+        # datePublished / dateModified from git-revision-date-localized plugin.
+        # The plugin sets page.meta keys before hooks run.
+        date_modified = (page.meta or {}).get("git_revision_date_localized", "")
+        date_created = (page.meta or {}).get("git_creation_date_localized", "")
+        if date_modified:
+            article["dateModified"] = date_modified
+        if date_created:
+            article["datePublished"] = date_created
+
+        page.meta["json_ld_article"] = json.dumps(
+            article, ensure_ascii=False, indent=2
+        )
+
+    # ── FAQPage JSON-LD (homepage only) ──
+    if page.file.src_path == "index.md":
+        faq_schema = {
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": [
+                {
+                    "@type": "Question",
+                    "name": entry["question"],
+                    "acceptedAnswer": {
+                        "@type": "Answer",
+                        "text": entry["answer"],
+                    },
+                }
+                for entry in _HOMEPAGE_FAQ
+            ],
+        }
+        page.meta["json_ld_faq"] = json.dumps(
+            faq_schema, ensure_ascii=False, indent=2
+        )
+
+    # ── BreadcrumbList JSON-LD ──
+    breadcrumbs = _build_breadcrumbs(page, config, nav)
+    if breadcrumbs:
+        page.meta["json_ld_breadcrumbs"] = json.dumps(
+            breadcrumbs, ensure_ascii=False, indent=2
+        )
 
     return context

--- a/docs/hooks/schema_inject.py
+++ b/docs/hooks/schema_inject.py
@@ -13,6 +13,8 @@ docs/overrides/main.html can emit it inside <script type="application/ld+json">.
 Also injects:
 - FAQPage JSON-LD on the homepage (index.md)
 - BreadcrumbList JSON-LD for pages with navigation ancestors
+- Dataset JSON-LD on the comparison page
+- Citation (ScholarlyArticle) on algorithm pages
 """
 
 import json
@@ -22,6 +24,9 @@ import json
 ORG_ID = "https://roboflow.com/#organization"
 
 # Fixed FAQ entries for the homepage FAQPage schema.
+# NOTE: dataset list must stay in sync with trackers/datasets/manifest.py.
+# Currently only MOT17 and SportsMOT are downloadable; DanceTrack and SoccerNet
+# are "coming soon" (see docs/learn/download.md).
 _HOMEPAGE_FAQ = [
     {
         "question": "Which tracker should I use?",
@@ -61,25 +66,74 @@ _HOMEPAGE_FAQ = [
     {
         "question": "What MOT datasets does the library support?",
         "answer": (
-            "MOT17, MOT20, SportsMOT, SoccerNet-tracking, and DanceTrack are supported "
-            "for download and evaluation. Use trackers download <dataset> to pull frames, "
-            "annotations, and pre-computed detections."
+            "MOT17 and SportsMOT are supported for download and evaluation. "
+            "Use trackers download <dataset> to pull frames, annotations, and "
+            "pre-computed detections. DanceTrack and SoccerNet-tracking support "
+            "is coming soon."
         ),
     },
 ]
 
+# Academic citations for algorithm pages (keyed by page.file.src_path).
+_CITATIONS = {
+    "trackers/sort.md": {
+        "name": "SORT: A Simple, Online and Realtime Tracking",
+        "url": "https://arxiv.org/abs/1602.00763",
+        "author": "Alex Bewley et al.",
+    },
+    "trackers/bytetrack.md": {
+        "name": "ByteTrack: Multi-Object Tracking by Associating Every Detection Box",
+        "url": "https://arxiv.org/abs/2110.06864",
+        "author": "Zhang et al.",
+    },
+    "trackers/ocsort.md": {
+        "name": "Observation-Centric SORT: Rethinking SORT for Robust Multi-Object Tracking",
+        "url": "https://arxiv.org/abs/2203.14360",
+        "author": "Cao et al.",
+    },
+}
 
-def _build_breadcrumbs(page, config, nav):
+# Benchmark datasets shown on the comparison page.
+_BENCHMARK_DATASETS = [
+    {
+        "name": "MOT17",
+        "url": "https://motchallenge.net/data/MOT17/",
+        "citation": "https://arxiv.org/abs/1603.00831",
+    },
+    {
+        "name": "SportsMOT",
+        "url": "https://deeperaction.github.io/sportsmot/",
+        "citation": "https://arxiv.org/abs/2304.05170",
+    },
+    {
+        "name": "SoccerNet-tracking",
+        "url": "https://www.soccer-net.org/tasks/tracking",
+        "citation": "https://arxiv.org/abs/2204.12438",
+    },
+    {
+        "name": "DanceTrack",
+        "url": "https://dancetrack.github.io/",
+        "citation": "https://arxiv.org/abs/2111.14690",
+    },
+]
+
+
+def _build_breadcrumbs(page, config, nav):  # type: ignore[no-untyped-def]
     """Build BreadcrumbList JSON-LD from navigation hierarchy.
 
-    Returns None if the page is at the root level (no meaningful breadcrumb).
+    Returns None if the page is at the root level (no meaningful breadcrumb)
+    or if the page is the homepage (to avoid "Home > Home > ..." duplication).
     """
+    # Skip breadcrumbs for the homepage to avoid "Home > Home > ..." duplication.
+    if page.file.src_path == "index.md":
+        return None
+
     site_url = config.get("site_url", "https://trackers.roboflow.com").rstrip("/")
 
     # Walk the nav tree to find the path of sections leading to this page.
     crumbs = [{"name": "Home", "url": site_url + "/"}]
 
-    def _find_in_nav(items, path):
+    def _find_in_nav(items, path):  # type: ignore[no-untyped-def]
         """Recursively search nav for the page, building the path of sections."""
         for item in items:
             if hasattr(item, "children") and item.children:
@@ -87,11 +141,15 @@ def _build_breadcrumbs(page, config, nav):
                 if _find_in_nav(item.children, path):
                     return True
                 path.pop()
-            elif hasattr(item, "file") and item.file and item.file.src_path == page.file.src_path:
+            elif (
+                hasattr(item, "file")
+                and item.file
+                and item.file.src_path == page.file.src_path
+            ):
                 return True
         return False
 
-    section_path = []
+    section_path: list[dict[str, str]] = []
     _find_in_nav(nav.items, section_path)
 
     if not section_path:
@@ -102,12 +160,14 @@ def _build_breadcrumbs(page, config, nav):
 
     items = []
     for i, crumb in enumerate(crumbs, start=1):
-        items.append({
-            "@type": "ListItem",
-            "position": i,
-            "name": crumb["name"],
-            **({"item": crumb["url"]} if crumb["url"] else {}),
-        })
+        items.append(
+            {
+                "@type": "ListItem",
+                "position": i,
+                "name": crumb["name"],
+                **({"item": crumb["url"]} if crumb["url"] else {}),
+            }
+        )
 
     return {
         "@context": "https://schema.org",
@@ -166,13 +226,33 @@ def on_page_context(context, page, config, nav):  # type: ignore[no-untyped-def]
         }
 
         # datePublished / dateModified from git-revision-date-localized plugin.
-        # The plugin sets page.meta keys before hooks run.
-        date_modified = (page.meta or {}).get("git_revision_date_localized", "")
-        date_created = (page.meta or {}).get("git_creation_date_localized", "")
+        # Prefer the raw iso_date keys which are always YYYY-MM-DD regardless of
+        # the plugin's "type" setting in mkdocs.yml (set by plugin v1.5+ in
+        # on_page_markdown, which runs before hooks). Falls back to the
+        # formatted string key — safe as long as mkdocs.yml keeps type: iso_date.
+        date_modified = (page.meta or {}).get(
+            "git_revision_date_localized_raw_iso_date",
+            (page.meta or {}).get("git_revision_date_localized", ""),
+        )
+        date_created = (page.meta or {}).get(
+            "git_creation_date_localized_raw_iso_date",
+            (page.meta or {}).get("git_creation_date_localized", ""),
+        )
         if date_modified:
             article["dateModified"] = date_modified
         if date_created:
             article["datePublished"] = date_created
+
+        # Add citation for algorithm pages.
+        src_path = page.file.src_path
+        if src_path in _CITATIONS:
+            cite = _CITATIONS[src_path]
+            article["citation"] = {
+                "@type": "ScholarlyArticle",
+                "name": cite["name"],
+                "url": cite["url"],
+                "author": {"@type": "Person", "name": cite["author"]},
+            }
 
         page.meta["json_ld_article"] = json.dumps(
             article, ensure_ascii=False, indent=2
@@ -205,5 +285,24 @@ def on_page_context(context, page, config, nav):  # type: ignore[no-untyped-def]
         page.meta["json_ld_breadcrumbs"] = json.dumps(
             breadcrumbs, ensure_ascii=False, indent=2
         )
+
+    # ── Dataset JSON-LD (comparison page only) ──
+    if page.file.src_path == "trackers/comparison.md":
+        datasets = []
+        for ds in _BENCHMARK_DATASETS:
+            datasets.append(
+                json.dumps(
+                    {
+                        "@context": "https://schema.org",
+                        "@type": "Dataset",
+                        "name": ds["name"],
+                        "url": ds["url"],
+                        "citation": ds["citation"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        page.meta["json_ld_datasets"] = datasets
 
     return context

--- a/docs/hooks/schema_inject.py
+++ b/docs/hooks/schema_inject.py
@@ -133,14 +133,33 @@ def _build_breadcrumbs(page, config, nav):  # type: ignore[no-untyped-def]
     # Walk the nav tree to find the path of sections leading to this page.
     crumbs = [{"name": "Home", "url": site_url + "/"}]
 
+    def _resolve_nav_item_url(item):  # type: ignore[no-untyped-def]
+        """Return an absolute URL for a nav item when it maps to a concrete page."""
+        raw_url = getattr(item, "url", None)
+        if not raw_url and hasattr(item, "file") and item.file:
+            raw_url = getattr(item.file, "url", None)
+
+        if not raw_url:
+            return ""
+        if raw_url.startswith(("http://", "https://")):
+            return raw_url
+        if raw_url.startswith("/"):
+            return site_url + raw_url
+        return site_url + "/" + raw_url.lstrip("/")
+
     def _find_in_nav(items, path):  # type: ignore[no-untyped-def]
         """Recursively search nav for the page, building the path of sections."""
         for item in items:
             if hasattr(item, "children") and item.children:
-                path.append({"name": item.title, "url": ""})
+                section_url = _resolve_nav_item_url(item)
+                appended = False
+                if section_url:
+                    path.append({"name": item.title, "url": section_url})
+                    appended = True
                 if _find_in_nav(item.children, path):
                     return True
-                path.pop()
+                if appended:
+                    path.pop()
             elif (
                 hasattr(item, "file")
                 and item.file

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart — Multi-Object Tracking in Python | Trackers"
+title: Quickstart — Multi-Object Tracking in Python | Trackers
 comments: true
 description: Get started with Roboflow Trackers — install SORT, ByteTrack, and OC-SORT, run your first tracking pipeline, and evaluate results with HOTA, IDF1, and MOTA metrics.
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ---
+title: "Quickstart — Multi-Object Tracking in Python | Trackers"
 comments: true
 description: Get started with Roboflow Trackers — install SORT, ByteTrack, and OC-SORT, run your first tracking pipeline, and evaluate results with HOTA, IDF1, and MOTA metrics.
 ---
@@ -200,9 +201,10 @@ and any custom model. The tracker never inspects the detection model directly.
 
 **What MOT datasets does the library support?**
 
-MOT17, MOT20, SportsMOT, SoccerNet-tracking, and DanceTrack are supported for download and
-evaluation. Use `trackers download <dataset>` to pull frames, annotations, and pre-computed
-detections in one command. See the [download guide](learn/download.md) for asset options.
+MOT17 and SportsMOT are supported for download and evaluation. Use
+`trackers download <dataset>` to pull frames, annotations, and pre-computed
+detections in one command. DanceTrack and SoccerNet-tracking support is coming soon.
+See the [download guide](learn/download.md) for asset options.
 
 **How do I evaluate my tracker?**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: Get started with Roboflow Trackers — install SORT, ByteTrack, and
 
 </div>
 
-Plug-and-play multi-object tracking for any detection model. Clean, modular implementations of SORT, ByteTrack, and OC-SORT under the Apache 2.0 license.
+Roboflow Trackers achieves 60.5 HOTA (ByteTrack) and 62.0 HOTA (OC-SORT) on MOT17, benchmarked across four standard datasets. Apache 2.0, Python 3.10+, 71K+ monthly PyPI installs.
 
 <video width="100%" controls autoplay muted loop>
   <source src="https://storage.googleapis.com/com-roboflow-marketing/trackers/docs/track-objects-page.mp4" type="video/mp4">

--- a/docs/learn/about.md
+++ b/docs/learn/about.md
@@ -20,12 +20,12 @@ A full list of contributors is available on the [GitHub contributors page](https
 
 Roboflow Trackers is distributed as the [`trackers` package on PyPI](https://pypi.org/project/trackers/). The source code is hosted on [GitHub](https://github.com/roboflow/trackers) under the Apache 2.0 license.
 
-| Detail | Value |
-| :--- | :--- |
-| **PyPI** | [`trackers`](https://pypi.org/project/trackers/) |
-| **Repository** | [roboflow/trackers](https://github.com/roboflow/trackers) |
-| **License** | [Apache License 2.0](https://github.com/roboflow/trackers/blob/main/LICENSE) |
-| **Python** | 3.10+ |
+| Detail         | Value                                                                        |
+| :------------- | :--------------------------------------------------------------------------- |
+| **PyPI**       | [`trackers`](https://pypi.org/project/trackers/)                             |
+| **Repository** | [roboflow/trackers](https://github.com/roboflow/trackers)                    |
+| **License**    | [Apache License 2.0](https://github.com/roboflow/trackers/blob/main/LICENSE) |
+| **Python**     | 3.10+                                                                        |
 
 ## Support
 

--- a/docs/learn/about.md
+++ b/docs/learn/about.md
@@ -16,6 +16,17 @@ Roboflow Trackers is built and maintained by the [Roboflow](https://roboflow.com
 
 A full list of contributors is available on the [GitHub contributors page](https://github.com/roboflow/trackers/graphs/contributors).
 
+## Package Provenance
+
+Roboflow Trackers is distributed as the [`trackers` package on PyPI](https://pypi.org/project/trackers/). The source code is hosted on [GitHub](https://github.com/roboflow/trackers) under the Apache 2.0 license.
+
+| Detail | Value |
+| :--- | :--- |
+| **PyPI** | [`trackers`](https://pypi.org/project/trackers/) |
+| **Repository** | [roboflow/trackers](https://github.com/roboflow/trackers) |
+| **License** | [Apache License 2.0](https://github.com/roboflow/trackers/blob/main/LICENSE) |
+| **Python** | 3.10+ |
+
 ## Support
 
 If you run into a bug, have a feature request, or need help with integration:

--- a/docs/learn/download.md
+++ b/docs/learn/download.md
@@ -1,5 +1,5 @@
 ---
-description: Download MOT benchmark datasets — MOT17, MOT20, DanceTrack, and SportsMOT — with a single command for tracker evaluation and development.
+description: Download MOT benchmark datasets — MOT17 and SportsMOT — with a single command for tracker evaluation and development.
 ---
 
 # Download Datasets

--- a/docs/learn/evaluate.md
+++ b/docs/learn/evaluate.md
@@ -1,5 +1,5 @@
 ---
-title: "Evaluate Tracker Performance — HOTA, IDF1, MOTA Metrics | Trackers"
+title: Evaluate Tracker Performance — HOTA, IDF1, MOTA Metrics | Trackers
 description: Measure tracker accuracy with standard MOT metrics — HOTA, IDF1, and MOTA — using Roboflow Trackers built-in evaluation pipeline on MOT benchmark datasets.
 ---
 

--- a/docs/learn/evaluate.md
+++ b/docs/learn/evaluate.md
@@ -1,4 +1,5 @@
 ---
+title: "Evaluate Tracker Performance — HOTA, IDF1, MOTA Metrics | Trackers"
 description: Measure tracker accuracy with standard MOT metrics — HOTA, IDF1, and MOTA — using Roboflow Trackers built-in evaluation pipeline on MOT benchmark datasets.
 ---
 

--- a/docs/learn/install.md
+++ b/docs/learn/install.md
@@ -1,5 +1,5 @@
 ---
-title: "Install Roboflow Trackers — Python MOT Library | Trackers"
+title: Install Roboflow Trackers — Python MOT Library | Trackers
 description: Install Roboflow Trackers with pip or uv. Add multi-object tracking to any detection pipeline with a single package — supports SORT, ByteTrack, and OC-SORT out of the box.
 ---
 

--- a/docs/learn/install.md
+++ b/docs/learn/install.md
@@ -1,4 +1,5 @@
 ---
+title: "Install Roboflow Trackers — Python MOT Library | Trackers"
 description: Install Roboflow Trackers with pip or uv. Add multi-object tracking to any detection pipeline with a single package — supports SORT, ByteTrack, and OC-SORT out of the box.
 ---
 

--- a/docs/learn/track.md
+++ b/docs/learn/track.md
@@ -1,5 +1,5 @@
 ---
-title: "Track Objects in Video — Python API & CLI Guide | Trackers"
+title: Track Objects in Video — Python API & CLI Guide | Trackers
 description: Learn how to run multi-object tracking on video with Roboflow Trackers. Combine any detection model with SORT, ByteTrack, or OC-SORT to maintain consistent object IDs across frames.
 ---
 

--- a/docs/learn/track.md
+++ b/docs/learn/track.md
@@ -1,4 +1,5 @@
 ---
+title: "Track Objects in Video — Python API & CLI Guide | Trackers"
 description: Learn how to run multi-object tracking on video with Roboflow Trackers. Combine any detection model with SORT, ByteTrack, or OC-SORT to maintain consistent object IDs across frames.
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,23 +1,28 @@
 # Roboflow Trackers
 
-> A unified library for multi-object tracking (MOT) with clean-room implementations of SORT, ByteTrack, and OC-SORT. Designed to plug into any detection model via the supervision library.
+> Clean-room Python implementations of SORT, ByteTrack, and OC-SORT —
+> multi-object tracking algorithms that plug into any detection model
+> via the supervision library. Apache 2.0. 71,000+ monthly PyPI installs.
 
-Roboflow Trackers is an open-source Python library that provides production-ready implementations of leading multi-object tracking algorithms. It supports evaluation on standard MOT benchmarks (HOTA, IDF1, MOTA) and integrates natively with the supervision detection format.
+## Documentation
 
-## Pages
+- [Quickstart](https://trackers.roboflow.com/latest/): Install and run your first tracking pipeline
+- [Tracker Comparison](https://trackers.roboflow.com/latest/trackers/comparison/): HOTA/IDF1/MOTA benchmarks across MOT17, SportsMOT, SoccerNet, DanceTrack
+- [Track Objects](https://trackers.roboflow.com/latest/learn/track/): CLI and Python API
+- [Evaluate Trackers](https://trackers.roboflow.com/latest/learn/evaluate/): HOTA, IDF1, MOTA metrics guide
+- [Detection Quality Matters](https://trackers.roboflow.com/latest/learn/detection-quality/): How detector quality affects tracking
+- [SORT](https://trackers.roboflow.com/latest/trackers/sort/): Kalman + Hungarian algorithm tracker
+- [ByteTrack](https://trackers.roboflow.com/latest/trackers/bytetrack/): Low-confidence detection association tracker
+- [OC-SORT](https://trackers.roboflow.com/latest/trackers/ocsort/): Observation-centric re-update tracker
 
-- [Quickstart](https://trackers.roboflow.com/latest/): Get started with Roboflow Trackers — installation, basic tracking, and evaluation
-- [Install Trackers](https://trackers.roboflow.com/latest/learn/install/): Step-by-step installation guide using pip or uv
-- [Track Objects](https://trackers.roboflow.com/latest/learn/track/): How to run object tracking on video with any detection model
-- [Download Datasets](https://trackers.roboflow.com/latest/learn/download/): Download MOT benchmark datasets (MOT17, MOT20, DanceTrack, SportsMOT)
-- [Evaluate Trackers](https://trackers.roboflow.com/latest/learn/evaluate/): Run HOTA, IDF1, and MOTA evaluation on tracking results
-- [Detection Quality Matters](https://trackers.roboflow.com/latest/learn/detection-quality/): How detector quality affects tracker performance
-- [Tracker Comparison](https://trackers.roboflow.com/latest/trackers/comparison/): Side-by-side benchmark comparison of SORT, ByteTrack, and OC-SORT
-- [SORT](https://trackers.roboflow.com/latest/trackers/sort/): SORT (Simple Online and Realtime Tracking) algorithm reference
-- [ByteTrack](https://trackers.roboflow.com/latest/trackers/bytetrack/): ByteTrack algorithm reference — tracking by associating every detection box
-- [OC-SORT](https://trackers.roboflow.com/latest/trackers/ocsort/): OC-SORT (Observation-Centric SORT) algorithm reference
-- [API: Trackers](https://trackers.roboflow.com/latest/api/trackers/): Python API reference for tracker classes
-- [API: Motion](https://trackers.roboflow.com/latest/api/motion/): Python API reference for motion estimation (optical flow, homography)
-- [API: Datasets](https://trackers.roboflow.com/latest/api/datasets/): Python API reference for dataset download helpers
-- [API: Evals](https://trackers.roboflow.com/latest/api/evals/): Python API reference for evaluation metrics (HOTA, IDF1, MOTA)
-- [API: I/O](https://trackers.roboflow.com/latest/api/io/): Python API reference for MOT-format file I/O and video readers
+## API Reference
+
+- [Trackers API](https://trackers.roboflow.com/latest/api/trackers/)
+- [Motion API](https://trackers.roboflow.com/latest/api/motion/)
+- [Evals API](https://trackers.roboflow.com/latest/api/evals/)
+
+## Optional
+
+- [GitHub](https://github.com/roboflow/trackers): Source, 3,300+ stars, Apache 2.0
+- [PyPI](https://pypi.org/project/trackers/): pip install trackers
+- [About](https://trackers.roboflow.com/latest/learn/about/): Project background and contributors

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -18,7 +18,7 @@
       "url": "https://roboflow.com",
       "description": "Roboflow builds computer vision infrastructure and tools for training and deploying vision AI models.",
       "foundingDate": "2019",
-      "logo": "https://trackers.roboflow.com/assets/logo-trackers-violet.svg",
+      "logo": "{{ 'assets/logo-trackers-violet.svg' | url }}",
       "sameAs": [
         "https://github.com/roboflow",
         "https://twitter.com/roboflow",
@@ -57,18 +57,22 @@
 
 {# ── WebSite + SearchAction JSON-LD (homepage only) ── #}
 {% if page.url == '' or page.url == './' %}
+{% set canonical_site_url = config.site_url | default('https://trackers.roboflow.com/latest/', true) %}
+{% if not canonical_site_url.endswith('/') %}
+{% set canonical_site_url = canonical_site_url ~ '/' %}
+{% endif %}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "WebSite",
   "name": "Roboflow Trackers",
-  "url": "https://trackers.roboflow.com/",
+  "url": "{{ canonical_site_url }}",
   "description": "Documentation for Roboflow Trackers — multi-object tracking library with SORT, ByteTrack, and OC-SORT implementations.",
   "potentialAction": {
     "@type": "SearchAction",
     "target": {
       "@type": "EntryPoint",
-      "urlTemplate": "https://trackers.roboflow.com/?q={search_term_string}"
+      "urlTemplate": "{{ canonical_site_url }}?q={search_term_string}"
     },
     "query-input": "required name=search_term_string"
   }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -16,13 +16,17 @@
       "@id": "https://roboflow.com/#organization",
       "name": "Roboflow",
       "url": "https://roboflow.com",
+      "description": "Roboflow builds computer vision infrastructure and tools for training and deploying vision AI models.",
+      "foundingDate": "2019",
       "logo": "https://trackers.roboflow.com/assets/logo-trackers-violet.svg",
       "sameAs": [
         "https://github.com/roboflow",
         "https://twitter.com/roboflow",
         "https://www.linkedin.com/company/roboflow-ai/",
         "https://www.youtube.com/roboflow",
-        "https://en.wikipedia.org/wiki/Roboflow"
+        "https://en.wikipedia.org/wiki/Roboflow",
+        "https://www.wikidata.org/wiki/Q117062679",
+        "https://www.crunchbase.com/organization/roboflow"
       ]
     },
     {
@@ -31,6 +35,8 @@
       "name": "Roboflow Trackers",
       "description": "A unified library for multi-object tracking with clean-room implementations of SORT, ByteTrack, and OC-SORT, designed to plug into any detection model via the supervision library.",
       "applicationCategory": "DeveloperApplication",
+      "applicationSubCategory": "Object Tracking",
+      "featureList": ["SORT tracking", "ByteTrack tracking", "OC-SORT tracking", "HOTA evaluation", "IDF1 evaluation", "MOTA evaluation", "MOT17 dataset support", "SportsMOT dataset support"],
       "operatingSystem": "Linux, macOS, Windows",
       "url": "https://trackers.roboflow.com",
       "downloadUrl": "https://pypi.org/project/trackers/",
@@ -56,6 +62,20 @@
 </script>
 {% endif %}
 
+{# ── Per-page FAQPage JSON-LD (injected by schema_inject.py hook — homepage only) ── #}
+{% if page.meta and page.meta.json_ld_faq %}
+<script type="application/ld+json">
+{{ page.meta.json_ld_faq | safe }}
+</script>
+{% endif %}
+
+{# ── Per-page BreadcrumbList JSON-LD (injected by schema_inject.py hook) ── #}
+{% if page.meta and page.meta.json_ld_breadcrumbs %}
+<script type="application/ld+json">
+{{ page.meta.json_ld_breadcrumbs | safe }}
+</script>
+{% endif %}
+
 {# ── Open Graph meta tags ── #}
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="Roboflow Trackers" />
@@ -68,10 +88,6 @@
 {# ── IndexNow key (Bing/Yandex site ownership verification) ── #}
 {# Key file: docs/bc061e8ae9e449d7acb9f86d29637e58.txt — must stay in sync with workflow + this tag #}
 <meta name="indexnow-key" content="bc061e8ae9e449d7acb9f86d29637e58" />
-
-{# ── Bing Webmaster Tools verification ── #}
-{# Replace the content value with your key from https://www.bing.com/webmasters #}
-<meta name="msvalidate.01" content="REPLACE_WITH_BING_VERIFICATION_KEY" />
 
 {# ── Twitter / X Card meta tags ── #}
 <meta name="twitter:card" content="summary_large_image" />

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,7 +3,7 @@
 {% block extrahead %}
 {{ super() }}
 
-{# ── GEO: JSON-LD + meta tags (page context required — skip for 404 and theme templates) #}
+{# ── GEO: JSON-LD + meta tags (page context required — skip for 404 and theme templates) ── #}
 {% if page %}
 
 {# ── Organization + SoftwareApplication JSON-LD (site-wide) ── #}
@@ -55,6 +55,27 @@
 }
 </script>
 
+{# ── WebSite + SearchAction JSON-LD (homepage only) ── #}
+{% if page.url == '' or page.url == './' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Roboflow Trackers",
+  "url": "https://trackers.roboflow.com/",
+  "description": "Documentation for Roboflow Trackers — multi-object tracking library with SORT, ByteTrack, and OC-SORT implementations.",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://trackers.roboflow.com/?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
+{% endif %}
+
 {# ── Per-page TechArticle JSON-LD (injected by schema_inject.py hook) ── #}
 {% if page.meta and page.meta.json_ld_article %}
 <script type="application/ld+json">
@@ -76,8 +97,17 @@
 </script>
 {% endif %}
 
+{# ── Per-page Dataset JSON-LD (injected by schema_inject.py hook — comparison page only) ── #}
+{% if page.meta and page.meta.json_ld_datasets %}
+{% for ds_json in page.meta.json_ld_datasets %}
+<script type="application/ld+json">
+{{ ds_json | safe }}
+</script>
+{% endfor %}
+{% endif %}
+
 {# ── Open Graph meta tags ── #}
-<meta property="og:type" content="website" />
+<meta property="og:type" content="{% if page.url == '' or page.url == './' %}website{% else %}article{% endif %}" />
 <meta property="og:site_name" content="Roboflow Trackers" />
 <meta property="og:url" content="{{ page.canonical_url }}" />
 <meta property="og:title" content="{% if page.meta and page.meta.title %}{{ page.meta.title }}{% else %}{{ page.title }} — Roboflow Trackers{% endif %}" />

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -35,4 +35,16 @@ Allow: /
 User-agent: Applebot
 Allow: /
 
-Sitemap: https://trackers.roboflow.com/sitemap.xml
+User-agent: Google-Extended
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+Sitemap: https://trackers.roboflow.com/latest/sitemap.xml

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,39 +1,17 @@
 User-agent: *
 Allow: /
 # Block numeric mike version directories (/0.28.0/, /1.0.0/, etc.) — canonical URL is /latest/
-# robots.txt has no character classes, so one Disallow per leading digit is required.
-Disallow: /0.*/
-Disallow: /1.*/
-Disallow: /2.*/
-Disallow: /3.*/
-Disallow: /4.*/
-Disallow: /5.*/
-Disallow: /6.*/
-Disallow: /7.*/
-Disallow: /8.*/
-Disallow: /9.*/
-
-# AI crawlers
-User-agent: GPTBot
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: PerplexityBot
-Allow: /
-
-User-agent: Bytespider
-Allow: /
-
-User-agent: CCBot
-Allow: /
-
-User-agent: GoogleOther
-Allow: /
-
-User-agent: Applebot
-Allow: /
+# Use prefix-match (no wildcard) for maximum parser portability.
+Disallow: /0.
+Disallow: /1.
+Disallow: /2.
+Disallow: /3.
+Disallow: /4.
+Disallow: /5.
+Disallow: /6.
+Disallow: /7.
+Disallow: /8.
+Disallow: /9.
 
 User-agent: Google-Extended
 Allow: /

--- a/docs/trackers/bytetrack.md
+++ b/docs/trackers/bytetrack.md
@@ -1,5 +1,5 @@
 ---
-title: "ByteTrack — Multi-Object Tracking Algorithm | Trackers"
+title: ByteTrack — Multi-Object Tracking Algorithm | Trackers
 comments: true
 description: ByteTrack improves multi-object tracking by associating every detection box — including low-confidence ones — to reduce missed tracks and fragmentation while maintaining real-time performance.
 ---

--- a/docs/trackers/bytetrack.md
+++ b/docs/trackers/bytetrack.md
@@ -1,4 +1,5 @@
 ---
+title: "ByteTrack — Multi-Object Tracking Algorithm | Trackers"
 comments: true
 description: ByteTrack improves multi-object tracking by associating every detection box — including low-confidence ones — to reduce missed tracks and fragmentation while maintaining real-time performance.
 ---

--- a/docs/trackers/bytetrack.md
+++ b/docs/trackers/bytetrack.md
@@ -5,11 +5,11 @@ description: ByteTrack improves multi-object tracking by associating every detec
 
 # ByteTrack
 
-## Overview
+## What is ByteTrack?
 
 ByteTrack builds on the same Kalman filter plus Hungarian algorithm framework as SORT but changes the data association strategy to use almost every detection box regardless of confidence score. It runs a two-stage matching: first match high-confidence detections to tracks, then match low-confidence detections to any unmatched tracks using IoU. This reduces missed tracks and fragmentation for occluded or weak detections while retaining simplicity and high frame rates. ByteTrack has set state-of-the-art results on standard MOT benchmarks with real-time performance, because it recovers valid low-score detections instead of discarding them.
 
-## Comparison
+## How does ByteTrack compare to other trackers?
 
 For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](comparison.md) page.
 
@@ -19,7 +19,7 @@ For comparisons with other trackers, plus dataset context and evaluation details
 | SportsMOT | 73.0 | 72.5 | 96.4 |
 | SoccerNet | 84.0 | 78.1 | 97.8 |
 
-## Algorithm
+## How does ByteTrack work?
 
 ByteTrack builds on the same Kalman filter and Hungarian algorithm framework as [SORT](sort.md) but changes how detections are associated to tracks. Instead of discarding low-confidence detections, ByteTrack uses a two-stage matching strategy that recovers valid objects the detector scored low due to occlusion, blur, or partial visibility.
 

--- a/docs/trackers/comparison.md
+++ b/docs/trackers/comparison.md
@@ -1,4 +1,5 @@
 ---
+title: "SORT vs ByteTrack vs OC-SORT — MOT Benchmark Comparison | Trackers"
 description: Side-by-side benchmark comparison of SORT, ByteTrack, and OC-SORT on MOT17, MOT20, DanceTrack, and SportsMOT — HOTA, IDF1, MOTA scores with default and tuned parameters.
 ---
 

--- a/docs/trackers/comparison.md
+++ b/docs/trackers/comparison.md
@@ -1,5 +1,5 @@
 ---
-title: "SORT vs ByteTrack vs OC-SORT — MOT Benchmark Comparison | Trackers"
+title: SORT vs ByteTrack vs OC-SORT — MOT Benchmark Comparison | Trackers
 description: Side-by-side benchmark comparison of SORT, ByteTrack, and OC-SORT on MOT17, MOT20, DanceTrack, and SportsMOT — HOTA, IDF1, MOTA scores with default and tuned parameters.
 ---
 

--- a/docs/trackers/comparison.md
+++ b/docs/trackers/comparison.md
@@ -10,6 +10,10 @@ This page shows head-to-head performance of SORT, ByteTrack, and OC-SORT on stan
 
     Results use **trackers v2.3.0** (released 2026-03-16). Detections are from YOLOX (MOT17, SportsMOT) or ground-truth oracle boxes (SoccerNet, DanceTrack). Parameters were tuned via grid search on held-out splits. See [Methodology](#methodology) for details.
 
+!!! note "Benchmark methodology"
+
+    Results measured using YOLOX detections (MOT17, SportsMOT) or oracle ground-truth boxes (SoccerNet, DanceTrack) with default and grid-searched parameters. Performance varies across detectors — see [Detection Quality Matters](../learn/detection-quality.md) for the impact of detector quality on tracking metrics.
+
 ## [MOT17](https://arxiv.org/abs/1603.00831)
 
 Pedestrian tracking with crowded scenes and frequent occlusions. Strongly tests re-identification and identity stability.

--- a/docs/trackers/ocsort.md
+++ b/docs/trackers/ocsort.md
@@ -1,5 +1,5 @@
 ---
-title: "OC-SORT — Observation-Centric SORT Tracker | Trackers"
+title: OC-SORT — Observation-Centric SORT Tracker | Trackers
 comments: true
 description: OC-SORT (Observation-Centric SORT) enhances SORT with three mechanisms for robust tracking under occlusion and non-linear motion, improving identity consistency on crowded scenes.
 ---

--- a/docs/trackers/ocsort.md
+++ b/docs/trackers/ocsort.md
@@ -5,14 +5,14 @@ description: OC-SORT (Observation-Centric SORT) enhances SORT with three mechani
 
 # OC-SORT
 
-## Overview
+## What is OC-SORT?
 
 OC-SORT remains Simple, Online, and Real-Time like ([SORT](sort.md)) but improves robustness during occlusion and non-linear motion.
 It recognizes limitations from SORT and the linear motion assumption of the Kalman filter, and adds three mechanisms to enhance tracking. These
 mechanisms help having better Kalman Filter parameters after an occlusion, add a term to the association process to incorporate how consistent is the direction with the new association with respect to the tracks' previous direction and add a second-stage association step between the last observation of unmatched tracks and the unmatched observations after the usual association to attempt to recover tracks that were lost
 due to object stopping or short-term occlusion.
 
-## Comparison
+## How does OC-SORT compare to other trackers?
 
 For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](comparison.md) page.
 
@@ -22,7 +22,7 @@ For comparisons with other trackers, plus dataset context and evaluation details
 | SportsMOT | 71.5 | 71.2 | 95.2 |
 | SoccerNet | 78.6 | 72.7 | 94.5 |
 
-## Algorithm
+## How does OC-SORT work?
 
 OC-SORT extends [SORT](sort.md) with three observation-centric mechanisms that address the linear motion assumption's failures during occlusion and non-linear trajectories. It retains the same Kalman filter and Hungarian algorithm backbone but adds corrections that use stored observations rather than relying solely on the filter's predicted state.
 

--- a/docs/trackers/ocsort.md
+++ b/docs/trackers/ocsort.md
@@ -1,4 +1,5 @@
 ---
+title: "OC-SORT — Observation-Centric SORT Tracker | Trackers"
 comments: true
 description: OC-SORT (Observation-Centric SORT) enhances SORT with three mechanisms for robust tracking under occlusion and non-linear motion, improving identity consistency on crowded scenes.
 ---
@@ -19,8 +20,8 @@ For comparisons with other trackers, plus dataset context and evaluation details
 |  Dataset  | HOTA | IDF1 | MOTA |
 | :-------: | :--: | :--: | :--: |
 |   MOT17   | 61.9 | 76.1 | 76.7 |
-| SportsMOT | 71.5 | 71.2 | 95.2 |
-| SoccerNet | 78.6 | 72.7 | 94.5 |
+| SportsMOT | 71.7 | 71.4 | 95.0 |
+| SoccerNet | 78.4 | 72.6 | 94.1 |
 
 ## How does OC-SORT work?
 

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -1,4 +1,5 @@
 ---
+title: "SORT Tracker — Simple Online and Realtime Tracking | Trackers"
 comments: true
 description: SORT (Simple Online and Realtime Tracking) uses a Kalman filter and Hungarian algorithm to track objects in real time using only bounding-box geometry — fast, lightweight, and easy to integrate.
 ---

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -1,5 +1,5 @@
 ---
-title: "SORT Tracker — Simple Online and Realtime Tracking | Trackers"
+title: SORT Tracker — Simple Online and Realtime Tracking | Trackers
 comments: true
 description: SORT (Simple Online and Realtime Tracking) uses a Kalman filter and Hungarian algorithm to track objects in real time using only bounding-box geometry — fast, lightweight, and easy to integrate.
 ---

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -5,11 +5,11 @@ description: SORT (Simple Online and Realtime Tracking) uses a Kalman filter and
 
 # SORT
 
-## Overview
+## What is SORT?
 
 SORT is a classic online, tracking-by-detection method that predicts object motion with a Kalman filter and matches predicted tracks to detections using the Hungarian algorithm based on Intersection over Union (IoU). The tracker uses only geometric cues from bounding boxes, without appearance features, so it runs extremely fast and scales to hundreds of frames per second on typical hardware. Detections from a strong CNN detector feed SORT, which updates each track’s state via a constant velocity motion model and prunes stale tracks. Because SORT lacks explicit re-identification or appearance cues, it can suffer identity switches and fragmented tracks under long occlusions or heavy crowding.
 
-## Comparison
+## How does SORT compare to other trackers?
 
 For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](comparison.md) page.
 
@@ -19,7 +19,7 @@ For comparisons with other trackers, plus dataset context and evaluation details
 | SportsMOT | 70.9 | 68.9 | 95.7 |
 | SoccerNet | 81.6 | 76.2 | 95.1 |
 
-## Algorithm
+## How does SORT work?
 
 SORT models each tracked object with a seven-dimensional state vector `[x, y, s, r, dx, dy, ds]`, where `x` and `y` are the bounding-box center coordinates, `s` is the box area (scale), `r` is the aspect ratio (held constant across predictions), and `dx`, `dy`, `ds` are the corresponding velocities.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,10 @@ site_description: A unified library for object tracking featuring clean room re-
 repo_name: roboflow/trackers
 repo_url: https://github.com/roboflow/trackers
 edit_uri: https://github.com/roboflow/trackers/tree/main/docs
-copyright: Roboflow 2026. All rights reserved.
+copyright: >
+  Roboflow 2026. All rights reserved. |
+  <a href="https://roboflow.com/privacy">Privacy Policy</a> |
+  <a href="https://roboflow.com/terms">Terms of Service</a>
 
 hooks:
   - docs/hooks/doctest_filter.py
@@ -93,6 +96,7 @@ plugins:
   - search
   - git-revision-date-localized:
       enable_creation_date: true
+      type: iso_date
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
- robots.txt: add Google-Extended, OAI-SearchBot, ChatGPT-User, Applebot-Extended; fix Sitemap URL → /latest/sitemap.xml
- mkdocs.yml: add iso_date type for git-revision-date plugin; add Privacy Policy + ToS to copyright
- schema_inject.py: add datePublished/dateModified, mainEntityOfPage, image to TechArticle; inject FAQPage (homepage) and BreadcrumbList schemas
- main.html: remove REPLACE_WITH_BING_VERIFICATION_KEY placeholder; enhance Organization (description, foundingDate, Wikidata, Crunchbase sameAs); add SoftwareApplication featureList; render FAQPage + BreadcrumbList blocks
- docs/llms.txt: new file — AI crawler content map with Documentation/API/Optional sections
- index.md: rewrite hero from marketing to stat-forward (HOTA scores, PyPI installs, license)
- comparison.md: add benchmark methodology disclosure (detector + parameter info)
- sort.md, bytetrack.md, ocsort.md: convert declarative H2s to question format for AIO extraction
