### PR TITLE
refactor(tests): group into classes, parametrize, prune method names

### DIFF
--- a/tests/core/test_botsort_cmc.py
+++ b/tests/core/test_botsort_cmc.py
@@ -145,12 +145,12 @@ class TestCMCEstimateAcrossMethods:
         cmc_ds2.estimate(frame1)
         H2 = cmc_ds2.estimate(frame2)
 
-        for label, H in [("downscale=1", H1), ("downscale=2", H2)]:
-            assert H.shape == (2, 3), f"[{method}/{label}] Bad shape: {H.shape}"
-            assert H.dtype == np.float32, f"[{method}/{label}] Bad dtype: {H.dtype}"
-            assert np.all(np.isfinite(H)), (
-                f"[{method}/{label}] H must contain only finite values"
-            )
+        assert H1.shape == (2, 3)
+        assert H1.dtype == np.float32
+        assert np.all(np.isfinite(H1))
+        assert H2.shape == (2, 3)
+        assert H2.dtype == np.float32
+        assert np.all(np.isfinite(H2))
 
 
 class TestBoTSORTApplyCMCBatch:

--- a/tests/core/test_botsort_tracker.py
+++ b/tests/core/test_botsort_tracker.py
@@ -16,6 +16,7 @@ test_trackers.py.
 from __future__ import annotations
 
 import numpy as np
+import pytest
 import supervision as sv
 
 from trackers.core.botsort.tracker import BoTSORTTracker
@@ -58,21 +59,23 @@ class TestBoTSORTTrackerLifecycle:
         assert result.tracker_id is not None
         assert result.tracker_id[0] >= 0
 
-    def test_supports_all_state_estimators(self) -> None:
-        """BoTSORTTracker should construct and update with all estimator types."""
-        estimators: list[type[BaseStateEstimator]] = [
-            XCYCWHStateEstimator,
-            XYXYStateEstimator,
-            XCYCSRStateEstimator,
-        ]
-        for estimator in estimators:
-            tracker = BoTSORTTracker(
-                enable_cmc=False,
-                state_estimator_class=estimator,
-                minimum_consecutive_frames=1,
-            )
-            result = tracker.update(_detection((100.0, 100.0, 200.0, 200.0), conf=0.9))
-            assert len(result) == 1
+    @pytest.mark.parametrize(
+        "estimator_class",
+        [XCYCWHStateEstimator, XYXYStateEstimator, XCYCSRStateEstimator],
+        ids=["xcycwh", "xyxy", "xcycsr"],
+    )
+    def test_supports_state_estimator(
+        self,
+        estimator_class: type[BaseStateEstimator],
+    ) -> None:
+        """BoTSORTTracker constructs and updates with any supported estimator."""
+        tracker = BoTSORTTracker(
+            enable_cmc=False,
+            state_estimator_class=estimator_class,
+            minimum_consecutive_frames=1,
+        )
+        result = tracker.update(_detection((100.0, 100.0, 200.0, 200.0), conf=0.9))
+        assert len(result) == 1
 
 
 class TestBoTSORTTrackerCMC:

--- a/tests/core/test_registration.py
+++ b/tests/core/test_registration.py
@@ -170,6 +170,7 @@ class TestNormalizeType:
     def test_normalize_type(
         self, annotation: Any, default: Any, expected: type
     ) -> None:
+        """_normalize_type returns the expected base type for assorted annotations."""
         assert _normalize_type(annotation, default) == expected
 
 

--- a/tests/eval/test_box.py
+++ b/tests/eval/test_box.py
@@ -14,238 +14,250 @@ import pytest
 from trackers.eval.box import EPS, BoxFormat, box_ioa, box_iou
 
 
-@pytest.mark.parametrize(
-    ("boxes1", "boxes2", "box_format", "expected_iou"),
-    [
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[0, 0, 10, 10]]),
-            "xyxy",
-            np.array([[1.0]]),
-        ),  # identical boxes, perfect overlap
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[20, 20, 30, 30]]),
-            "xyxy",
-            np.array([[0.0]]),
-        ),  # disjoint boxes, no overlap
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[5, 0, 15, 10]]),
-            "xyxy",
-            np.array([[1 / 3]]),
-        ),  # partial overlap, intersection=50, union=150
-        (
-            np.array([[0, 0, 20, 20]]),
-            np.array([[5, 5, 15, 15]]),
-            "xyxy",
-            np.array([[0.25]]),
-        ),  # contained box, intersection=100, union=400
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[10, 0, 20, 10]]),
-            "xyxy",
-            np.array([[0.0]]),
-        ),  # boxes touching at edge
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[10, 10, 20, 20]]),
-            "xyxy",
-            np.array([[0.0]]),
-        ),  # boxes touching at corner
-        (
-            np.array([[0, 0, 10, 10], [20, 20, 30, 30]]),
-            np.array([[0, 0, 10, 10], [5, 0, 15, 10], [100, 100, 110, 110]]),
-            "xyxy",
-            np.array([[1.0, 1 / 3, 0.0], [0.0, 0.0, 0.0]]),
-        ),  # multiple boxes batch
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[5, 0, 10, 10]]),
-            "xywh",
-            np.array([[1 / 3]]),
-        ),  # xywh format
-        (
-            np.empty((0, 4)),
-            np.array([[0, 0, 10, 10]]),
-            "xyxy",
-            np.empty((0, 1)),
-        ),  # empty boxes1
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.empty((0, 4)),
-            "xyxy",
-            np.empty((1, 0)),
-        ),  # empty boxes2
-        (
-            np.empty((0, 4)),
-            np.empty((0, 4)),
-            "xyxy",
-            np.empty((0, 0)),
-        ),  # both empty
-        (
-            np.array([[5, 5, 5, 5]]),
-            np.array([[0, 0, 10, 10]]),
-            "xyxy",
-            np.array([[0.0]]),
-        ),  # zero-area box
-        (
-            np.array([[1e6, 1e6, 1e6 + 10, 1e6 + 10]]),
-            np.array([[1e6, 1e6, 1e6 + 10, 1e6 + 10]]),
-            "xyxy",
-            np.array([[1.0]]),
-        ),  # large coordinates
-    ],
-)
-def test_box_iou(
-    boxes1: np.ndarray[Any, np.dtype[Any]],
-    boxes2: np.ndarray[Any, np.dtype[Any]],
-    box_format: BoxFormat,
-    expected_iou: np.ndarray[Any, np.dtype[Any]],
-) -> None:
-    result = box_iou(boxes1, boxes2, box_format=box_format)
-    assert result.shape == expected_iou.shape
-    assert np.allclose(result, expected_iou, rtol=1e-6, atol=1e-12)
+class TestBoxIoU:
+    """Pairwise intersection-over-union computation."""
+
+    @pytest.mark.parametrize(
+        ("boxes1", "boxes2", "box_format", "expected_iou"),
+        [
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[0, 0, 10, 10]]),
+                "xyxy",
+                np.array([[1.0]]),
+            ),  # identical boxes, perfect overlap
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[20, 20, 30, 30]]),
+                "xyxy",
+                np.array([[0.0]]),
+            ),  # disjoint boxes, no overlap
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[5, 0, 15, 10]]),
+                "xyxy",
+                np.array([[1 / 3]]),
+            ),  # partial overlap, intersection=50, union=150
+            (
+                np.array([[0, 0, 20, 20]]),
+                np.array([[5, 5, 15, 15]]),
+                "xyxy",
+                np.array([[0.25]]),
+            ),  # contained box, intersection=100, union=400
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[10, 0, 20, 10]]),
+                "xyxy",
+                np.array([[0.0]]),
+            ),  # boxes touching at edge
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[10, 10, 20, 20]]),
+                "xyxy",
+                np.array([[0.0]]),
+            ),  # boxes touching at corner
+            (
+                np.array([[0, 0, 10, 10], [20, 20, 30, 30]]),
+                np.array([[0, 0, 10, 10], [5, 0, 15, 10], [100, 100, 110, 110]]),
+                "xyxy",
+                np.array([[1.0, 1 / 3, 0.0], [0.0, 0.0, 0.0]]),
+            ),  # multiple boxes batch
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[5, 0, 10, 10]]),
+                "xywh",
+                np.array([[1 / 3]]),
+            ),  # xywh format
+            (
+                np.empty((0, 4)),
+                np.array([[0, 0, 10, 10]]),
+                "xyxy",
+                np.empty((0, 1)),
+            ),  # empty boxes1
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.empty((0, 4)),
+                "xyxy",
+                np.empty((1, 0)),
+            ),  # empty boxes2
+            (
+                np.empty((0, 4)),
+                np.empty((0, 4)),
+                "xyxy",
+                np.empty((0, 0)),
+            ),  # both empty
+            (
+                np.array([[5, 5, 5, 5]]),
+                np.array([[0, 0, 10, 10]]),
+                "xyxy",
+                np.array([[0.0]]),
+            ),  # zero-area box
+            (
+                np.array([[1e6, 1e6, 1e6 + 10, 1e6 + 10]]),
+                np.array([[1e6, 1e6, 1e6 + 10, 1e6 + 10]]),
+                "xyxy",
+                np.array([[1.0]]),
+            ),  # large coordinates
+        ],
+    )
+    def test_values(
+        self,
+        boxes1: np.ndarray[Any, np.dtype[Any]],
+        boxes2: np.ndarray[Any, np.dtype[Any]],
+        box_format: BoxFormat,
+        expected_iou: np.ndarray[Any, np.dtype[Any]],
+    ) -> None:
+        """box_iou returns the expected pairwise IoU matrix for assorted box layouts."""
+        result = box_iou(boxes1, boxes2, box_format=box_format)
+        assert result.shape == expected_iou.shape
+        assert np.allclose(result, expected_iou, rtol=1e-6, atol=1e-12)
+
+    def test_invalid_format(self) -> None:
+        """box_iou raises ValueError when box_format is not 'xyxy' or 'xywh'."""
+        boxes = np.array([[0, 0, 10, 10]])
+        with pytest.raises(ValueError, match="box_format must be"):
+            box_iou(boxes, boxes, box_format="invalid")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        ("boxes1", "boxes2", "expected_iou"),
+        [
+            (
+                np.array([[0.5, 0.5, 10.5, 10.5]]),
+                np.array([[0.5, 0.5, 10.5, 10.5]]),
+                np.array([[1.0]]),
+            ),  # floating point coords, identical boxes
+            (
+                np.array([[0.0, 0.0, 1.0, 1.0]]),
+                np.array([[0.5, 0.0, 1.5, 1.0]]),
+                np.array([[1 / 3]]),
+            ),  # unit boxes with 50% horizontal overlap
+            (
+                np.array([[0.0, 0.0, 0.1, 0.1]]),
+                np.array([[0.0, 0.0, 0.1, 0.1]]),
+                np.array([[1.0]]),
+            ),  # very small boxes (area=0.01)
+            (
+                np.array([[0.0, 0.0, 1e-6, 1e-6]]),
+                np.array([[0.0, 0.0, 1e-6, 1e-6]]),
+                np.array([[1.0]]),
+            ),  # near-epsilon sized boxes
+            (
+                np.array([[0.0, 0.0, 100.0, 100.0]]),
+                np.array([[99.9, 99.9, 100.0, 100.0]]),
+                np.array([[0.01 / (10000 + 0.01 - 0.01)]]),
+            ),  # tiny overlap (0.1 x 0.1 = 0.01)
+            (
+                np.array([[0.123456789, 0.987654321, 10.111111111, 10.222222222]]),
+                np.array([[0.123456789, 0.987654321, 10.111111111, 10.222222222]]),
+                np.array([[1.0]]),
+            ),  # many decimal places, identical
+            (
+                np.array([[1e-10, 1e-10, 1.0 + 1e-10, 1.0 + 1e-10]]),
+                np.array([[0.0, 0.0, 1.0, 1.0]]),
+                np.array([[1.0]]),
+            ),  # near-identical with tiny offset
+        ],
+    )
+    def test_floating_point(
+        self,
+        boxes1: np.ndarray[Any, np.dtype[Any]],
+        boxes2: np.ndarray[Any, np.dtype[Any]],
+        expected_iou: np.ndarray[Any, np.dtype[Any]],
+    ) -> None:
+        """box_iou is numerically stable across sub-pixel and large-coordinate boxes."""
+        result = box_iou(boxes1, boxes2, box_format="xyxy")
+        assert result.shape == expected_iou.shape
+        assert np.allclose(result, expected_iou, rtol=1e-5, atol=1e-10)
+
+    @pytest.mark.parametrize(
+        ("num_boxes1", "num_boxes2"),
+        [
+            (5, 5),
+            (5, 10),
+            (10, 5),
+            (50, 50),
+        ],
+    )
+    def test_valid_range(self, num_boxes1: int, num_boxes2: int) -> None:
+        """box_iou results stay within [0, 1] (modulo EPS) for random boxes."""
+        rng = np.random.default_rng(42)
+        boxes1 = rng.random((num_boxes1, 4)) * 100
+        boxes2 = rng.random((num_boxes2, 4)) * 100
+
+        # Ensure valid xyxy format (x1 > x0, y1 > y0)
+        boxes1[:, 2:] = boxes1[:, :2] + np.abs(boxes1[:, 2:])
+        boxes2[:, 2:] = boxes2[:, :2] + np.abs(boxes2[:, 2:])
+
+        ious = box_iou(boxes1, boxes2, box_format="xyxy")
+
+        assert ious.shape == (num_boxes1, num_boxes2)
+        assert (ious >= 0 - EPS).all()
+        assert (ious <= 1 + EPS).all()
 
 
-def test_box_iou_invalid_format() -> None:
-    boxes = np.array([[0, 0, 10, 10]])
-    with pytest.raises(ValueError, match="box_format must be"):
-        box_iou(boxes, boxes, box_format="invalid")  # type: ignore[arg-type]
+class TestBoxIoA:
+    """Intersection-over-area computation."""
 
+    @pytest.mark.parametrize(
+        ("boxes1", "boxes2", "box_format", "expected_ioa"),
+        [
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[0, 0, 10, 10]]),
+                "xyxy",
+                np.array([[1.0]]),
+            ),  # identical boxes
+            (
+                np.array([[5, 5, 15, 15]]),
+                np.array([[0, 0, 20, 20]]),
+                "xyxy",
+                np.array([[1.0]]),
+            ),  # detection fully inside ignore region
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[5, 0, 15, 10]]),
+                "xyxy",
+                np.array([[0.5]]),
+            ),  # partial overlap, intersection=50, area1=100
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[20, 20, 30, 30]]),
+                "xyxy",
+                np.array([[0.0]]),
+            ),  # no overlap
+            (
+                np.array([[5, 5, 5, 5]]),
+                np.array([[0, 0, 10, 10]]),
+                "xyxy",
+                np.array([[0.0]]),
+            ),  # zero-area box
+            (
+                np.array([[0, 0, 10, 10]]),
+                np.array([[5, 0, 10, 10]]),
+                "xywh",
+                np.array([[0.5]]),
+            ),  # xywh format
+        ],
+    )
+    def test_values(
+        self,
+        boxes1: np.ndarray[Any, np.dtype[Any]],
+        boxes2: np.ndarray[Any, np.dtype[Any]],
+        box_format: BoxFormat,
+        expected_ioa: np.ndarray[Any, np.dtype[Any]],
+    ) -> None:
+        """box_ioa returns the expected intersection-over-area matrix."""
+        result = box_ioa(boxes1, boxes2, box_format=box_format)
+        assert result.shape == expected_ioa.shape
+        assert np.allclose(result, expected_ioa, rtol=1e-6, atol=1e-12)
 
-@pytest.mark.parametrize(
-    ("boxes1", "boxes2", "box_format", "expected_ioa"),
-    [
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[0, 0, 10, 10]]),
-            "xyxy",
-            np.array([[1.0]]),
-        ),  # identical boxes
-        (
-            np.array([[5, 5, 15, 15]]),
-            np.array([[0, 0, 20, 20]]),
-            "xyxy",
-            np.array([[1.0]]),
-        ),  # detection fully inside ignore region
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[5, 0, 15, 10]]),
-            "xyxy",
-            np.array([[0.5]]),
-        ),  # partial overlap, intersection=50, area1=100
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[20, 20, 30, 30]]),
-            "xyxy",
-            np.array([[0.0]]),
-        ),  # no overlap
-        (
-            np.array([[5, 5, 5, 5]]),
-            np.array([[0, 0, 10, 10]]),
-            "xyxy",
-            np.array([[0.0]]),
-        ),  # zero-area box
-        (
-            np.array([[0, 0, 10, 10]]),
-            np.array([[5, 0, 10, 10]]),
-            "xywh",
-            np.array([[0.5]]),
-        ),  # xywh format
-    ],
-)
-def test_box_ioa(
-    boxes1: np.ndarray[Any, np.dtype[Any]],
-    boxes2: np.ndarray[Any, np.dtype[Any]],
-    box_format: BoxFormat,
-    expected_ioa: np.ndarray[Any, np.dtype[Any]],
-) -> None:
-    result = box_ioa(boxes1, boxes2, box_format=box_format)
-    assert result.shape == expected_ioa.shape
-    assert np.allclose(result, expected_ioa, rtol=1e-6, atol=1e-12)
-
-
-def test_box_ioa_invalid_format() -> None:
-    boxes = np.array([[0, 0, 10, 10]])
-    with pytest.raises(ValueError, match="box_format must be"):
-        box_ioa(boxes, boxes, box_format="invalid")  # type: ignore[arg-type]
-
-
-@pytest.mark.parametrize(
-    ("boxes1", "boxes2", "expected_iou"),
-    [
-        (
-            np.array([[0.5, 0.5, 10.5, 10.5]]),
-            np.array([[0.5, 0.5, 10.5, 10.5]]),
-            np.array([[1.0]]),
-        ),  # floating point coords, identical boxes
-        (
-            np.array([[0.0, 0.0, 1.0, 1.0]]),
-            np.array([[0.5, 0.0, 1.5, 1.0]]),
-            np.array([[1 / 3]]),
-        ),  # unit boxes with 50% horizontal overlap
-        (
-            np.array([[0.0, 0.0, 0.1, 0.1]]),
-            np.array([[0.0, 0.0, 0.1, 0.1]]),
-            np.array([[1.0]]),
-        ),  # very small boxes (area=0.01)
-        (
-            np.array([[0.0, 0.0, 1e-6, 1e-6]]),
-            np.array([[0.0, 0.0, 1e-6, 1e-6]]),
-            np.array([[1.0]]),
-        ),  # near-epsilon sized boxes
-        (
-            np.array([[0.0, 0.0, 100.0, 100.0]]),
-            np.array([[99.9, 99.9, 100.0, 100.0]]),
-            np.array([[0.01 / (10000 + 0.01 - 0.01)]]),
-        ),  # tiny overlap (0.1 x 0.1 = 0.01)
-        (
-            np.array([[0.123456789, 0.987654321, 10.111111111, 10.222222222]]),
-            np.array([[0.123456789, 0.987654321, 10.111111111, 10.222222222]]),
-            np.array([[1.0]]),
-        ),  # many decimal places, identical
-        (
-            np.array([[1e-10, 1e-10, 1.0 + 1e-10, 1.0 + 1e-10]]),
-            np.array([[0.0, 0.0, 1.0, 1.0]]),
-            np.array([[1.0]]),
-        ),  # near-identical with tiny offset
-    ],
-)
-def test_box_iou_floating_point(
-    boxes1: np.ndarray[Any, np.dtype[Any]],
-    boxes2: np.ndarray[Any, np.dtype[Any]],
-    expected_iou: np.ndarray[Any, np.dtype[Any]],
-) -> None:
-    result = box_iou(boxes1, boxes2, box_format="xyxy")
-    assert result.shape == expected_iou.shape
-    assert np.allclose(result, expected_iou, rtol=1e-5, atol=1e-10)
-
-
-@pytest.mark.parametrize(
-    ("num_boxes1", "num_boxes2"),
-    [
-        (5, 5),
-        (5, 10),
-        (10, 5),
-        (50, 50),
-    ],
-)
-def test_box_iou_valid_range(num_boxes1: int, num_boxes2: int) -> None:
-    rng = np.random.default_rng(42)
-    boxes1 = rng.random((num_boxes1, 4)) * 100
-    boxes2 = rng.random((num_boxes2, 4)) * 100
-
-    # Ensure valid xyxy format (x1 > x0, y1 > y0)
-    boxes1[:, 2:] = boxes1[:, :2] + np.abs(boxes1[:, 2:])
-    boxes2[:, 2:] = boxes2[:, :2] + np.abs(boxes2[:, 2:])
-
-    ious = box_iou(boxes1, boxes2, box_format="xyxy")
-
-    assert ious.shape == (num_boxes1, num_boxes2)
-    assert (ious >= 0 - EPS).all()
-    assert (ious <= 1 + EPS).all()
+    def test_invalid_format(self) -> None:
+        """box_ioa raises ValueError when box_format is not 'xyxy' or 'xywh'."""
+        boxes = np.array([[0, 0, 10, 10]])
+        with pytest.raises(ValueError, match="box_format must be"):
+            box_ioa(boxes, boxes, box_format="invalid")  # type: ignore[arg-type]
 
 
 def test_epsilon_matches_trackeval() -> None:
+    """EPS constant equals numpy float epsilon, matching the TrackEval reference."""
     assert EPS == np.finfo("float").eps

--- a/tests/eval/test_clear.py
+++ b/tests/eval/test_clear.py
@@ -300,6 +300,7 @@ def test_compute_clear_metrics(
     threshold: float,
     expected: dict[str, Any],
 ) -> None:
+    """compute_clear_metrics produces the expected CLEAR-MOT counts across scenarios."""
     result = compute_clear_metrics(
         gt_ids, tracker_ids, similarity_scores, threshold=threshold
     )

--- a/tests/eval/test_evaluate.py
+++ b/tests/eval/test_evaluate.py
@@ -29,118 +29,76 @@ def sample_mot_files(tmp_path: Path) -> tuple[Path, Path]:
     return gt_path, tracker_path
 
 
-def test_evaluate_mot_sequence_hota_only(sample_mot_files: tuple[Path, Path]) -> None:
-    """Test evaluate_mot_sequence with only HOTA metrics (no CLEAR)."""
-    gt_path, tracker_path = sample_mot_files
+class TestEvaluateMOTSequence:
+    """MOT sequence evaluation: single-metric, multi-metric, and output formats."""
 
-    result = evaluate_mot_sequence(
-        gt_path=gt_path,
-        tracker_path=tracker_path,
-        metrics=["HOTA"],
+    @pytest.mark.parametrize(
+        ("metric", "check_field", "other_metrics"),
+        [
+            ("HOTA", ("HOTA", "HOTA"), ["CLEAR", "Identity"]),
+            ("Identity", ("Identity", "IDF1"), ["CLEAR", "HOTA"]),
+            ("CLEAR", ("CLEAR", "MOTA"), ["HOTA", "Identity"]),
+        ],
+        ids=["hota_only", "identity_only", "clear_only"],
     )
+    def test_single_metric(
+        self,
+        sample_mot_files: tuple[Path, Path],
+        metric: str,
+        check_field: tuple[str, str],
+        other_metrics: list[str],
+    ) -> None:
+        """Single-metric evaluation returns only the requested metric."""
+        gt_path, tracker_path = sample_mot_files
+        result = evaluate_mot_sequence(
+            gt_path=gt_path, tracker_path=tracker_path, metrics=[metric]
+        )
+        attr_name, field_name = check_field
+        computed = getattr(result, attr_name)
+        assert computed is not None
+        assert getattr(computed, field_name) is not None
+        for other in other_metrics:
+            assert getattr(result, other) is None
 
-    # HOTA should be present
-    assert result.HOTA is not None
-    assert result.HOTA.HOTA >= 0
-    assert result.HOTA.DetA >= 0
-    assert result.HOTA.AssA >= 0
+    def test_all_metrics(self, sample_mot_files: tuple[Path, Path]) -> None:
+        """All three metric groups are present when all metrics requested."""
+        gt_path, tracker_path = sample_mot_files
 
-    # CLEAR should be None when not requested
-    assert result.CLEAR is None
+        result = evaluate_mot_sequence(
+            gt_path=gt_path,
+            tracker_path=tracker_path,
+            metrics=["CLEAR", "HOTA", "Identity"],
+        )
 
-    # Identity should be None when not requested
-    assert result.Identity is None
+        assert result.CLEAR is not None
+        assert result.HOTA is not None
+        assert result.Identity is not None
 
+    def test_table_hota_only(self, sample_mot_files: tuple[Path, Path]) -> None:
+        """table() shows HOTA and DetA; MOTA absent when only HOTA computed."""
+        gt_path, tracker_path = sample_mot_files
 
-def test_evaluate_mot_sequence_identity_only(
-    sample_mot_files: tuple[Path, Path],
-) -> None:
-    """Test evaluate_mot_sequence with only Identity metrics."""
-    gt_path, tracker_path = sample_mot_files
+        result = evaluate_mot_sequence(
+            gt_path=gt_path,
+            tracker_path=tracker_path,
+            metrics=["HOTA"],
+        )
 
-    result = evaluate_mot_sequence(
-        gt_path=gt_path,
-        tracker_path=tracker_path,
-        metrics=["Identity"],
-    )
+        table_str = result.table()
+        assert "HOTA" in table_str
+        assert "DetA" in table_str
+        assert "MOTA" not in table_str
 
-    # Identity should be present
-    assert result.Identity is not None
-    assert result.Identity.IDF1 >= 0
+    def test_json_hota_only(self, sample_mot_files: tuple[Path, Path]) -> None:
+        """json() includes HOTA fields when only HOTA computed."""
+        gt_path, tracker_path = sample_mot_files
 
-    # CLEAR and HOTA should be None
-    assert result.CLEAR is None
-    assert result.HOTA is None
+        result = evaluate_mot_sequence(
+            gt_path=gt_path,
+            tracker_path=tracker_path,
+            metrics=["HOTA"],
+        )
 
-
-def test_evaluate_mot_sequence_clear_only(sample_mot_files: tuple[Path, Path]) -> None:
-    """Test evaluate_mot_sequence with only CLEAR metrics (default)."""
-    gt_path, tracker_path = sample_mot_files
-
-    result = evaluate_mot_sequence(
-        gt_path=gt_path,
-        tracker_path=tracker_path,
-        metrics=["CLEAR"],
-    )
-
-    # CLEAR should be present
-    assert result.CLEAR is not None
-    assert result.CLEAR.MOTA is not None
-
-    # HOTA and Identity should be None
-    assert result.HOTA is None
-    assert result.Identity is None
-
-
-def test_evaluate_mot_sequence_all_metrics(sample_mot_files: tuple[Path, Path]) -> None:
-    """Test evaluate_mot_sequence with all metrics."""
-    gt_path, tracker_path = sample_mot_files
-
-    result = evaluate_mot_sequence(
-        gt_path=gt_path,
-        tracker_path=tracker_path,
-        metrics=["CLEAR", "HOTA", "Identity"],
-    )
-
-    # All should be present
-    assert result.CLEAR is not None
-    assert result.HOTA is not None
-    assert result.Identity is not None
-
-
-def test_evaluate_mot_sequence_table_hota_only(
-    sample_mot_files: tuple[Path, Path],
-) -> None:
-    """Test that table() works when only HOTA is computed."""
-    gt_path, tracker_path = sample_mot_files
-
-    result = evaluate_mot_sequence(
-        gt_path=gt_path,
-        tracker_path=tracker_path,
-        metrics=["HOTA"],
-    )
-
-    # table() should work without errors
-    table_str = result.table()
-    assert "HOTA" in table_str
-    assert "DetA" in table_str
-    # CLEAR columns should not be present
-    assert "MOTA" not in table_str
-
-
-def test_evaluate_mot_sequence_json_hota_only(
-    sample_mot_files: tuple[Path, Path],
-) -> None:
-    """Test that json() works when only HOTA is computed."""
-    gt_path, tracker_path = sample_mot_files
-
-    result = evaluate_mot_sequence(
-        gt_path=gt_path,
-        tracker_path=tracker_path,
-        metrics=["HOTA"],
-    )
-
-    # json() should work without errors
-    json_str = result.json()
-    assert "HOTA" in json_str
-    assert "DetA" in json_str
+        json_str = result.json()
+        assert "HOTA" in json_str
+        assert "DetA" in json_str

--- a/tests/eval/test_evaluate.py
+++ b/tests/eval/test_evaluate.py
@@ -57,6 +57,9 @@ class TestEvaluateMOTSequence:
         computed = getattr(result, attr_name)
         assert computed is not None
         assert getattr(computed, field_name) is not None
+        if metric == "HOTA":
+            assert computed.DetA is not None
+            assert computed.AssA is not None
         for other in other_metrics:
             assert getattr(result, other) is None
 

--- a/tests/eval/test_hota.py
+++ b/tests/eval/test_hota.py
@@ -18,256 +18,251 @@ from trackers.eval.hota import (
 )
 
 
-@pytest.mark.parametrize(
-    (
-        "gt_ids",
-        "tracker_ids",
-        "similarity_scores",
-        "expected",
-    ),
-    [
-        # Empty GT and tracker
+class TestComputeHOTAMetrics:
+    """Per-sequence HOTA metric computation (DetA, AssA, LocA, HOTA)."""
+
+    @pytest.mark.parametrize(
         (
-            [np.array([])],
-            [np.array([])],
-            [np.zeros((0, 0))],
-            {"HOTA_TP": 0, "HOTA_FN": 0, "HOTA_FP": 0},
+            "gt_ids",
+            "tracker_ids",
+            "similarity_scores",
+            "expected",
         ),
-        # No tracker detections - all FN
-        (
-            [np.array([0, 1]), np.array([0, 1])],
-            [np.array([]), np.array([])],
-            [np.zeros((2, 0)), np.zeros((2, 0))],
-            {"HOTA": 0.0, "DetA": 0.0, "HOTA_FN": 4 * 19, "HOTA_FP": 0, "HOTA_TP": 0},
-        ),
-        # No GT detections - all FP
-        (
-            [np.array([]), np.array([])],
-            [np.array([10, 20]), np.array([10, 20])],
-            [np.zeros((0, 2)), np.zeros((0, 2))],
-            {"HOTA": 0.0, "DetA": 0.0, "HOTA_FP": 4 * 19, "HOTA_FN": 0, "HOTA_TP": 0},
-        ),
-        # Perfect tracking with high IoU
-        (
-            [np.array([0, 1]), np.array([0, 1])],
-            [np.array([10, 20]), np.array([10, 20])],
-            [
-                np.array([[0.9, 0.0], [0.0, 0.9]]),
-                np.array([[0.9, 0.0], [0.0, 0.9]]),
-            ],
-            {"HOTA_min": 0.8, "DetA_min": 0.8, "AssA_min": 0.9},
-        ),
-        # ID switch reduces AssA
-        (
-            [np.array([0, 1]), np.array([0, 1])],
-            [np.array([10, 20]), np.array([10, 20])],
-            [
-                np.array([[0.8, 0.1], [0.1, 0.8]]),  # Normal matching
-                np.array([[0.1, 0.8], [0.8, 0.1]]),  # Swapped!
-            ],
-            {"DetA_min": 0.5, "AssA_max": 0.8},
-        ),
-        # Low IoU passes fewer alpha thresholds
-        (
-            [np.array([0])],
-            [np.array([10])],
-            [np.array([[0.3]])],
-            {"HOTA_min": 0.0, "HOTA_max": 0.5, "HOTA_TP_min": 1},
-        ),
-        # Multiple objects partial match
-        (
-            [np.array([0, 1, 2])],
-            [np.array([10, 20])],  # Only 2 trackers for 3 GTs
-            [
-                np.array(
-                    [
-                        [0.8, 0.0],
-                        [0.0, 0.8],
-                        [0.0, 0.0],  # GT2 has no match
-                    ]
+        [
+            # Empty GT and tracker
+            (
+                [np.array([])],
+                [np.array([])],
+                [np.zeros((0, 0))],
+                {"HOTA_TP": 0, "HOTA_FN": 0, "HOTA_FP": 0},
+            ),
+            # No tracker detections - all FN
+            (
+                [np.array([0, 1]), np.array([0, 1])],
+                [np.array([]), np.array([])],
+                [np.zeros((2, 0)), np.zeros((2, 0))],
+                {
+                    "HOTA": 0.0,
+                    "DetA": 0.0,
+                    "HOTA_FN": 4 * 19,
+                    "HOTA_FP": 0,
+                    "HOTA_TP": 0,
+                },
+            ),
+            # No GT detections - all FP
+            (
+                [np.array([]), np.array([])],
+                [np.array([10, 20]), np.array([10, 20])],
+                [np.zeros((0, 2)), np.zeros((0, 2))],
+                {
+                    "HOTA": 0.0,
+                    "DetA": 0.0,
+                    "HOTA_FP": 4 * 19,
+                    "HOTA_FN": 0,
+                    "HOTA_TP": 0,
+                },
+            ),
+            # Perfect tracking with high IoU
+            (
+                [np.array([0, 1]), np.array([0, 1])],
+                [np.array([10, 20]), np.array([10, 20])],
+                [
+                    np.array([[0.9, 0.0], [0.0, 0.9]]),
+                    np.array([[0.9, 0.0], [0.0, 0.9]]),
+                ],
+                {"HOTA_min": 0.8, "DetA_min": 0.8, "AssA_min": 0.9},
+            ),
+            # ID switch reduces AssA
+            (
+                [np.array([0, 1]), np.array([0, 1])],
+                [np.array([10, 20]), np.array([10, 20])],
+                [
+                    np.array([[0.8, 0.1], [0.1, 0.8]]),  # Normal matching
+                    np.array([[0.1, 0.8], [0.8, 0.1]]),  # Swapped!
+                ],
+                {"DetA_min": 0.5, "AssA_max": 0.8},
+            ),
+            # Low IoU passes fewer alpha thresholds
+            (
+                [np.array([0])],
+                [np.array([10])],
+                [np.array([[0.3]])],
+                {"HOTA_min": 0.0, "HOTA_max": 0.5, "HOTA_TP_min": 1},
+            ),
+            # Multiple objects partial match
+            (
+                [np.array([0, 1, 2])],
+                [np.array([10, 20])],  # Only 2 trackers for 3 GTs
+                [
+                    np.array(
+                        [
+                            [0.8, 0.0],
+                            [0.0, 0.8],
+                            [0.0, 0.0],  # GT2 has no match
+                        ]
+                    )
+                ],
+                {"HOTA_FN_min": 19, "DetRe_max": 1.0, "DetPr_max": 1.0},
+            ),
+            # Single frame perfect matching
+            (
+                [np.array([0])],
+                [np.array([10])],
+                [np.array([[0.8]])],
+                {"HOTA_TP_min": 1, "LocA_min": 0.8},
+            ),
+        ],
+    )
+    def test_scenarios(
+        self,
+        gt_ids: list[np.ndarray[Any, np.dtype[Any]]],
+        tracker_ids: list[np.ndarray[Any, np.dtype[Any]]],
+        similarity_scores: list[np.ndarray[Any, np.dtype[Any]]],
+        expected: dict[str, Any],
+    ) -> None:
+        """compute_hota_metrics produces expected HOTA fields across scenarios."""
+        result = compute_hota_metrics(gt_ids, tracker_ids, similarity_scores)
+
+        for field in [
+            "HOTA",
+            "DetA",
+            "AssA",
+            "DetRe",
+            "DetPr",
+            "AssRe",
+            "AssPr",
+            "LocA",
+        ]:
+            assert field in result
+            assert isinstance(result[field], float)
+
+        for field in ["HOTA_TP", "HOTA_FN", "HOTA_FP"]:
+            assert field in result
+            assert isinstance(result[field], int)
+
+        for key, value in expected.items():
+            if key.endswith("_min"):
+                actual_key = key[:-4]
+                assert result[actual_key] >= value, (
+                    f"{actual_key} should be >= {value}, got {result[actual_key]}"
                 )
-            ],
-            {"HOTA_FN_min": 19, "DetRe_max": 1.0, "DetPr_max": 1.0},
-        ),
-        # Single frame perfect matching
-        (
-            [np.array([0])],
-            [np.array([10])],
-            [np.array([[0.8]])],
-            {"HOTA_TP_min": 1, "LocA_min": 0.8},
-        ),
-    ],
-)
-def test_compute_hota_metrics(
-    gt_ids: list[np.ndarray[Any, np.dtype[Any]]],
-    tracker_ids: list[np.ndarray[Any, np.dtype[Any]]],
-    similarity_scores: list[np.ndarray[Any, np.dtype[Any]]],
-    expected: dict[str, Any],
-) -> None:
-    result = compute_hota_metrics(gt_ids, tracker_ids, similarity_scores)
+            elif key.endswith("_max"):
+                actual_key = key[:-4]
+                assert result[actual_key] <= value, (
+                    f"{actual_key} should be <= {value}, got {result[actual_key]}"
+                )
+            elif key.endswith("_approx"):
+                actual_key = key[:-7]
+                assert result[actual_key] == pytest.approx(value, rel=0.01), (
+                    f"{actual_key} should be ~{value}, got {result[actual_key]}"
+                )
+            elif isinstance(value, float):
+                assert result[key] == pytest.approx(value), (
+                    f"Mismatch for {key}: {result[key]} != {value}"
+                )
+            else:
+                assert result[key] == value, (
+                    f"Mismatch for {key}: {result[key]} != {value}"
+                )
 
-    # Verify all expected fields are present
-    for field in ["HOTA", "DetA", "AssA", "DetRe", "DetPr", "AssRe", "AssPr", "LocA"]:
-        assert field in result
-        assert isinstance(result[field], float)
+    def test_result_structure(self) -> None:
+        """Result contains all float summary, integer count, and array fields."""
+        result = compute_hota_metrics(
+            gt_ids=[np.array([0])],
+            tracker_ids=[np.array([10])],
+            similarity_scores=[np.array([[0.8]])],
+        )
 
-    for field in ["HOTA_TP", "HOTA_FN", "HOTA_FP"]:
-        assert field in result
-        assert isinstance(result[field], int)
+        for field in [
+            "HOTA",
+            "DetA",
+            "AssA",
+            "DetRe",
+            "DetPr",
+            "AssRe",
+            "AssPr",
+            "LocA",
+            "OWTA",
+        ]:
+            assert field in result
+            assert isinstance(result[field], float)
+            assert 0 <= result[field] <= 1
 
-    # Check expected values
-    for key, value in expected.items():
-        if key.endswith("_min"):
-            actual_key = key[:-4]
-            assert result[actual_key] >= value, (
-                f"{actual_key} should be >= {value}, got {result[actual_key]}"
-            )
-        elif key.endswith("_max"):
-            actual_key = key[:-4]
-            assert result[actual_key] <= value, (
-                f"{actual_key} should be <= {value}, got {result[actual_key]}"
-            )
-        elif key.endswith("_approx"):
-            actual_key = key[:-7]
-            assert result[actual_key] == pytest.approx(value, rel=0.01), (
-                f"{actual_key} should be ~{value}, got {result[actual_key]}"
-            )
-        elif isinstance(value, float):
-            assert result[key] == pytest.approx(value), (
-                f"Mismatch for {key}: {result[key]} != {value}"
-            )
-        else:
-            assert result[key] == value, f"Mismatch for {key}: {result[key]} != {value}"
+        for field in ["HOTA_TP", "HOTA_FN", "HOTA_FP"]:
+            assert field in result
+            assert isinstance(result[field], int)
+            assert result[field] >= 0
 
-
-def test_compute_hota_metrics_result_structure() -> None:
-    """Verify all expected fields are present in result with correct types."""
-    result = compute_hota_metrics(
-        gt_ids=[np.array([0])],
-        tracker_ids=[np.array([10])],
-        similarity_scores=[np.array([[0.8]])],
-    )
-
-    # Float summary fields
-    for field in [
-        "HOTA",
-        "DetA",
-        "AssA",
-        "DetRe",
-        "DetPr",
-        "AssRe",
-        "AssPr",
-        "LocA",
-        "OWTA",
-    ]:
-        assert field in result
-        assert isinstance(result[field], float)
-        assert 0 <= result[field] <= 1
-
-    # Integer summary fields
-    for field in ["HOTA_TP", "HOTA_FN", "HOTA_FP"]:
-        assert field in result
-        assert isinstance(result[field], int)
-        assert result[field] >= 0
-
-    # Array fields for aggregation
-    for field in [
-        "HOTA_TP_array",
-        "HOTA_FN_array",
-        "HOTA_FP_array",
-        "AssA_array",
-        "AssRe_array",
-        "AssPr_array",
-        "LocA_array",
-    ]:
-        assert field in result
-        assert isinstance(result[field], np.ndarray)
-        assert len(result[field]) == len(ALPHA_THRESHOLDS)
+        for field in [
+            "HOTA_TP_array",
+            "HOTA_FN_array",
+            "HOTA_FP_array",
+            "AssA_array",
+            "AssRe_array",
+            "AssPr_array",
+            "LocA_array",
+        ]:
+            assert field in result
+            assert isinstance(result[field], np.ndarray)
+            assert len(result[field]) == len(ALPHA_THRESHOLDS)
 
 
-@pytest.mark.parametrize(
-    (
-        "sequence_metrics",
-        "expected",
-    ),
-    [
-        # Empty list
-        (
-            [],
-            {"HOTA": 0.0, "HOTA_TP": 0, "HOTA_FN": 0, "HOTA_FP": 0},
-        ),
-    ],
-)
-def test_aggregate_hota_metrics(
-    sequence_metrics: list[dict[str, Any]],
-    expected: dict[str, Any],
-) -> None:
-    result = aggregate_hota_metrics(sequence_metrics)
+class TestAggregateHOTAMetrics:
+    """Multi-sequence aggregation of HOTA metrics."""
 
-    for key, value in expected.items():
-        if isinstance(value, float):
-            assert result[key] == pytest.approx(value), (
-                f"Mismatch for {key}: {result[key]} != {value}"
-            )
-        else:
-            assert result[key] == value, f"Mismatch for {key}: {result[key]} != {value}"
+    def test_empty(self) -> None:
+        """Empty sequence list returns all-zero HOTA metrics."""
+        result = aggregate_hota_metrics([])
+        assert result["HOTA"] == pytest.approx(0.0)
+        assert result["HOTA_TP"] == 0
+        assert result["HOTA_FN"] == 0
+        assert result["HOTA_FP"] == 0
 
+    def test_single_sequence(self) -> None:
+        """Single-sequence aggregation reproduces per-sequence HOTA scores."""
+        seq_result = compute_hota_metrics(
+            gt_ids=[np.array([0, 1])],
+            tracker_ids=[np.array([10, 20])],
+            similarity_scores=[np.array([[0.8, 0.0], [0.0, 0.8]])],
+        )
 
-def test_aggregate_hota_metrics_single_sequence() -> None:
-    """Single sequence aggregation should match original."""
-    seq_result = compute_hota_metrics(
-        gt_ids=[np.array([0, 1])],
-        tracker_ids=[np.array([10, 20])],
-        similarity_scores=[np.array([[0.8, 0.0], [0.0, 0.8]])],
-    )
+        agg_result = aggregate_hota_metrics([seq_result])
 
-    agg_result = aggregate_hota_metrics([seq_result])
+        assert agg_result["HOTA"] == pytest.approx(seq_result["HOTA"], rel=1e-4)
+        assert agg_result["DetA"] == pytest.approx(seq_result["DetA"], rel=1e-4)
+        assert agg_result["AssA"] == pytest.approx(seq_result["AssA"], rel=1e-4)
 
-    assert agg_result["HOTA"] == pytest.approx(seq_result["HOTA"], rel=1e-4)
-    assert agg_result["DetA"] == pytest.approx(seq_result["DetA"], rel=1e-4)
-    assert agg_result["AssA"] == pytest.approx(seq_result["AssA"], rel=1e-4)
+    def test_multiple_sequences(self) -> None:
+        """Identical sequences aggregate to the same HOTA; TP counts are summed."""
+        seq1 = compute_hota_metrics(
+            gt_ids=[np.array([0])],
+            tracker_ids=[np.array([10])],
+            similarity_scores=[np.array([[0.9]])],
+        )
+        seq2 = compute_hota_metrics(
+            gt_ids=[np.array([0])],
+            tracker_ids=[np.array([10])],
+            similarity_scores=[np.array([[0.9]])],
+        )
 
+        agg_result = aggregate_hota_metrics([seq1, seq2])
 
-def test_aggregate_hota_metrics_multiple_sequences() -> None:
-    """Multiple sequences should aggregate correctly."""
-    seq_result1 = compute_hota_metrics(
-        gt_ids=[np.array([0])],
-        tracker_ids=[np.array([10])],
-        similarity_scores=[np.array([[0.9]])],
-    )
-    seq_result2 = compute_hota_metrics(
-        gt_ids=[np.array([0])],
-        tracker_ids=[np.array([10])],
-        similarity_scores=[np.array([[0.9]])],
-    )
+        assert agg_result["HOTA_TP"] == seq1["HOTA_TP"] + seq2["HOTA_TP"]
+        assert agg_result["HOTA"] == pytest.approx(seq1["HOTA"], rel=0.01)
 
-    agg_result = aggregate_hota_metrics([seq_result1, seq_result2])
+    def test_weighted_by_tp(self) -> None:
+        """Aggregated HOTA skews toward the higher-TP sequence."""
+        high_quality = compute_hota_metrics(
+            gt_ids=[np.array([0, 1, 2, 3])],
+            tracker_ids=[np.array([10, 20, 30, 40])],
+            similarity_scores=[np.diag([0.9, 0.9, 0.9, 0.9])],
+        )
+        low_quality = compute_hota_metrics(
+            gt_ids=[np.array([0])],
+            tracker_ids=[np.array([10])],
+            similarity_scores=[np.array([[0.3]])],
+        )
 
-    # TP/FN/FP should be summed
-    expected_tp = seq_result1["HOTA_TP"] + seq_result2["HOTA_TP"]
-    assert agg_result["HOTA_TP"] == expected_tp
+        agg_result = aggregate_hota_metrics([high_quality, low_quality])
 
-    # HOTA should be similar to individual sequences since they're identical
-    assert agg_result["HOTA"] == pytest.approx(seq_result1["HOTA"], rel=0.01)
-
-
-def test_aggregate_hota_metrics_weighted_by_tp() -> None:
-    """Aggregation should weight by TP count."""
-    # High quality sequence (many TPs)
-    high_quality = compute_hota_metrics(
-        gt_ids=[np.array([0, 1, 2, 3])],
-        tracker_ids=[np.array([10, 20, 30, 40])],
-        similarity_scores=[np.diag([0.9, 0.9, 0.9, 0.9])],
-    )
-
-    # Low quality sequence (few TPs)
-    low_quality = compute_hota_metrics(
-        gt_ids=[np.array([0])],
-        tracker_ids=[np.array([10])],
-        similarity_scores=[np.array([[0.3]])],
-    )
-
-    agg_result = aggregate_hota_metrics([high_quality, low_quality])
-
-    # Result should be closer to high_quality since it has more TPs
-    assert agg_result["HOTA"] > low_quality["HOTA"]
+        assert agg_result["HOTA"] > low_quality["HOTA"]

--- a/tests/eval/test_identity.py
+++ b/tests/eval/test_identity.py
@@ -17,208 +17,216 @@ from trackers.eval.identity import (
 )
 
 
-@pytest.mark.parametrize(
-    (
-        "gt_ids",
-        "tracker_ids",
-        "similarity_scores",
-        "expected",
-    ),
-    [
-        # Empty GT and tracker
-        (
-            [np.array([])],
-            [np.array([])],
-            [np.zeros((0, 0))],
-            {"IDTP": 0, "IDFN": 0, "IDFP": 0, "IDF1": 0.0},
-        ),
-        # No tracker detections - all FN
-        (
-            [np.array([0, 1]), np.array([0, 1])],
-            [np.array([]), np.array([])],
-            [np.zeros((2, 0)), np.zeros((2, 0))],
-            {"IDTP": 0, "IDFN": 4, "IDFP": 0, "IDF1": 0.0, "IDR": 0.0},
-        ),
-        # No GT detections - all FP
-        (
-            [np.array([]), np.array([])],
-            [np.array([10, 20]), np.array([10, 20])],
-            [np.zeros((0, 2)), np.zeros((0, 2))],
-            {"IDTP": 0, "IDFN": 0, "IDFP": 4, "IDF1": 0.0, "IDP": 0.0},
-        ),
-        # Perfect tracking - all detections matched with correct IDs
-        (
-            [np.array([0, 1]), np.array([0, 1])],
-            [np.array([10, 20]), np.array([10, 20])],
-            [
-                np.array([[0.8, 0.0], [0.0, 0.8]]),
-                np.array([[0.8, 0.0], [0.0, 0.8]]),
-            ],
-            {"IDTP": 4, "IDFN": 0, "IDFP": 0, "IDF1": 1.0, "IDR": 1.0, "IDP": 1.0},
-        ),
-        # ID switch - GT 0 matched tracker 10 in frame 1, tracker 20 in frame 2
-        (
-            [np.array([0, 1]), np.array([0, 1])],
-            [np.array([10, 20]), np.array([10, 20])],
-            [
-                np.array([[0.8, 0.1], [0.1, 0.8]]),  # Normal matching
-                np.array([[0.1, 0.8], [0.8, 0.1]]),  # Swapped!
-            ],
-            # With ID switch, each GT can only match one tracker globally
-            # So 2 IDTP per ID = 4 total, but need to split FN/FP
-            {"IDTP_min": 2, "IDF1_min": 0.3},
-        ),
-        # Low IoU below threshold - no matches
-        (
-            [np.array([0])],
-            [np.array([10])],
-            [np.array([[0.3]])],  # Below default 0.5 threshold
-            {"IDTP": 0, "IDFN": 1, "IDFP": 1, "IDF1": 0.0},
-        ),
-        # Multiple objects partial match
-        (
-            [np.array([0, 1, 2])],
-            [np.array([10, 20])],  # Only 2 trackers for 3 GTs
-            [np.array([[0.8, 0.0], [0.0, 0.8], [0.0, 0.0]])],
-            {"IDTP": 2, "IDFN": 1, "IDFP": 0},
-        ),
-        # Extra tracker detections
-        (
-            [np.array([0])],
-            [np.array([10, 20, 30])],  # 3 trackers for 1 GT
-            [np.array([[0.8, 0.0, 0.0]])],
-            {"IDTP": 1, "IDFN": 0, "IDFP": 2},
-        ),
-    ],
-)
-def test_compute_identity_metrics(
-    gt_ids: list[np.ndarray],
-    tracker_ids: list[np.ndarray],
-    similarity_scores: list[np.ndarray],
-    expected: dict[str, Any],
-) -> None:
-    """Test Identity metrics computation for various scenarios."""
-    result = compute_identity_metrics(gt_ids, tracker_ids, similarity_scores)
+class TestComputeIdentityMetrics:
+    """Per-sequence Identity metric computation (IDTP, IDFN, IDFP, IDF1)."""
 
-    for key, value in expected.items():
-        if key.endswith("_min"):
-            actual_key = key[:-4]
-            assert result[actual_key] >= value, (
-                f"{actual_key} should be >= {value}, got {result[actual_key]}"
-            )
-        elif key.endswith("_max"):
-            actual_key = key[:-4]
-            assert result[actual_key] <= value, (
-                f"{actual_key} should be <= {value}, got {result[actual_key]}"
-            )
-        else:
-            if isinstance(value, float):
-                assert result[key] == pytest.approx(value, abs=1e-6), (
-                    f"{key} mismatch: expected {value}, got {result[key]}"
+    @pytest.mark.parametrize(
+        (
+            "gt_ids",
+            "tracker_ids",
+            "similarity_scores",
+            "expected",
+        ),
+        [
+            # Empty GT and tracker
+            (
+                [np.array([])],
+                [np.array([])],
+                [np.zeros((0, 0))],
+                {"IDTP": 0, "IDFN": 0, "IDFP": 0, "IDF1": 0.0},
+            ),
+            # No tracker detections - all FN
+            (
+                [np.array([0, 1]), np.array([0, 1])],
+                [np.array([]), np.array([])],
+                [np.zeros((2, 0)), np.zeros((2, 0))],
+                {"IDTP": 0, "IDFN": 4, "IDFP": 0, "IDF1": 0.0, "IDR": 0.0},
+            ),
+            # No GT detections - all FP
+            (
+                [np.array([]), np.array([])],
+                [np.array([10, 20]), np.array([10, 20])],
+                [np.zeros((0, 2)), np.zeros((0, 2))],
+                {"IDTP": 0, "IDFN": 0, "IDFP": 4, "IDF1": 0.0, "IDP": 0.0},
+            ),
+            # Perfect tracking - all detections matched with correct IDs
+            (
+                [np.array([0, 1]), np.array([0, 1])],
+                [np.array([10, 20]), np.array([10, 20])],
+                [
+                    np.array([[0.8, 0.0], [0.0, 0.8]]),
+                    np.array([[0.8, 0.0], [0.0, 0.8]]),
+                ],
+                {
+                    "IDTP": 4,
+                    "IDFN": 0,
+                    "IDFP": 0,
+                    "IDF1": 1.0,
+                    "IDR": 1.0,
+                    "IDP": 1.0,
+                },
+            ),
+            # ID switch - GT 0 matched tracker 10 in frame 1, tracker 20 in frame 2
+            (
+                [np.array([0, 1]), np.array([0, 1])],
+                [np.array([10, 20]), np.array([10, 20])],
+                [
+                    np.array([[0.8, 0.1], [0.1, 0.8]]),  # Normal matching
+                    np.array([[0.1, 0.8], [0.8, 0.1]]),  # Swapped!
+                ],
+                # With ID switch, each GT can only match one tracker globally
+                # So 2 IDTP per ID = 4 total, but need to split FN/FP
+                {"IDTP_min": 2, "IDF1_min": 0.3},
+            ),
+            # Low IoU below threshold - no matches
+            (
+                [np.array([0])],
+                [np.array([10])],
+                [np.array([[0.3]])],  # Below default 0.5 threshold
+                {"IDTP": 0, "IDFN": 1, "IDFP": 1, "IDF1": 0.0},
+            ),
+            # Multiple objects partial match
+            (
+                [np.array([0, 1, 2])],
+                [np.array([10, 20])],  # Only 2 trackers for 3 GTs
+                [np.array([[0.8, 0.0], [0.0, 0.8], [0.0, 0.0]])],
+                {"IDTP": 2, "IDFN": 1, "IDFP": 0},
+            ),
+            # Extra tracker detections
+            (
+                [np.array([0])],
+                [np.array([10, 20, 30])],  # 3 trackers for 1 GT
+                [np.array([[0.8, 0.0, 0.0]])],
+                {"IDTP": 1, "IDFN": 0, "IDFP": 2},
+            ),
+        ],
+    )
+    def test_scenarios(
+        self,
+        gt_ids: list[np.ndarray],
+        tracker_ids: list[np.ndarray],
+        similarity_scores: list[np.ndarray],
+        expected: dict[str, Any],
+    ) -> None:
+        """Test Identity metrics computation for various scenarios."""
+        result = compute_identity_metrics(gt_ids, tracker_ids, similarity_scores)
+
+        for key, value in expected.items():
+            if key.endswith("_min"):
+                actual_key = key[:-4]
+                assert result[actual_key] >= value, (
+                    f"{actual_key} should be >= {value}, got {result[actual_key]}"
+                )
+            elif key.endswith("_max"):
+                actual_key = key[:-4]
+                assert result[actual_key] <= value, (
+                    f"{actual_key} should be <= {value}, got {result[actual_key]}"
                 )
             else:
-                assert result[key] == value, (
-                    f"{key} mismatch: expected {value}, got {result[key]}"
-                )
+                if isinstance(value, float):
+                    assert result[key] == pytest.approx(value, abs=1e-6), (
+                        f"{key} mismatch: expected {value}, got {result[key]}"
+                    )
+                else:
+                    assert result[key] == value, (
+                        f"{key} mismatch: expected {value}, got {result[key]}"
+                    )
 
-
-def test_compute_identity_metrics_custom_threshold() -> None:
-    """Test Identity metrics with custom IoU threshold."""
-    gt_ids = [np.array([0])]
-    tracker_ids = [np.array([10])]
-    similarity_scores = [np.array([[0.4]])]
-
-    # Default threshold 0.5 - no match
-    result_high = compute_identity_metrics(
-        gt_ids, tracker_ids, similarity_scores, threshold=0.5
+    @pytest.mark.parametrize(
+        ("threshold", "expected_idtp"),
+        [
+            (0.5, 0),  # default threshold — no match
+            (0.3, 1),  # lower threshold — should match
+        ],
+        ids=["threshold_0.5_no_match", "threshold_0.3_matches"],
     )
-    assert result_high["IDTP"] == 0
+    def test_threshold_gate(
+        self,
+        threshold: float,
+        expected_idtp: int,
+    ) -> None:
+        """IoU threshold controls whether a 0.4-similarity pair matches."""
+        gt_ids = [np.array([0])]
+        tracker_ids = [np.array([10])]
+        similarity_scores = [np.array([[0.4]])]
+        result = compute_identity_metrics(
+            gt_ids, tracker_ids, similarity_scores, threshold=threshold
+        )
+        assert result["IDTP"] == expected_idtp
 
-    # Lower threshold 0.3 - should match
-    result_low = compute_identity_metrics(
-        gt_ids, tracker_ids, similarity_scores, threshold=0.3
-    )
-    assert result_low["IDTP"] == 1
+    def test_multi_frame_consistency(self) -> None:
+        """Consistent tracking across frames yields perfect IDTP/IDFN/IDFP."""
+        gt_ids = [np.array([0]), np.array([0]), np.array([0])]
+        tracker_ids = [np.array([10]), np.array([10]), np.array([10])]
+        similarity_scores = [
+            np.array([[0.9]]),
+            np.array([[0.85]]),
+            np.array([[0.8]]),
+        ]
 
+        result = compute_identity_metrics(gt_ids, tracker_ids, similarity_scores)
 
-def test_compute_identity_metrics_multi_frame_consistency() -> None:
-    """Test that Identity correctly handles consistent tracking across frames."""
-    # GT ID 0 appears in all 3 frames
-    # Tracker ID 10 tracks it consistently
-    gt_ids = [np.array([0]), np.array([0]), np.array([0])]
-    tracker_ids = [np.array([10]), np.array([10]), np.array([10])]
-    similarity_scores = [
-        np.array([[0.9]]),
-        np.array([[0.85]]),
-        np.array([[0.8]]),
-    ]
-
-    result = compute_identity_metrics(gt_ids, tracker_ids, similarity_scores)
-
-    # Perfect tracking: 3 IDTP, 0 IDFN, 0 IDFP
-    assert result["IDTP"] == 3
-    assert result["IDFN"] == 0
-    assert result["IDFP"] == 0
-    assert result["IDF1"] == pytest.approx(1.0)
-
-
-def test_aggregate_identity_metrics_empty() -> None:
-    """Test aggregation with empty input."""
-    result = aggregate_identity_metrics([])
-
-    assert result["IDTP"] == 0
-    assert result["IDFN"] == 0
-    assert result["IDFP"] == 0
-    assert result["IDF1"] == 0.0
+        assert result["IDTP"] == 3
+        assert result["IDFN"] == 0
+        assert result["IDFP"] == 0
+        assert result["IDF1"] == pytest.approx(1.0)
 
 
-def test_aggregate_identity_metrics_single_sequence() -> None:
-    """Test aggregation with single sequence returns same values."""
-    seq_result = {
-        "IDTP": 100,
-        "IDFN": 10,
-        "IDFP": 5,
-        "IDF1": 0.93,
-        "IDR": 0.91,
-        "IDP": 0.95,
-    }
+class TestAggregateIdentityMetrics:
+    """Multi-sequence aggregation of Identity metrics."""
 
-    agg = aggregate_identity_metrics([seq_result])
+    def test_empty(self) -> None:
+        """Empty sequence list returns all-zero Identity metrics."""
+        result = aggregate_identity_metrics([])
 
-    assert agg["IDTP"] == 100
-    assert agg["IDFN"] == 10
-    assert agg["IDFP"] == 5
-    # IDF1 is recomputed from sums
-    expected_idf1 = 100 / (100 + 0.5 * 5 + 0.5 * 10)
-    assert agg["IDF1"] == pytest.approx(expected_idf1)
+        assert result["IDTP"] == 0
+        assert result["IDFN"] == 0
+        assert result["IDFP"] == 0
+        assert result["IDF1"] == 0.0
 
+    def test_single_sequence(self) -> None:
+        """Single-sequence aggregation preserves raw counts; recomputes IDF1."""
+        seq_result = {
+            "IDTP": 100,
+            "IDFN": 10,
+            "IDFP": 5,
+            "IDF1": 0.93,
+            "IDR": 0.91,
+            "IDP": 0.95,
+        }
 
-def test_aggregate_identity_metrics_multiple_sequences() -> None:
-    """Test aggregation sums counts and recomputes ratios."""
-    seq1 = compute_identity_metrics(
-        gt_ids=[np.array([0, 1])],
-        tracker_ids=[np.array([10, 20])],
-        similarity_scores=[np.array([[0.9, 0.0], [0.0, 0.9]])],
-    )
-    seq2 = compute_identity_metrics(
-        gt_ids=[np.array([0])],
-        tracker_ids=[np.array([10])],
-        similarity_scores=[np.array([[0.9]])],
-    )
+        agg = aggregate_identity_metrics([seq_result])
 
-    agg = aggregate_identity_metrics([seq1, seq2])
+        assert agg["IDTP"] == 100
+        assert agg["IDFN"] == 10
+        assert agg["IDFP"] == 5
+        expected_idf1 = 100 / (100 + 0.5 * 5 + 0.5 * 10)
+        assert agg["IDF1"] == pytest.approx(expected_idf1)
 
-    # IDTP/IDFN/IDFP should be summed
-    expected_idtp = seq1["IDTP"] + seq2["IDTP"]
-    expected_idfn = seq1["IDFN"] + seq2["IDFN"]
-    expected_idfp = seq1["IDFP"] + seq2["IDFP"]
+    def test_multiple_sequences(self) -> None:
+        """Multi-sequence aggregation sums raw counts and recomputes IDF1."""
+        seq1 = compute_identity_metrics(
+            gt_ids=[np.array([0, 1])],
+            tracker_ids=[np.array([10, 20])],
+            similarity_scores=[np.array([[0.9, 0.0], [0.0, 0.9]])],
+        )
+        seq2 = compute_identity_metrics(
+            gt_ids=[np.array([0])],
+            tracker_ids=[np.array([10])],
+            similarity_scores=[np.array([[0.9]])],
+        )
 
-    assert agg["IDTP"] == expected_idtp
-    assert agg["IDFN"] == expected_idfn
-    assert agg["IDFP"] == expected_idfp
+        agg = aggregate_identity_metrics([seq1, seq2])
 
-    # IDF1 should be recomputed from totals
-    expected_idf1 = expected_idtp / max(
-        1.0, expected_idtp + 0.5 * expected_idfp + 0.5 * expected_idfn
-    )
-    assert agg["IDF1"] == pytest.approx(expected_idf1)
+        expected_idtp = seq1["IDTP"] + seq2["IDTP"]
+        expected_idfn = seq1["IDFN"] + seq2["IDFN"]
+        expected_idfp = seq1["IDFP"] + seq2["IDFP"]
+
+        assert agg["IDTP"] == expected_idtp
+        assert agg["IDFN"] == expected_idfn
+        assert agg["IDFP"] == expected_idfp
+
+        expected_idf1 = expected_idtp / max(
+            1.0, expected_idtp + 0.5 * expected_idfp + 0.5 * expected_idfn
+        )
+        assert agg["IDF1"] == pytest.approx(expected_idf1)

--- a/tests/scripts/test_tune.py
+++ b/tests/scripts/test_tune.py
@@ -26,6 +26,15 @@ def _make_parser() -> tuple[argparse.ArgumentParser, argparse._SubParsersAction]
 
 
 class TestAddTuneSubparser:
+    @pytest.fixture
+    def minimal_args(self) -> argparse.Namespace:
+        """Parsed args with only required flags."""
+        parser, subparsers = _make_parser()
+        add_tune_subparser(subparsers)
+        return parser.parse_args(
+            ["tune", "--tracker", "sort", "--gt-dir", "/gt", "--detections-dir", "/det"]
+        )
+
     def test_registers_tune_subcommand(self) -> None:
         """tune subcommand is accessible under the 'tune' name."""
         parser, subparsers = _make_parser()
@@ -64,23 +73,15 @@ class TestAddTuneSubparser:
             ("output", None),
         ],
     )
-    def test_optional_defaults(self, flag: str, expected: object) -> None:
+    def test_optional_defaults(
+        self, minimal_args: argparse.Namespace, flag: str, expected: object
+    ) -> None:
         """Optional arguments have correct defaults when omitted."""
-        parser, subparsers = _make_parser()
-        add_tune_subparser(subparsers)
-        args = parser.parse_args(
-            ["tune", "--tracker", "sort", "--gt-dir", "/gt", "--detections-dir", "/det"]
-        )
-        assert getattr(args, flag) == expected
+        assert getattr(minimal_args, flag) == expected
 
-    def test_metrics_default(self) -> None:
+    def test_metrics_default(self, minimal_args: argparse.Namespace) -> None:
         """--metrics defaults to ['CLEAR'] when not supplied."""
-        parser, subparsers = _make_parser()
-        add_tune_subparser(subparsers)
-        args = parser.parse_args(
-            ["tune", "--tracker", "sort", "--gt-dir", "/gt", "--detections-dir", "/det"]
-        )
-        assert args.metrics == ["CLEAR"]
+        assert minimal_args.metrics == ["CLEAR"]
 
     def test_output_flag_short_form(self) -> None:
         """-o is an alias for --output."""

--- a/tests/utils/test_converters.py
+++ b/tests/utils/test_converters.py
@@ -17,230 +17,238 @@ from trackers.utils.converters import (
 )
 
 
-@pytest.mark.parametrize(
-    ("xyxy", "expected"),
-    [
-        (np.array([0.0, 0.0, 10.0, 20.0]), np.array([5.0, 10.0, 10.0, 20.0])),
-        (np.array([-2.0, -4.0, 2.0, 4.0]), np.array([0.0, 0.0, 4.0, 8.0])),
-    ],
-)
-def test_xyxy_to_xywh_single_box(xyxy: np.ndarray, expected: np.ndarray) -> None:
-    result = xyxy_to_xywh(xyxy)
-    assert result.shape == (4,)
-    np.testing.assert_array_almost_equal(result, expected, decimal=6)
+class TestXYWHConversion:
+    """xyxy ↔ xywh conversions and round-trip."""
 
-
-def test_xyxy_to_xywh_batch() -> None:
-    xyxy = np.array([[0.0, 0.0, 2.0, 2.0], [10.0, 20.0, 30.0, 50.0]])
-    expected = np.array([[1.0, 1.0, 2.0, 2.0], [20.0, 35.0, 20.0, 30.0]])
-    result = xyxy_to_xywh(xyxy)
-    assert result.shape == (2, 4)
-    np.testing.assert_array_almost_equal(result, expected, decimal=6)
-
-
-@pytest.mark.parametrize(
-    ("xywh", "expected"),
-    [
-        (np.array([5.0, 10.0, 10.0, 20.0]), np.array([0.0, 0.0, 10.0, 20.0])),
-        (np.array([0.0, 0.0, 4.0, 8.0]), np.array([-2.0, -4.0, 2.0, 4.0])),
-    ],
-)
-def test_xywh_to_xyxy_single_box(xywh: np.ndarray, expected: np.ndarray) -> None:
-    result = xywh_to_xyxy(xywh)
-    assert result.shape == (4,)
-    np.testing.assert_array_almost_equal(result, expected, decimal=6)
-
-
-def test_xywh_to_xyxy_batch() -> None:
-    xywh = np.array([[1.0, 1.0, 2.0, 2.0], [20.0, 35.0, 20.0, 30.0]])
-    expected = np.array([[0.0, 0.0, 2.0, 2.0], [10.0, 20.0, 30.0, 50.0]])
-    result = xywh_to_xyxy(xywh)
-    assert result.shape == (2, 4)
-    np.testing.assert_array_almost_equal(result, expected, decimal=6)
-
-
-@pytest.mark.parametrize(
-    "xyxy",
-    [
-        np.array([0.0, 0.0, 10.0, 20.0]),
-        np.array([10.0, 20.0, 30.0, 50.0]),
-        np.array([-2.0, -4.0, 2.0, 4.0]),
-    ],
-)
-def test_xyxy_xywh_roundtrip(xyxy: np.ndarray) -> None:
-    xywh = xyxy_to_xywh(xyxy)
-    recovered = xywh_to_xyxy(xywh)
-    np.testing.assert_array_almost_equal(recovered, xyxy, decimal=6)
-
-
-@pytest.mark.parametrize(
-    ("xyxy", "expected"),
-    [
-        # Unit square at origin
-        (
-            np.array([0.0, 0.0, 1.0, 1.0]),
-            np.array([0.5, 0.5, 1.0, 1.0]),
-        ),
-        # Rectangle 2x4 at (10, 20)
-        (
-            np.array([10.0, 20.0, 12.0, 24.0]),
-            np.array([11.0, 22.0, 8.0, 0.5]),
-        ),
-        # Wide rectangle (aspect ratio > 1)
-        (
-            np.array([0.0, 0.0, 100.0, 50.0]),
-            np.array([50.0, 25.0, 5000.0, 2.0]),
-        ),
-        # Tall rectangle (aspect ratio < 1)
-        (
-            np.array([5.0, 5.0, 15.0, 55.0]),
-            np.array([10.0, 30.0, 500.0, 0.2]),
-        ),
-        # Negative coordinates (box crossing origin)
-        (
-            np.array([-5.0, -5.0, 5.0, 5.0]),
-            np.array([0.0, 0.0, 100.0, 1.0]),
-        ),
-        # Very small box (sub-pixel) - aspect ratio affected by epsilon protection
-        (
-            np.array([0.0, 0.0, 0.001, 0.001]),
-            np.array([0.0005, 0.0005, 0.000001, 0.999001]),
-        ),
-        # Very large box
-        (
-            np.array([0.0, 0.0, 10000.0, 10000.0]),
-            np.array([5000.0, 5000.0, 100000000.0, 1.0]),
-        ),
-    ],
-)
-def test_xyxy_to_xcycsr_single_box(xyxy: np.ndarray, expected: np.ndarray) -> None:
-    result = xyxy_to_xcycsr(xyxy)
-    assert result.shape == (4,)
-    np.testing.assert_array_almost_equal(result, expected, decimal=5)
-
-
-def test_xyxy_to_xcycsr_zero_height_returns_finite() -> None:
-    xyxy = np.array([0.0, 0.0, 10.0, 0.0])
-    result = xyxy_to_xcycsr(xyxy)
-    assert np.isfinite(result).all()
-    assert result[2] == 0.0
-
-
-def test_xyxy_to_xcycsr_single_row_2d_returns_2d() -> None:
-    xyxy = np.array([[0.0, 0.0, 1.0, 1.0]])
-    result = xyxy_to_xcycsr(xyxy)
-    assert result.shape == (1, 4)
-    np.testing.assert_array_almost_equal(
-        result[0], np.array([0.5, 0.5, 1.0, 1.0]), decimal=5
+    @pytest.mark.parametrize(
+        ("xyxy", "expected"),
+        [
+            (np.array([0.0, 0.0, 10.0, 20.0]), np.array([5.0, 10.0, 10.0, 20.0])),
+            (np.array([-2.0, -4.0, 2.0, 4.0]), np.array([0.0, 0.0, 4.0, 8.0])),
+        ],
     )
+    def test_xyxy_to_xywh(self, xyxy: np.ndarray, expected: np.ndarray) -> None:
+        """xyxy_to_xywh converts a single 1-D xyxy box to (cx, cy, w, h)."""
+        result = xyxy_to_xywh(xyxy)
+        assert result.shape == (4,)
+        np.testing.assert_array_almost_equal(result, expected, decimal=6)
 
+    def test_xyxy_to_xywh_batch(self) -> None:
+        """xyxy_to_xywh converts a 2-D batch of xyxy boxes element-wise."""
+        xyxy = np.array([[0.0, 0.0, 2.0, 2.0], [10.0, 20.0, 30.0, 50.0]])
+        expected = np.array([[1.0, 1.0, 2.0, 2.0], [20.0, 35.0, 20.0, 30.0]])
+        result = xyxy_to_xywh(xyxy)
+        assert result.shape == (2, 4)
+        np.testing.assert_array_almost_equal(result, expected, decimal=6)
 
-def test_xyxy_to_xcycsr_empty_batch_returns_empty() -> None:
-    xyxy = np.zeros((0, 4))
-    result = xyxy_to_xcycsr(xyxy)
-    assert result.shape == (0, 4)
-
-
-@pytest.mark.parametrize(
-    ("xcycsr", "expected"),
-    [
-        # Unit square at (0.5, 0.5)
-        (
-            np.array([0.5, 0.5, 1.0, 1.0]),
-            np.array([0.0, 0.0, 1.0, 1.0]),
-        ),
-        # Rectangle at (11, 22) with area=8, ratio=0.5
-        (
-            np.array([11.0, 22.0, 8.0, 0.5]),
-            np.array([10.0, 20.0, 12.0, 24.0]),
-        ),
-        # Wide box
-        (
-            np.array([50.0, 25.0, 5000.0, 2.0]),
-            np.array([0.0, 0.0, 100.0, 50.0]),
-        ),
-        # Tall box
-        (
-            np.array([10.0, 30.0, 500.0, 0.2]),
-            np.array([5.0, 5.0, 15.0, 55.0]),
-        ),
-        # Center at origin
-        (
-            np.array([0.0, 0.0, 100.0, 1.0]),
-            np.array([-5.0, -5.0, 5.0, 5.0]),
-        ),
-        # Very small box
-        (
-            np.array([0.0005, 0.0005, 0.000001, 1.0]),
-            np.array([0.0, 0.0, 0.001, 0.001]),
-        ),
-        # Very large box
-        (
-            np.array([5000.0, 5000.0, 100000000.0, 1.0]),
-            np.array([0.0, 0.0, 10000.0, 10000.0]),
-        ),
-    ],
-)
-def test_xcycsr_to_xyxy_single_box(xcycsr: np.ndarray, expected: np.ndarray) -> None:
-    result = xcycsr_to_xyxy(xcycsr)
-    assert result.shape == (4,)
-    np.testing.assert_array_almost_equal(result, expected, decimal=4)
-
-
-def test_xcycsr_to_xyxy_zero_scale_produces_nan() -> None:
-    xcycsr = np.array([10.0, 20.0, 0.0, 1.0])
-    result = xcycsr_to_xyxy(xcycsr)
-    assert result[0] == result[2] == 10.0
-    assert np.isnan(result[1]) and np.isnan(result[3])
-
-
-def test_xcycsr_to_xyxy_zero_aspect_ratio_produces_nan() -> None:
-    xcycsr = np.array([10.0, 20.0, 100.0, 0.0])
-    result = xcycsr_to_xyxy(xcycsr)
-    assert np.isnan(result).any() or np.isinf(result).any()
-
-
-def test_xcycsr_to_xyxy_negative_scale_produces_nan() -> None:
-    xcycsr = np.array([10.0, 20.0, -100.0, 1.0])
-    result = xcycsr_to_xyxy(xcycsr)
-    assert np.isnan(result).any()
-
-
-def test_xcycsr_to_xyxy_single_row_2d_returns_2d() -> None:
-    xcycsr = np.array([[0.5, 0.5, 1.0, 1.0]])
-    result = xcycsr_to_xyxy(xcycsr)
-    assert result.shape == (1, 4)
-    np.testing.assert_array_almost_equal(
-        result[0], np.array([0.0, 0.0, 1.0, 1.0]), decimal=5
+    @pytest.mark.parametrize(
+        ("xywh", "expected"),
+        [
+            (np.array([5.0, 10.0, 10.0, 20.0]), np.array([0.0, 0.0, 10.0, 20.0])),
+            (np.array([0.0, 0.0, 4.0, 8.0]), np.array([-2.0, -4.0, 2.0, 4.0])),
+        ],
     )
+    def test_xywh_to_xyxy(self, xywh: np.ndarray, expected: np.ndarray) -> None:
+        """xywh_to_xyxy converts a single 1-D (cx, cy, w, h) box to xyxy."""
+        result = xywh_to_xyxy(xywh)
+        assert result.shape == (4,)
+        np.testing.assert_array_almost_equal(result, expected, decimal=6)
+
+    def test_xywh_to_xyxy_batch(self) -> None:
+        """xywh_to_xyxy converts a 2-D batch of (cx, cy, w, h) boxes element-wise."""
+        xywh = np.array([[1.0, 1.0, 2.0, 2.0], [20.0, 35.0, 20.0, 30.0]])
+        expected = np.array([[0.0, 0.0, 2.0, 2.0], [10.0, 20.0, 30.0, 50.0]])
+        result = xywh_to_xyxy(xywh)
+        assert result.shape == (2, 4)
+        np.testing.assert_array_almost_equal(result, expected, decimal=6)
+
+    @pytest.mark.parametrize(
+        "xyxy",
+        [
+            np.array([0.0, 0.0, 10.0, 20.0]),
+            np.array([10.0, 20.0, 30.0, 50.0]),
+            np.array([-2.0, -4.0, 2.0, 4.0]),
+        ],
+    )
+    def test_roundtrip(self, xyxy: np.ndarray) -> None:
+        """xyxy → xywh → xyxy round-trip recovers the original box without drift."""
+        xywh = xyxy_to_xywh(xyxy)
+        recovered = xywh_to_xyxy(xywh)
+        np.testing.assert_array_almost_equal(recovered, xyxy, decimal=6)
 
 
-def test_xcycsr_to_xyxy_empty_batch_returns_empty() -> None:
-    xcycsr = np.zeros((0, 4))
-    result = xcycsr_to_xyxy(xcycsr)
-    assert result.shape == (0, 4)
+class TestXCYCSRConversion:
+    """xyxy ↔ xcycsr (center-x, center-y, scale, aspect) conversions and round-trip."""
 
+    @pytest.mark.parametrize(
+        ("xyxy", "expected"),
+        [
+            # Unit square at origin
+            (
+                np.array([0.0, 0.0, 1.0, 1.0]),
+                np.array([0.5, 0.5, 1.0, 1.0]),
+            ),
+            # Rectangle 2x4 at (10, 20)
+            (
+                np.array([10.0, 20.0, 12.0, 24.0]),
+                np.array([11.0, 22.0, 8.0, 0.5]),
+            ),
+            # Wide rectangle (aspect ratio > 1)
+            (
+                np.array([0.0, 0.0, 100.0, 50.0]),
+                np.array([50.0, 25.0, 5000.0, 2.0]),
+            ),
+            # Tall rectangle (aspect ratio < 1)
+            (
+                np.array([5.0, 5.0, 15.0, 55.0]),
+                np.array([10.0, 30.0, 500.0, 0.2]),
+            ),
+            # Negative coordinates (box crossing origin)
+            (
+                np.array([-5.0, -5.0, 5.0, 5.0]),
+                np.array([0.0, 0.0, 100.0, 1.0]),
+            ),
+            # Very small box (sub-pixel) - aspect ratio affected by epsilon protection
+            (
+                np.array([0.0, 0.0, 0.001, 0.001]),
+                np.array([0.0005, 0.0005, 0.000001, 0.999001]),
+            ),
+            # Very large box
+            (
+                np.array([0.0, 0.0, 10000.0, 10000.0]),
+                np.array([5000.0, 5000.0, 100000000.0, 1.0]),
+            ),
+        ],
+    )
+    def test_xyxy_to_xcycsr(self, xyxy: np.ndarray, expected: np.ndarray) -> None:
+        """xyxy_to_xcycsr converts a 1-D xyxy box to (cx, cy, scale, aspect)."""
+        result = xyxy_to_xcycsr(xyxy)
+        assert result.shape == (4,)
+        np.testing.assert_array_almost_equal(result, expected, decimal=5)
 
-@pytest.mark.parametrize(
-    "xyxy",
-    [
-        np.array([0.0, 0.0, 1.0, 1.0]),
-        np.array([10.0, 20.0, 30.0, 50.0]),
-        np.array([100.0, 200.0, 150.0, 210.0]),
-        np.array([-10.0, -20.0, 10.0, 20.0]),
-        np.array([0.0, 0.0, 0.01, 0.01]),
-        np.array([0.0, 0.0, 1000.0, 500.0]),
-    ],
-)
-def test_xyxy_xcycsr_roundtrip(xyxy: np.ndarray) -> None:
-    xcycsr = xyxy_to_xcycsr(xyxy)
-    recovered = xcycsr_to_xyxy(xcycsr)
-    np.testing.assert_array_almost_equal(recovered, xyxy, decimal=5)
+    def test_xyxy_to_xcycsr_zero_height(self) -> None:
+        """A zero-height box yields a finite xcycsr (no NaN/Inf) with scale=0."""
+        xyxy = np.array([0.0, 0.0, 10.0, 0.0])
+        result = xyxy_to_xcycsr(xyxy)
+        assert np.isfinite(result).all()
+        assert result[2] == 0.0
 
+    def test_xyxy_to_xcycsr_2d_input(self) -> None:
+        """A 1-row 2-D xyxy input keeps its 2-D shape after conversion."""
+        xyxy = np.array([[0.0, 0.0, 1.0, 1.0]])
+        result = xyxy_to_xcycsr(xyxy)
+        assert result.shape == (1, 4)
+        np.testing.assert_array_almost_equal(
+            result[0], np.array([0.5, 0.5, 1.0, 1.0]), decimal=5
+        )
 
-def test_xyxy_xcycsr_roundtrip_preserves_2d_shape() -> None:
-    xyxy = np.array([[0.0, 0.0, 10.0, 10.0]])
-    xcycsr = xyxy_to_xcycsr(xyxy)
-    recovered = xcycsr_to_xyxy(xcycsr)
-    assert recovered.shape == (1, 4)
-    np.testing.assert_array_almost_equal(recovered, xyxy, decimal=5)
+    def test_xyxy_to_xcycsr_empty(self) -> None:
+        """An empty (0, 4) xyxy batch returns an empty (0, 4) xcycsr batch."""
+        xyxy = np.zeros((0, 4))
+        result = xyxy_to_xcycsr(xyxy)
+        assert result.shape == (0, 4)
+
+    @pytest.mark.parametrize(
+        ("xcycsr", "expected"),
+        [
+            # Unit square at (0.5, 0.5)
+            (
+                np.array([0.5, 0.5, 1.0, 1.0]),
+                np.array([0.0, 0.0, 1.0, 1.0]),
+            ),
+            # Rectangle at (11, 22) with area=8, ratio=0.5
+            (
+                np.array([11.0, 22.0, 8.0, 0.5]),
+                np.array([10.0, 20.0, 12.0, 24.0]),
+            ),
+            # Wide box
+            (
+                np.array([50.0, 25.0, 5000.0, 2.0]),
+                np.array([0.0, 0.0, 100.0, 50.0]),
+            ),
+            # Tall box
+            (
+                np.array([10.0, 30.0, 500.0, 0.2]),
+                np.array([5.0, 5.0, 15.0, 55.0]),
+            ),
+            # Center at origin
+            (
+                np.array([0.0, 0.0, 100.0, 1.0]),
+                np.array([-5.0, -5.0, 5.0, 5.0]),
+            ),
+            # Very small box
+            (
+                np.array([0.0005, 0.0005, 0.000001, 1.0]),
+                np.array([0.0, 0.0, 0.001, 0.001]),
+            ),
+            # Very large box
+            (
+                np.array([5000.0, 5000.0, 100000000.0, 1.0]),
+                np.array([0.0, 0.0, 10000.0, 10000.0]),
+            ),
+        ],
+    )
+    def test_xcycsr_to_xyxy(self, xcycsr: np.ndarray, expected: np.ndarray) -> None:
+        """xcycsr_to_xyxy converts a 1-D (cx, cy, scale, aspect) box back to xyxy."""
+        result = xcycsr_to_xyxy(xcycsr)
+        assert result.shape == (4,)
+        np.testing.assert_array_almost_equal(result, expected, decimal=4)
+
+    def test_xcycsr_to_xyxy_zero_scale(self) -> None:
+        """Zero-scale xcycsr decodes with NaN y-coords; x-center is preserved."""
+        xcycsr = np.array([10.0, 20.0, 0.0, 1.0])
+        result = xcycsr_to_xyxy(xcycsr)
+        assert result[0] == result[2] == 10.0
+        assert np.isnan(result[1]) and np.isnan(result[3])
+
+    def test_xcycsr_to_xyxy_zero_aspect(self) -> None:
+        """A zero aspect-ratio xcycsr decodes to a non-finite (NaN/Inf) box."""
+        xcycsr = np.array([10.0, 20.0, 100.0, 0.0])
+        result = xcycsr_to_xyxy(xcycsr)
+        assert np.isnan(result).any() or np.isinf(result).any()
+
+    def test_xcycsr_to_xyxy_negative_scale(self) -> None:
+        """A negative-scale xcycsr decodes with NaN entries (sqrt of negative)."""
+        xcycsr = np.array([10.0, 20.0, -100.0, 1.0])
+        result = xcycsr_to_xyxy(xcycsr)
+        assert np.isnan(result).any()
+
+    def test_xcycsr_to_xyxy_2d_input(self) -> None:
+        """A 1-row 2-D xcycsr input keeps its 2-D shape after conversion."""
+        xcycsr = np.array([[0.5, 0.5, 1.0, 1.0]])
+        result = xcycsr_to_xyxy(xcycsr)
+        assert result.shape == (1, 4)
+        np.testing.assert_array_almost_equal(
+            result[0], np.array([0.0, 0.0, 1.0, 1.0]), decimal=5
+        )
+
+    def test_xcycsr_to_xyxy_empty(self) -> None:
+        """An empty (0, 4) xcycsr batch returns an empty (0, 4) xyxy batch."""
+        xcycsr = np.zeros((0, 4))
+        result = xcycsr_to_xyxy(xcycsr)
+        assert result.shape == (0, 4)
+
+    @pytest.mark.parametrize(
+        "xyxy",
+        [
+            np.array([0.0, 0.0, 1.0, 1.0]),
+            np.array([10.0, 20.0, 30.0, 50.0]),
+            np.array([100.0, 200.0, 150.0, 210.0]),
+            np.array([-10.0, -20.0, 10.0, 20.0]),
+            np.array([0.0, 0.0, 0.01, 0.01]),
+            np.array([0.0, 0.0, 1000.0, 500.0]),
+        ],
+    )
+    def test_roundtrip(self, xyxy: np.ndarray) -> None:
+        """xyxy → xcycsr → xyxy round-trip recovers the original 1-D box."""
+        xcycsr = xyxy_to_xcycsr(xyxy)
+        recovered = xcycsr_to_xyxy(xcycsr)
+        np.testing.assert_array_almost_equal(recovered, xyxy, decimal=5)
+
+    def test_roundtrip_2d(self) -> None:
+        """xyxy → xcycsr → xyxy round-trip preserves the original 2-D shape."""
+        xyxy = np.array([[0.0, 0.0, 10.0, 10.0]])
+        xcycsr = xyxy_to_xcycsr(xyxy)
+        recovered = xcycsr_to_xyxy(xcycsr)
+        assert recovered.shape == (1, 4)
+        np.testing.assert_array_almost_equal(recovered, xyxy, decimal=5)


### PR DESCRIPTION
This pull request refactors and improves the test suite for tracking and evaluation modules, focusing on better structure, clearer test organization, and improved readability. The main changes include reorganizing tests into classes, using parameterized tests for better coverage, enhancing docstrings, and splitting large test functions into smaller, more focused methods.

Test suite restructuring and organization:

* Refactored several test files (such as `test_box.py`, `test_evaluate.py`, `test_hota.py`) to group related tests into classes (`TestBoxIoU`, `TestBoxIoA`, `TestEvaluateMOTSequence`, `TestComputeHOTAMetrics`), improving clarity and maintainability. [[1]](diffhunk://#diff-124f9b419bb993f02ccb3892f0d8d36a353b57586924ffb53b68bff1660daf1bR17-R19) [[2]](diffhunk://#diff-86c0e0dd75ae179692941f35a07e85c82de15f822dabe49491f8b62d3aa82f77R21-R23) [[3]](diffhunk://#diff-31ff590229a7aef330230fd459c73589007ba5154cd6a1b7bc7955404a0d9654L32-R64)

Test parametrization and coverage:

* Replaced manual loops with `pytest.mark.parametrize` for state estimator tests in `test_botsort_tracker.py`, and for metric evaluation in other test files, leading to more concise and comprehensive test coverage. [[1]](diffhunk://#diff-238d04a4f93f4e08a504038032923fb9a27dbcf0f05c4784043fee7a1df210c5L61-R74) [[2]](diffhunk://#diff-31ff590229a7aef330230fd459c73589007ba5154cd6a1b7bc7955404a0d9654L32-R64) [[3]](diffhunk://#diff-124f9b419bb993f02ccb3892f0d8d36a353b57586924ffb53b68bff1660daf1bL100-L174)

Test clarity and documentation:

* Added or improved docstrings for test methods throughout the suite, making the purpose and behavior of each test clearer for future maintainers. [[1]](diffhunk://#diff-fa2ca8b74280f2b3882bdbbe9e36633498e0eb9f08348165dfc7bf5ad7f422f1R173) [[2]](diffhunk://#diff-124f9b419bb993f02ccb3892f0d8d36a353b57586924ffb53b68bff1660daf1bL100-L174) [[3]](diffhunk://#diff-b368a3aee24ec534208244b6ec50b6d10f986933952ef5e45779fd8619692c26R303) [[4]](diffhunk://#diff-86c0e0dd75ae179692941f35a07e85c82de15f822dabe49491f8b62d3aa82f77L101-L118)

Test granularity and focus:

* Split large, multi-purpose test functions into smaller, focused methods (e.g., separating value, invalid format, and floating-point stability tests for IoU and IoA), and improved assertions for result structure and content. [[1]](diffhunk://#diff-124f9b419bb993f02ccb3892f0d8d36a353b57586924ffb53b68bff1660daf1bL100-L174) [[2]](diffhunk://#diff-124f9b419bb993f02ccb3892f0d8d36a353b57586924ffb53b68bff1660daf1bL215-L224) [[3]](diffhunk://#diff-124f9b419bb993f02ccb3892f0d8d36a353b57586924ffb53b68bff1660daf1bR198-R262) [[4]](diffhunk://#diff-86c0e0dd75ae179692941f35a07e85c82de15f822dabe49491f8b62d3aa82f77L140-L151) [[5]](diffhunk://#diff-86c0e0dd75ae179692941f35a07e85c82de15f822dabe49491f8b62d3aa82f77L167-L173)

Minor improvements:

* Minor code and formatting cleanups, such as adding missing imports and improving parameter naming for clarity. [[1]](diffhunk://#diff-238d04a4f93f4e08a504038032923fb9a27dbcf0f05c4784043fee7a1df210c5R19) [[2]](diffhunk://#diff-124f9b419bb993f02ccb3892f0d8d36a353b57586924ffb53b68bff1660daf1bR17-R19) [[3]](diffhunk://#diff-86c0e0dd75ae179692941f35a07e85c82de15f822dabe49491f8b62d3aa82f77L41-R63)

These changes collectively make the test suite easier to read, extend, and debug, while providing more robust coverage of the codebase.

---

- Group related tests into classes with docstrings across test_box, test_evaluate, test_hota, test_identity, test_converters, test_tune
- Prune method names that duplicate class context (e.g. test_box_iou_invalid_format → test_invalid_format)
- Parametrize botsort_tracker state-estimator test; remove inner for-loop in test_botsort_cmc
- Add minimal_args fixture in test_tune; add docstrings to test_clear and test_registration
