### PR TITLE
Add tune cli

### DIFF
--- a/test/scripts/test_tune.py
+++ b/test/scripts/test_tune.py
@@ -1,0 +1,218 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""CLI-level tests for trackers/scripts/tune.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from trackers.scripts.tune import add_tune_subparser, run_tune, tune
+
+
+def _make_parser() -> tuple[argparse.ArgumentParser, argparse._SubParsersAction]:
+    """Return a top-level parser with a subparsers group."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    return parser, subparsers
+
+
+class TestAddTuneSubparser:
+    def test_registers_tune_subcommand(self) -> None:
+        """tune subcommand is accessible under the 'tune' name."""
+        parser, subparsers = _make_parser()
+        add_tune_subparser(subparsers)
+        args = parser.parse_args(
+            ["tune", "--tracker", "sort", "--gt-dir", "/gt", "--detections-dir", "/det"]
+        )
+        assert args.func is run_tune
+
+    def test_required_args_parsed(self) -> None:
+        """--tracker, --gt-dir, and --detections-dir are required and parsed."""
+        parser, subparsers = _make_parser()
+        add_tune_subparser(subparsers)
+        args = parser.parse_args(
+            [
+                "tune",
+                "--tracker",
+                "bytetrack",
+                "--gt-dir",
+                "/data/gt",
+                "--detections-dir",
+                "/data/det",
+            ]
+        )
+        assert args.tracker == "bytetrack"
+        assert args.gt_dir == Path("/data/gt")
+        assert args.detections_dir == Path("/data/det")
+
+    @pytest.mark.parametrize(
+        "flag,expected",
+        [
+            ("objective", "HOTA"),
+            ("n_trials", 100),
+            ("threshold", 0.5),
+            ("seqmap", None),
+            ("output", None),
+        ],
+    )
+    def test_optional_defaults(self, flag: str, expected: object) -> None:
+        """Optional arguments have correct defaults when omitted."""
+        parser, subparsers = _make_parser()
+        add_tune_subparser(subparsers)
+        args = parser.parse_args(
+            ["tune", "--tracker", "sort", "--gt-dir", "/gt", "--detections-dir", "/det"]
+        )
+        assert getattr(args, flag) == expected
+
+    def test_metrics_default(self) -> None:
+        """--metrics defaults to ['CLEAR'] when not supplied."""
+        parser, subparsers = _make_parser()
+        add_tune_subparser(subparsers)
+        args = parser.parse_args(
+            ["tune", "--tracker", "sort", "--gt-dir", "/gt", "--detections-dir", "/det"]
+        )
+        assert args.metrics == ["CLEAR"]
+
+    def test_output_flag_short_form(self) -> None:
+        """-o is an alias for --output."""
+        parser, subparsers = _make_parser()
+        add_tune_subparser(subparsers)
+        args = parser.parse_args(
+            [
+                "tune",
+                "--tracker",
+                "sort",
+                "--gt-dir",
+                "/gt",
+                "--detections-dir",
+                "/det",
+                "-o",
+                "/out/params.json",
+            ]
+        )
+        assert args.output == Path("/out/params.json")
+
+
+class TestTune:
+    def test_returns_1_on_invalid_tracker(self, tmp_path: Path) -> None:
+        """Invalid tracker ID causes tune() to return exit code 1."""
+        gt_dir = tmp_path / "gt"
+        gt_dir.mkdir()
+        det_dir = tmp_path / "det"
+        det_dir.mkdir()
+        result = tune("nonexistent_tracker_xyz", gt_dir, det_dir)
+        assert result == 1
+
+    def test_returns_1_on_missing_files(self, tmp_path: Path) -> None:
+        """FileNotFoundError from Tuner (missing sequence files) returns exit code 1."""
+        gt_dir = tmp_path / "gt"
+        gt_dir.mkdir()
+        det_dir = tmp_path / "det"
+        det_dir.mkdir()
+        # bytetrack is registered; empty det_dir → FileNotFoundError via Tuner
+        result = tune("bytetrack", gt_dir, det_dir)
+        assert result == 1
+
+    def test_returns_1_on_import_error(self, tmp_path: Path) -> None:
+        """ImportError (e.g. optuna not installed) causes tune() to return 1."""
+        gt_dir = tmp_path / "gt"
+        det_dir = tmp_path / "det"
+        with patch(
+            "trackers.tune.Tuner",
+            side_effect=ImportError("optuna is required"),
+        ):
+            result = tune("bytetrack", gt_dir, det_dir)
+        assert result == 1
+
+    def test_returns_0_on_success(self, tmp_path: Path) -> None:
+        """tune() returns 0 when Tuner.run() completes without error."""
+        gt_dir = tmp_path / "gt"
+        det_dir = tmp_path / "det"
+        mock_tuner = MagicMock()
+        mock_tuner.run.return_value = {"high_thresh": 0.6}
+        mock_tuner.study = None
+        with patch("trackers.tune.Tuner", return_value=mock_tuner):
+            result = tune("bytetrack", gt_dir, det_dir)
+        assert result == 0
+
+    def test_writes_json_output_on_success(self, tmp_path: Path) -> None:
+        """Best parameters are written to the output JSON file on success."""
+        gt_dir = tmp_path / "gt"
+        det_dir = tmp_path / "det"
+        output_path = tmp_path / "out" / "params.json"
+        best = {"high_thresh": 0.6, "match_thresh": 0.8}
+        mock_tuner = MagicMock()
+        mock_tuner.run.return_value = best
+        mock_tuner.study = None
+        with patch("trackers.tune.Tuner", return_value=mock_tuner):
+            result = tune("bytetrack", gt_dir, det_dir, output=output_path)
+        assert result == 0
+        assert output_path.exists()
+        assert json.loads(output_path.read_text()) == best
+
+    def test_returns_1_on_oserror_writing_output(self, tmp_path: Path) -> None:
+        """OSError while writing output file returns exit code 1."""
+        gt_dir = tmp_path / "gt"
+        det_dir = tmp_path / "det"
+        output_path = tmp_path / "params.json"
+        mock_tuner = MagicMock()
+        mock_tuner.run.return_value = {"high_thresh": 0.6}
+        mock_tuner.study = None
+        with (
+            patch("trackers.tune.Tuner", return_value=mock_tuner),
+            patch.object(Path, "write_text", side_effect=OSError("permission denied")),
+        ):
+            result = tune("bytetrack", gt_dir, det_dir, output=output_path)
+        assert result == 1
+
+    def test_returns_1_on_tuner_run_exception(self, tmp_path: Path) -> None:
+        """Exception from tuner.run() causes tune() to return exit code 1."""
+        gt_dir = tmp_path / "gt"
+        det_dir = tmp_path / "det"
+        mock_tuner = MagicMock()
+        mock_tuner.run.side_effect = RuntimeError("optimization failed")
+        with patch("trackers.tune.Tuner", return_value=mock_tuner):
+            result = tune("bytetrack", gt_dir, det_dir)
+        assert result == 1
+
+
+class TestRunTune:
+    def test_delegates_to_tune_with_namespace_args(self, tmp_path: Path) -> None:
+        """run_tune() passes all argparse.Namespace fields to tune() correctly."""
+        gt_dir = tmp_path / "gt"
+        det_dir = tmp_path / "det"
+        output_path = tmp_path / "params.json"
+        args = argparse.Namespace(
+            tracker="sort",
+            gt_dir=gt_dir,
+            detections_dir=det_dir,
+            objective="MOTA",
+            n_trials=50,
+            metrics=["CLEAR", "HOTA"],
+            threshold=0.3,
+            seqmap=None,
+            output=output_path,
+        )
+        with patch("trackers.scripts.tune.tune", return_value=0) as mock_tune:
+            result = run_tune(args)
+        assert result == 0
+        mock_tune.assert_called_once_with(
+            tracker="sort",
+            gt_dir=gt_dir,
+            detections_dir=det_dir,
+            objective="MOTA",
+            n_trials=50,
+            metrics=["CLEAR", "HOTA"],
+            threshold=0.3,
+            seqmap=None,
+            output=output_path,
+        )

--- a/test/tune/test_tuner.py
+++ b/test/tune/test_tuner.py
@@ -168,6 +168,35 @@ class TestTunerInit:
         tuner = Tuner("bytetrack", gt_dir, det_dir, seqmap=seqmap)
         assert tuner._sequences == ["seq1"]
 
+    @pytest.mark.parametrize(
+        "objective,initial_metrics,expected_metrics",
+        [
+            ("HOTA", ["CLEAR"], ["CLEAR", "HOTA"]),
+            ("IDF1", ["CLEAR"], ["CLEAR", "Identity"]),
+            ("MOTA", ["CLEAR"], ["CLEAR"]),
+            ("HOTA", ["CLEAR", "HOTA"], ["CLEAR", "HOTA"]),
+        ],
+    )
+    def test_auto_adds_required_metric_family(
+        self,
+        tmp_path: Path,
+        objective: str,
+        initial_metrics: list[str],
+        expected_metrics: list[str],
+    ) -> None:
+        """Tuner auto-adds the metric family required by the objective."""
+        gt_dir, det_dir = _setup_dirs(tmp_path)
+        tuner = Tuner(
+            "bytetrack", gt_dir, det_dir, metrics=initial_metrics, objective=objective
+        )
+        assert tuner._metrics == expected_metrics
+
+    def test_objective_normalized_to_uppercase(self, tmp_path: Path) -> None:
+        """Objective string is normalized to uppercase regardless of input case."""
+        gt_dir, det_dir = _setup_dirs(tmp_path)
+        tuner = Tuner("bytetrack", gt_dir, det_dir, objective="mota")
+        assert tuner._objective_metric == "MOTA"
+
 
 class TestTunerRun:
     def test_run_returns_dict_with_search_space_keys(self, tmp_path: Path) -> None:
@@ -197,6 +226,7 @@ class TestTunerRun:
         reset_calls: list[int] = []
         gt_dir, det_dir = _setup_dirs(tmp_path)
         (det_dir / "seq2.txt").write_text(_MOT_LINE)  # two sequences → two resets
+        (gt_dir / "seq2.txt").write_text(_MOT_LINE)
 
         original_reset = SORTTracker.reset
 

--- a/trackers/scripts/__main__.py
+++ b/trackers/scripts/__main__.py
@@ -42,10 +42,12 @@ def main() -> int:
     from trackers.scripts.download import add_download_subparser
     from trackers.scripts.eval import add_eval_subparser
     from trackers.scripts.track import add_track_subparser
+    from trackers.scripts.tune import add_tune_subparser
 
     add_download_subparser(subparsers)
     add_eval_subparser(subparsers)
     add_track_subparser(subparsers)
+    add_tune_subparser(subparsers)
 
     # Parse arguments
     args = parser.parse_args()

--- a/trackers/scripts/tune.py
+++ b/trackers/scripts/tune.py
@@ -164,8 +164,8 @@ def tune(
             threshold=threshold,
             seqmap=seqmap,
         )
-    except (ValueError, ImportError) as e:
-        print(f"Error: {e}", file=sys.stderr)
+    except (ValueError, ImportError, FileNotFoundError) as e:
+        print(str(e), file=sys.stderr)
         return 1
 
     try:

--- a/trackers/scripts/tune.py
+++ b/trackers/scripts/tune.py
@@ -181,8 +181,12 @@ def tune(
         print(f"\nBest {objective}: {tuner.study.best_value:.4f}")
 
     if output:
-        output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(json.dumps(best_params, indent=2))
+        try:
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps(best_params, indent=2))
+        except OSError as e:
+            print(f"Error writing output: {e}", file=sys.stderr)
+            return 1
         print(f"\nResults saved to: {output}")
 
     return 0

--- a/trackers/scripts/tune.py
+++ b/trackers/scripts/tune.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+import json
+import sys
+from pathlib import Path
+
+
+def tune(
+    tracker: str,
+    gt_dir: Path,
+    detections_dir: Path,
+    objective: str = "HOTA",
+    n_trials: int = 100,
+    metrics: list[str] | None = None,
+    threshold: float = 0.5,
+    seqmap: Path | None = None,
+    output: Path | None = None,
+) -> int:
+    """Tune tracker hyperparameters using Optuna.
+
+    Args:
+        tracker: Tracker ID to tune (e.g. bytetrack, sort).
+        gt_dir: Directory of ground-truth MOT files.
+        detections_dir: Directory of pre-computed detection files in MOT flat
+            format (one {seq}.txt per sequence).
+        objective: Scalar metric to maximise. Options: MOTA, HOTA, IDF1.
+        n_trials: Number of Optuna trials to run.
+        metrics: Metric families to compute. Options: CLEAR, HOTA, Identity.
+            Default: CLEAR.
+        threshold: IoU threshold for CLEAR and Identity matching.
+        seqmap: Sequence map file listing sequences to evaluate.
+        output: Output file path for best parameters (JSON format).
+    """
+    if metrics is None:
+        metrics = ["CLEAR"]
+
+    # Normalize objective to uppercase so metric lookup is case-insensitive
+    objective = objective.upper()
+
+    # Auto-add metric family required by the chosen objective
+    OBJECTIVE_TO_FAMILY = {
+        "MOTA": "CLEAR",
+        "HOTA": "HOTA",
+        "IDF1": "Identity",
+    }
+    required_family = OBJECTIVE_TO_FAMILY.get(objective)
+    if required_family and required_family not in metrics:
+        metrics = [*list(metrics), required_family]
+
+    from trackers.tune import Tuner
+
+    try:
+        tuner = Tuner(
+            tracker_id=tracker,
+            gt_dir=gt_dir,
+            detections_dir=detections_dir,
+            metrics=metrics,
+            objective=objective,
+            n_trials=n_trials,
+            threshold=threshold,
+            seqmap=seqmap,
+        )
+    except (ValueError, ImportError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        best_params = tuner.run()
+    except Exception as e:
+        print(f"Error during tuning: {e}", file=sys.stderr)
+        return 1
+
+    print(f"\nBest parameters for {tracker}:")
+    for name, value in best_params.items():
+        print(f"  {name}: {value}")
+    if tuner.study is not None:
+        print(f"\nBest {objective}: {tuner.study.best_value:.4f}")
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(best_params, indent=2))
+        print(f"\nResults saved to: {output}")
+
+    return 0

--- a/trackers/scripts/tune.py
+++ b/trackers/scripts/tune.py
@@ -134,6 +134,9 @@ def tune(
         threshold: IoU threshold for CLEAR and Identity matching.
         seqmap: Sequence map file listing sequences to evaluate.
         output: Output file path for best parameters (JSON format).
+
+    Returns:
+        Exit code: 0 on success, 1 on error.
     """
     if metrics is None:
         metrics = ["CLEAR"]

--- a/trackers/scripts/tune.py
+++ b/trackers/scripts/tune.py
@@ -5,9 +5,108 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from __future__ import annotations
+
+import argparse
 import json
 import sys
 from pathlib import Path
+
+
+def add_tune_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the tune subcommand to the argument parser."""
+    parser = subparsers.add_parser(
+        "tune",
+        help="Tune tracker hyperparameters via Optuna.",
+        description=(
+            "Run Optuna-based hyperparameter optimisation for a registered "
+            "tracker using pre-computed detections and ground-truth MOT files."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--tracker",
+        required=True,
+        metavar="ID",
+        help="Tracker ID to tune (e.g. bytetrack, sort, ocsort).",
+    )
+    parser.add_argument(
+        "--gt-dir",
+        type=Path,
+        required=True,
+        metavar="DIR",
+        help="Directory containing ground-truth MOT files.",
+    )
+    parser.add_argument(
+        "--detections-dir",
+        type=Path,
+        required=True,
+        metavar="DIR",
+        help=(
+            "Directory containing pre-computed detection files in MOT flat "
+            "format (one {seq}.txt per sequence)."
+        ),
+    )
+    parser.add_argument(
+        "--objective",
+        default="HOTA",
+        choices=["MOTA", "HOTA", "IDF1"],
+        help="Scalar metric to maximise. Default: HOTA.",
+    )
+    parser.add_argument(
+        "--n-trials",
+        type=int,
+        default=100,
+        metavar="N",
+        help="Number of Optuna trials to run. Default: 100.",
+    )
+    parser.add_argument(
+        "--metrics",
+        nargs="+",
+        default=["CLEAR"],
+        choices=["CLEAR", "HOTA", "Identity"],
+        help=(
+            "Metric families to compute. Default: CLEAR. The family required "
+            "by --objective is added automatically if missing."
+        ),
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="IoU threshold for CLEAR and Identity matching. Default: 0.5.",
+    )
+    parser.add_argument(
+        "--seqmap",
+        type=Path,
+        metavar="PATH",
+        help="Sequence map file listing sequences to evaluate.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        metavar="PATH",
+        help="Output file for best parameters (JSON format).",
+    )
+
+    parser.set_defaults(func=run_tune)
+
+
+def run_tune(args: argparse.Namespace) -> int:
+    """Execute the tune command."""
+    return tune(
+        tracker=args.tracker,
+        gt_dir=args.gt_dir,
+        detections_dir=args.detections_dir,
+        objective=args.objective,
+        n_trials=args.n_trials,
+        metrics=args.metrics,
+        threshold=args.threshold,
+        seqmap=args.seqmap,
+        output=args.output,
+    )
 
 
 def tune(

--- a/trackers/scripts/tune.py
+++ b/trackers/scripts/tune.py
@@ -141,19 +141,6 @@ def tune(
     if metrics is None:
         metrics = ["CLEAR"]
 
-    # Normalize objective to uppercase so metric lookup is case-insensitive
-    objective = objective.upper()
-
-    # Auto-add metric family required by the chosen objective
-    OBJECTIVE_TO_FAMILY = {
-        "MOTA": "CLEAR",
-        "HOTA": "HOTA",
-        "IDF1": "Identity",
-    }
-    required_family = OBJECTIVE_TO_FAMILY.get(objective)
-    if required_family and required_family not in metrics:
-        metrics = [*list(metrics), required_family]
-
     from trackers.tune import Tuner
 
     try:

--- a/trackers/tune/tuner.py
+++ b/trackers/tune/tuner.py
@@ -45,8 +45,11 @@ class Tuner:
             ``load_mot_file()`` applies its default values.
         metrics: Metric families to compute. Supported values are
             ``["CLEAR", "HOTA", "Identity"]``. Defaults to ``["CLEAR"]``.
+            The family required by ``objective`` is added automatically if
+            missing (e.g. ``objective="HOTA"`` adds ``"HOTA"`` to metrics).
         objective: Scalar metric field to maximise (e.g. ``"MOTA"``,
-            ``"HOTA"``, ``"IDF1"``). Defaults to ``"MOTA"``.
+            ``"HOTA"``, ``"IDF1"``). Case-insensitive. Defaults to
+            ``"MOTA"``.
         n_trials: Number of Optuna trials to run. Defaults to ``100``.
         threshold: IoU threshold forwarded to ``evaluate_mot_sequences``.
             Defaults to ``0.5``.
@@ -107,9 +110,20 @@ class Tuner:
         self._search_space: dict[str, dict] = search_space
         self._gt_dir = Path(gt_dir)
         self._detections_dir = Path(detections_dir)
-        self._metrics = metrics or ["CLEAR"]
-        self._objective_metric = objective
+        self._metrics = list(metrics) if metrics else ["CLEAR"]
+        self._objective_metric = objective.upper()
         self._n_trials = n_trials
+
+        # Auto-add the metric family required by the chosen objective so
+        # callers don't need to remember the mapping themselves.
+        _objective_to_family = {
+            "MOTA": "CLEAR",
+            "HOTA": "HOTA",
+            "IDF1": "Identity",
+        }
+        required_family = _objective_to_family.get(self._objective_metric)
+        if required_family and required_family not in self._metrics:
+            self._metrics = [*self._metrics, required_family]
         self._threshold = threshold
         self._sequences = _discover_sequences(self._detections_dir, seqmap)
         self.study: optuna.Study | None = None


### PR DESCRIPTION
## What does this PR do?

This pR wires the `Tuner` class from PR #301 into a `trackers tune` CLI subcommand, similar to`trackers eval` and `trackers track`. 
Part of #260

## Type of Change
- New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

usage

```bash                                                                                                                                           
# Basic                                                
trackers tune \
--tracker bytetrack \
--gt-dir path/to/gt/ \
--detections-dir path/to/detections/ \                                                                                                          
--n-trials 100

# Custom objective                                     
trackers tune \
--tracker sort \
--gt-dir path/to/gt/ \                                                                                                                          
--detections-dir path/to/detections/ \
--objective HOTA \                                                                                                                              
--n-trials 200   
```