### PR TITLE
fix/docs: Clarify SORTTracker deprecation status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### 🚀 Added
 
-- Clarified that `SORTTracker` is not deprecated; only the old `tracker.trackers` alias is deprecated in favor of `tracker.tracks`.
 - **Pluggable IoU variants** — `iou=` parameter on all four trackers (`SORTTracker`, `ByteTrackTracker`, `OCSORTTracker`, `BoTSORTTracker`) accepts any `BaseIoU` subclass. Built-in variants: `IoU` (standard), `GIoU`, `DIoU`, `CIoU`, `BIoU` (Buffered IoU) ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **`BaseIoU` ABC** in `trackers.utils.iou` — defines the `compute(boxes_1, boxes_2)` contract; subclass and override `_compute` to implement a custom similarity metric ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **`normalize_for_fusion` on `BaseIoU`** — signed variants (GIoU, DIoU, CIoU) override this to shift `[-1, 1]` → `[0, 1]` before BoT-SORT score fusion, preventing ranking inversion ([#403](https://github.com/roboflow/trackers/pull/403)).
 
 ### 🔄 Deprecated
 
+- **`SORTTracker.trackers`** — deprecated alias for `.tracks`; emits `FutureWarning` since v2.5, will be removed in v3.0. Use `tracker.tracks` instead.
 - **`trackers.core.botsort.cmc` module** — `CMC` moved to `trackers.utils.cmc`; old path re-exports all symbols with `DeprecationWarning` until v3.0. Migrate: `from trackers.utils.cmc import CMC` or `from trackers import CMC` ([#414](https://github.com/roboflow/trackers/pull/414)).
 - **`BoTSORTTracker.apply_cmc_batch`** — use `CMC.apply_batch(H, tracker.tracks)` directly. Will be removed in v3.0 ([#414](https://github.com/roboflow/trackers/pull/414)).
 - **`CMCTMethod` type alias** — kept as a back-compat alias for `CMCMethod`; will be removed in v3.0. Migrate to `CMCMethod` ([#414](https://github.com/roboflow/trackers/pull/414)).
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### 🔧 Fixed
 
+- Clarified in docs that `SORTTracker` itself is not deprecated — only the `.trackers` alias is.
 - **BoT-SORT score fusion with signed IoU** — `_fuse_score` multiplied raw negative IoU values by confidence, inverting track ranking for GIoU/DIoU/CIoU; `normalize_for_fusion` now normalises similarity before fusion ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **Non-finite box coordinates crash `linear_sum_assignment`** — `BaseIoU.compute` now raises `ValueError` with a clear message for NaN/inf inputs instead of propagating invalid entries into SciPy ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **OC-SORT Observation-Centric Recovery** now uses standard `IoU` per the paper, independent of the configured `iou=` variant ([#403](https://github.com/roboflow/trackers/pull/403)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### 🚀 Added
 
+- Clarified that `SORTTracker` is not deprecated; only the old `tracker.trackers` alias is deprecated in favor of `tracker.tracks`.
 - **Pluggable IoU variants** — `iou=` parameter on all four trackers (`SORTTracker`, `ByteTrackTracker`, `OCSORTTracker`, `BoTSORTTracker`) accepts any `BaseIoU` subclass. Built-in variants: `IoU` (standard), `GIoU`, `DIoU`, `CIoU`, `BIoU` (Buffered IoU) ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **`BaseIoU` ABC** in `trackers.utils.iou` — defines the `compute(boxes_1, boxes_2)` contract; subclass and override `_compute` to implement a custom similarity metric ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **`normalize_for_fusion` on `BaseIoU`** — signed variants (GIoU, DIoU, CIoU) override this to shift `[-1, 1]` → `[0, 1]` before BoT-SORT score fusion, preventing ranking inversion ([#403](https://github.com/roboflow/trackers/pull/403)).

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -181,6 +181,7 @@ These examples use `opencv-python` for decoding and display. Replace `<SOURCE_VI
     video_capture.release()
     cv2.destroyAllWindows()
     ```
+
 > Note: `SORTTracker` is not deprecated. The old `tracker.trackers` alias is deprecated in favor of `tracker.tracks`.
 
 ## Reference

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -53,6 +53,7 @@ SORT models each tracked object with a seven-dimensional state vector `[x, y, s,
     If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
 
 !!! note "SORTTracker is not deprecated"
+
     `SORTTracker` itself is not deprecated. Only the `tracker.trackers` attribute alias
     is deprecated in favor of `tracker.tracks`.
 

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -181,6 +181,7 @@ These examples use `opencv-python` for decoding and display. Replace `<SOURCE_VI
     video_capture.release()
     cv2.destroyAllWindows()
     ```
+> Note: `SORTTracker` is not deprecated. The old `tracker.trackers` alias is deprecated in favor of `tracker.tracks`.
 
 ## Reference
 

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -52,6 +52,10 @@ SORT models each tracked object with a seven-dimensional state vector `[x, y, s,
     `SORTTracker.update()` accepts `frame` for API consistency with other trackers, but SORT does not use image/frame pixels.
     If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
 
+!!! note "SORTTracker is not deprecated"
+    `SORTTracker` itself is not deprecated. Only the `tracker.trackers` attribute alias
+    is deprecated in favor of `tracker.tracks`.
+
 ## Run on video, webcam, or RTSP stream
 
 These examples use `opencv-python` for decoding and display. Replace `<SOURCE_VIDEO_PATH>`, `<WEBCAM_INDEX>`, and `<RTSP_STREAM_URL>` with your inputs. `<WEBCAM_INDEX>` is usually 0 for the default camera.
@@ -181,8 +185,6 @@ These examples use `opencv-python` for decoding and display. Replace `<SOURCE_VI
     video_capture.release()
     cv2.destroyAllWindows()
     ```
-
-> Note: `SORTTracker` is not deprecated. The old `tracker.trackers` alias is deprecated in favor of `tracker.tracks`.
 
 ## Reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "opencv-python>=4.8.0",
     "rich>=13.0.0",
     "requests>=2.28.0",
+    "pydeprecate>=0.7.0",
 ]
 
 [project.optional-dependencies]
@@ -200,6 +201,7 @@ plugins = ["numpy.typing.mypy_plugin"]
 
 [[tool.mypy.overrides]]
 module = [
+    "deprecate",
     "requests",
     "torch",
     "torchvision",

--- a/src/trackers/core/sort/tracker.py
+++ b/src/trackers/core/sort/tracker.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 
 import numpy as np
 import supervision as sv
+from deprecate import deprecated
 from scipy.optimize import linear_sum_assignment
 
 from trackers.core.base import BaseTracker
@@ -102,6 +103,7 @@ class SORTTracker(BaseTracker):
         self._reset_id_allocator()
 
     @property
+    @deprecated(target=None, deprecated_in="2.0", remove_in="3.0")
     def trackers(self) -> list[SORTTracklet]:
         """Deprecated: use tracks instead."""
         return self.tracks

--- a/src/trackers/core/sort/tracker.py
+++ b/src/trackers/core/sort/tracker.py
@@ -103,9 +103,13 @@ class SORTTracker(BaseTracker):
         self._reset_id_allocator()
 
     @property
-    @deprecated(target=None, deprecated_in="2.0", remove_in="3.0")
+    @deprecated(target=None, deprecated_in="2.5", remove_in="3.0")
     def trackers(self) -> list[SORTTracklet]:
-        """Deprecated: use tracks instead."""
+        """Deprecated alias for :attr:`tracks`.
+
+        .. deprecated:: 2.5
+            Use :attr:`tracks` instead. Will be removed in v3.0.
+        """
         return self.tracks
 
     def _get_associated_indices(

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -645,3 +645,12 @@ def test_bytetrack_consecutive_counter_resets_on_miss() -> None:
     tracker.update(_detection(bbox))
     assert tracker.tracks[0].number_of_successful_consecutive_updates == 1
     assert tracker.tracks[0].tracker_id == -1
+
+
+def test_sort_trackers_property_emits_future_warning() -> None:
+    """Accessing deprecated .trackers must emit FutureWarning with correct message."""
+    tracker = SORTTracker(minimum_consecutive_frames=1)
+    with pytest.warns(FutureWarning, match=r"deprecated since v2\.5"):
+        result = tracker.trackers
+    assert result is tracker.tracks
+    assert isinstance(type(tracker).__dict__["trackers"], property)

--- a/uv.lock
+++ b/uv.lock
@@ -4071,6 +4071,7 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "opencv-python" },
+    { name = "pydeprecate" },
     { name = "requests" },
     { name = "rich" },
     { name = "scipy" },
@@ -4118,6 +4119,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "opencv-python", specifier = ">=4.8.0" },
     { name = "optuna", marker = "extra == 'tune'", specifier = ">=3.0.0" },
+    { name = "pydeprecate", specifier = ">=0.7.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "scipy", specifier = ">=1.13.1" },


### PR DESCRIPTION
## What does this PR do?

Clarifies that `SORTTracker` itself is not deprecated. The deprecated API is only the old `tracker.trackers` alias, which should be replaced with `tracker.tracks`.

**Related Issue(s):** Fixes #454

## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Documentation update
- Refactoring (no functional changes)

## Testing

* [x] I have tested this change locally
* [ ] I have added/updated tests for this change


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)
