### PR TITLE
Fix ByteTrack handling of detections without confidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **OC-SORT Observation-Centric Recovery** now uses standard `IoU` per the paper, independent of the configured `iou=` variant ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **Eager division warnings on zero-area boxes** — IoU helper switched from `np.where` (eager) to `np.divide(..., where=...)` (lazy), suppressing `RuntimeWarning` under strict NumPy error settings ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **CLI argparse crash on `BaseIoU` parameter** — `iou=` is now excluded from argparse auto-discovery; the variant must be set programmatically ([#403](https://github.com/roboflow/trackers/pull/403)).
+- **ByteTrack tracked nothing when detections lacked confidence scores** — the default-fill changed from `np.zeros` to `np.ones`, matching SORT / OC-SORT / BoT-SORT behaviour, so detectors that emit `sv.Detections` without `confidence` now produce tracks instead of empty results ([#415](https://github.com/roboflow/trackers/pull/415)).
 
 ---
 

--- a/src/trackers/core/botsort/tracker.py
+++ b/src/trackers/core/botsort/tracker.py
@@ -15,6 +15,7 @@ from trackers.core.base import BaseTracker
 from trackers.core.botsort.tracklet import BoTSORTTracklet
 from trackers.core.botsort.utils import _fuse_score, get_alive_tracklets
 from trackers.utils.cmc import CMC, CMCConfig, CMCMethod
+from trackers.utils.detections import default_confidences
 from trackers.utils.iou import BaseIoU, IoU
 from trackers.utils.state_representations import (
     BaseStateEstimator,
@@ -187,7 +188,7 @@ class BoTSORTTracker(BaseTracker):
             tracker.predict()
 
         detection_boxes = detections.xyxy
-        confidences = detections.confidence if detections.confidence is not None else np.ones(len(detections))
+        confidences = default_confidences(detections)
 
         # Split indices into high / low / discarded by confidence
         high_mask = confidences >= self.high_conf_det_threshold

--- a/src/trackers/core/bytetrack/tracker.py
+++ b/src/trackers/core/bytetrack/tracker.py
@@ -13,6 +13,7 @@ from scipy.optimize import linear_sum_assignment
 from trackers.core.base import BaseTracker
 from trackers.core.bytetrack.tracklet import ByteTrackTracklet
 from trackers.core.bytetrack.utils import _get_alive_tracklets
+from trackers.utils.detections import default_confidences
 from trackers.utils.iou import BaseIoU, IoU
 from trackers.utils.state_representations import (
     BaseStateEstimator,
@@ -136,7 +137,7 @@ class ByteTrackTracker(BaseTracker):
             tracker.predict()
 
         detection_boxes = detections.xyxy
-        confidences = detections.confidence if detections.confidence is not None else np.ones(len(detections))
+        confidences = default_confidences(detections)
 
         # Split indices by confidence threshold (no sv.Detections slicing)
         high_mask = confidences >= self.high_conf_det_threshold

--- a/src/trackers/core/bytetrack/tracker.py
+++ b/src/trackers/core/bytetrack/tracker.py
@@ -115,7 +115,10 @@ class ByteTrackTracker(BaseTracker):
         Args:
             detections: `sv.Detections` containing bounding boxes with shape
                 `(N, 4)` in `(x_min, y_min, x_max, y_max)` format and optional
-                confidence scores.
+                confidence scores. When `detections.confidence is None`, all
+                detections are treated as confidence `1.0` — they bypass the
+                low-confidence stage and any unmatched boxes can spawn new
+                tracks regardless of `track_activation_threshold`.
             frame: Ignored by ByteTrack. If provided (not `None`), a warning is
                 emitted.
 

--- a/src/trackers/core/bytetrack/tracker.py
+++ b/src/trackers/core/bytetrack/tracker.py
@@ -41,6 +41,14 @@ class ByteTrackTracker(BaseTracker):
     Additionally, the motion-only secondary association may lead to erroneous matches
     in scenes with similar moving objects.
 
+    Note:
+        When input detections carry no confidence (`detections.confidence is
+        None`), ByteTrack falls back to a single-stage IoU match equivalent to
+        SORT — every detection is treated as fully confident, so the
+        low-confidence recovery stage is bypassed. Pass per-detection
+        confidences to exercise the two-stage matching this class otherwise
+        provides.
+
     Args:
         lost_track_buffer: `int` specifying number of frames to buffer when a
             track is lost. Increasing this value enhances occlusion handling but

--- a/src/trackers/core/bytetrack/tracker.py
+++ b/src/trackers/core/bytetrack/tracker.py
@@ -136,7 +136,7 @@ class ByteTrackTracker(BaseTracker):
             tracker.predict()
 
         detection_boxes = detections.xyxy
-        confidences = detections.confidence if detections.confidence is not None else np.zeros(len(detections))
+        confidences = detections.confidence if detections.confidence is not None else np.ones(len(detections))
 
         # Split indices by confidence threshold (no sv.Detections slicing)
         high_mask = confidences >= self.high_conf_det_threshold

--- a/src/trackers/core/ocsort/tracker.py
+++ b/src/trackers/core/ocsort/tracker.py
@@ -13,6 +13,7 @@ from scipy.optimize import linear_sum_assignment
 from trackers.core.base import BaseTracker
 from trackers.core.ocsort.tracklet import OCSORTTracklet
 from trackers.core.ocsort.utils import _build_direction_consistency_matrix_batch
+from trackers.utils.detections import default_confidences
 from trackers.utils.iou import BaseIoU, IoU
 from trackers.utils.state_representations import (
     BaseStateEstimator,
@@ -189,7 +190,7 @@ class OCSORTTracker(BaseTracker):
             detections = detections[detections.confidence >= self.high_conf_det_threshold]
 
         detection_boxes = detections.xyxy if len(detections) > 0 else np.empty((0, 4))
-        confidences = detections.confidence if detections.confidence is not None else np.ones(len(detections))
+        confidences = default_confidences(detections)
 
         # Collect (detection_index, tracker_id) pairs; assembled into
         # the output sv.Detections once at the end.

--- a/src/trackers/core/sort/tracker.py
+++ b/src/trackers/core/sort/tracker.py
@@ -13,6 +13,7 @@ from scipy.optimize import linear_sum_assignment
 from trackers.core.base import BaseTracker
 from trackers.core.sort.tracklet import SORTTracklet
 from trackers.core.sort.utils import _get_alive_tracklets
+from trackers.utils.detections import default_confidences
 from trackers.utils.iou import BaseIoU, IoU
 from trackers.utils.state_representations import (
     BaseStateEstimator,
@@ -199,7 +200,7 @@ class SORTTracker(BaseTracker):
             self.tracks[row].update(detection_boxes[col])
             matched_tracklet_for_det[col] = self.tracks[row]
 
-        confidences = detections.confidence if detections.confidence is not None else np.ones(len(detections))
+        confidences = default_confidences(detections)
         self._spawn_new_tracklets(confidences, detection_boxes, unmatched_detections)
 
         # Remove dead tracklets

--- a/src/trackers/utils/detections.py
+++ b/src/trackers/utils/detections.py
@@ -1,0 +1,45 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import numpy as np
+import supervision as sv
+
+
+def default_confidences(detections: sv.Detections) -> np.ndarray:
+    """Return per-detection confidence, defaulting to all-ones when absent.
+
+    When ``detections.confidence`` is ``None``, every detection is treated as
+    fully confident (``1.0``). All four trackers (SORT, ByteTrack, OC-SORT,
+    BoT-SORT) share this convention so callers that emit
+    ``sv.Detections`` without a ``confidence`` field still produce tracks
+    instead of empty results.
+
+    Args:
+        detections: ``sv.Detections`` whose ``confidence`` is either a
+            ``float32`` array of shape ``(N,)`` or ``None``.
+
+    Returns:
+        ``np.ndarray`` of shape ``(len(detections),)`` containing the
+        per-detection confidence used by tracker association. The fallback
+        array uses ``dtype=np.float32`` to match the ``supervision``
+        convention for the confidence field.
+
+    Examples:
+        >>> import numpy as np
+        >>> import supervision as sv
+        >>> from trackers.utils.detections import default_confidences
+        >>> det = sv.Detections(xyxy=np.array([[0.0, 0.0, 10.0, 10.0]]))
+        >>> default_confidences(det).tolist()
+        [1.0]
+        >>> det.confidence = np.array([0.5], dtype=np.float32)
+        >>> default_confidences(det).tolist()
+        [0.5]
+    """
+    if detections.confidence is not None:
+        return detections.confidence
+    return np.ones(len(detections), dtype=np.float32)

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -143,15 +143,44 @@ def test_no_confidence_detections_can_spawn_confirmed_tracks(tracker_id: str) ->
     raise AssertionError(f"{tracker_id} did not confirm any track for confidence=None detections")
 
 
-def test_bytetrack_no_confidence_matches_explicit_ones_confidence() -> None:
-    """ByteTrack should treat confidence=None the same as all-ones confidence."""
+@pytest.mark.parametrize(
+    "xyxy_boxes",
+    [
+        np.array([[100.0, 100.0, 200.0, 200.0]], dtype=np.float32),
+        np.array(
+            [
+                [100.0, 100.0, 200.0, 200.0],
+                [400.0, 400.0, 500.0, 500.0],
+            ],
+            dtype=np.float32,
+        ),
+        np.array(
+            [
+                [10.0, 10.0, 60.0, 60.0],
+                [200.0, 200.0, 260.0, 260.0],
+                [500.0, 500.0, 560.0, 560.0],
+            ],
+            dtype=np.float32,
+        ),
+    ],
+    ids=["single_box", "two_boxes", "three_boxes_non_overlapping"],
+)
+def test_bytetrack_no_confidence_matches_explicit_ones_confidence(xyxy_boxes: np.ndarray) -> None:
+    """ByteTrack treats confidence=None the same as all-ones across multi-box batches.
+
+    The batched scenarios exercise the high/low split machinery in
+    `ByteTrackTracker.update()` that single-box equivalence cannot trigger; a
+    regression that mis-buckets `confidence=None` in a multi-detection batch
+    would still pass single-box equality but would diverge here.
+    """
     no_confidence_tracker = ByteTrackTracker(minimum_consecutive_frames=1)
     explicit_confidence_tracker = ByteTrackTracker(minimum_consecutive_frames=1)
-    detection_without_confidence = _no_confidence_detection((100.0, 100.0, 200.0, 200.0))
+    class_ids = np.zeros(len(xyxy_boxes), dtype=int)
+    detection_without_confidence = sv.Detections(xyxy=xyxy_boxes.copy(), class_id=class_ids.copy())
     detection_with_ones_confidence = sv.Detections(
-        xyxy=detection_without_confidence.xyxy.copy(),
-        confidence=np.ones(len(detection_without_confidence), dtype=np.float32),
-        class_id=detection_without_confidence.class_id.copy(),
+        xyxy=xyxy_boxes.copy(),
+        confidence=np.ones(len(xyxy_boxes), dtype=np.float32),
+        class_id=class_ids.copy(),
     )
 
     no_confidence_tracker.reset()
@@ -164,6 +193,56 @@ def test_bytetrack_no_confidence_matches_explicit_ones_confidence() -> None:
         assert no_confidence_result.tracker_id is not None
         assert explicit_confidence_result.tracker_id is not None
         np.testing.assert_array_equal(no_confidence_result.tracker_id, explicit_confidence_result.tracker_id)
+        np.testing.assert_array_equal(no_confidence_result.xyxy, explicit_confidence_result.xyxy)
+
+
+def test_bytetrack_no_confidence_spawns_tracks_below_activation_threshold() -> None:
+    """confidence=None must route every detection to Stage 1 even when explicit-low-conf would not spawn.
+
+    Asserts the actual semantic of treating `None` as 1.0: explicit
+    confidences that fall under `track_activation_threshold` get suppressed
+    in the low-confidence branch, but the same boxes with `confidence=None`
+    still produce confirmed tracker IDs.
+    """
+    activation_threshold = 0.6
+    xyxy_boxes = np.array(
+        [
+            [100.0, 100.0, 200.0, 200.0],
+            [400.0, 400.0, 500.0, 500.0],
+        ],
+        dtype=np.float32,
+    )
+    class_ids = np.zeros(len(xyxy_boxes), dtype=int)
+    detection_without_confidence = sv.Detections(xyxy=xyxy_boxes.copy(), class_id=class_ids.copy())
+    detection_with_low_confidence = sv.Detections(
+        xyxy=xyxy_boxes.copy(),
+        confidence=np.array([0.2, 0.3], dtype=np.float32),
+        class_id=class_ids.copy(),
+    )
+
+    no_confidence_tracker = ByteTrackTracker(
+        minimum_consecutive_frames=1,
+        track_activation_threshold=activation_threshold,
+        high_conf_det_threshold=activation_threshold,
+    )
+    low_confidence_tracker = ByteTrackTracker(
+        minimum_consecutive_frames=1,
+        track_activation_threshold=activation_threshold,
+        high_conf_det_threshold=activation_threshold,
+    )
+
+    no_confidence_tracker.reset()
+    low_confidence_tracker.reset()
+    for _ in range(4):
+        no_confidence_result = no_confidence_tracker.update(detection_without_confidence)
+        low_confidence_result = low_confidence_tracker.update(detection_with_low_confidence)
+
+    assert no_confidence_result.tracker_id is not None
+    assert low_confidence_result.tracker_id is not None
+    assert np.all(no_confidence_result.tracker_id >= 0), "confidence=None should spawn confirmed tracks for every box"
+    assert np.all(low_confidence_result.tracker_id < 0), (
+        "explicit low confidence below activation threshold should NOT spawn tracks"
+    )
 
 
 def test_bytetrack_calls_iou_in_low_confidence_branch() -> None:

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -54,6 +54,13 @@ def _detection(xyxy: tuple[float, float, float, float]) -> sv.Detections:
     )
 
 
+def _no_confidence_detection(xyxy: tuple[float, float, float, float]) -> sv.Detections:
+    return sv.Detections(
+        xyxy=np.array([xyxy], dtype=np.float32),
+        class_id=np.array([0], dtype=int),
+    )
+
+
 class _TrackingIoU(BaseIoU):
     """Test-double IoU that records non-empty compute calls."""
 
@@ -120,6 +127,43 @@ def test_tracker_uses_configured_iou_variant(tracker_id: str) -> None:
     tracker.update(_detection((100.0, 100.0, 200.0, 200.0)))
     tracker.update(_detection((105.0, 105.0, 205.0, 205.0)))
     assert tracking_iou.compute_calls > 0
+
+
+@pytest.mark.parametrize("tracker_id", ALL_TRACKER_IDS)
+def test_no_confidence_detections_can_spawn_confirmed_tracks(tracker_id: str) -> None:
+    """Missing confidence should behave like usable detections, not suppress tracking."""
+    tracker = _instantiate(tracker_id, minimum_consecutive_frames=1)
+    detection = _no_confidence_detection((100.0, 100.0, 200.0, 200.0))
+
+    for _ in range(4):
+        result = tracker.update(detection)
+        if result.tracker_id is not None and np.any(result.tracker_id >= 0):
+            return
+
+    raise AssertionError(f"{tracker_id} did not confirm any track for confidence=None detections")
+
+
+def test_bytetrack_no_confidence_matches_explicit_ones_confidence() -> None:
+    """ByteTrack should treat confidence=None the same as all-ones confidence."""
+    no_confidence_tracker = ByteTrackTracker(minimum_consecutive_frames=1)
+    explicit_confidence_tracker = ByteTrackTracker(minimum_consecutive_frames=1)
+    detection_without_confidence = _no_confidence_detection((100.0, 100.0, 200.0, 200.0))
+    detection_with_ones_confidence = sv.Detections(
+        xyxy=detection_without_confidence.xyxy.copy(),
+        confidence=np.ones(len(detection_without_confidence), dtype=np.float32),
+        class_id=detection_without_confidence.class_id.copy(),
+    )
+
+    no_confidence_tracker.reset()
+    no_confidence_results = [no_confidence_tracker.update(detection_without_confidence) for _ in range(4)]
+    explicit_confidence_tracker.reset()
+    explicit_confidence_results = [explicit_confidence_tracker.update(detection_with_ones_confidence) for _ in range(4)]
+
+    for no_confidence_result, explicit_confidence_result in zip(no_confidence_results, explicit_confidence_results):
+        assert len(no_confidence_result) == len(explicit_confidence_result)
+        assert no_confidence_result.tracker_id is not None
+        assert explicit_confidence_result.tracker_id is not None
+        np.testing.assert_array_equal(no_confidence_result.tracker_id, explicit_confidence_result.tracker_id)
 
 
 def test_bytetrack_calls_iou_in_low_confidence_branch() -> None:


### PR DESCRIPTION
## What does this PR do?

Make `ByteTrackTracker.update()` treat `detections.confidence is None` as all-ones confidence, matching SORT, OC-SORT, and BoT-SORT behavior.

Previously, ByteTrack defaulted missing confidence to zeros, which routed every detection into the low-confidence bucket. Since ByteTrack only starts new tracks from unmatched high-confidence detections, valid `sv.Detections(xyxy=...)` inputs could silently return only `tracker_id=-1` forever.

## Type of Change

I think this could be considered a bug fix or at least consistency improvement.

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Note

As mentioned previously I want to do a Dart clone of Trackers so that I can use it in my mobile app offline.
To avoid rework I asked a coding agent to review the Python package with Claude Opus 4.7 and GPT 5.5 and it suggested several fixes and improvements.

See here: https://gist.github.com/cdeil/0807f9b4f6e668f4277614822bc8b52f

@Borda - maybe you could skim the list and let me know if you think which/any are actual issues / worth doing. And if you want me to send PRs like this one or just prompt yourself. I'm not very familiar with this, so unfortunately probably won't be able to add much value over what the agents suggest.