### PR TITLE
v2.5.0: Pluggable IoU variants + C-BIoU tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.0] — 2026-06-22
 
 ### 🚀 Added
 
 - **Pluggable IoU variants** — `iou=` parameter on all four trackers (`SORTTracker`, `ByteTrackTracker`, `OCSORTTracker`, `BoTSORTTracker`) accepts any `BaseIoU` subclass. Built-in variants: `IoU` (standard), `GIoU`, `DIoU`, `CIoU`, `BIoU` (Buffered IoU) ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **`BaseIoU` ABC** in `trackers.utils.iou` — defines the `compute(boxes_1, boxes_2)` contract; subclass and override `_compute` to implement a custom similarity metric ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **`normalize_for_fusion` on `BaseIoU`** — signed variants (GIoU, DIoU, CIoU) override this to shift `[-1, 1]` → `[0, 1]` before BoT-SORT score fusion, preventing ranking inversion ([#403](https://github.com/roboflow/trackers/pull/403)).
+- **`CBIoUTracker`** — Cascaded-Buffered IoU tracker (Yang et al., WACV 2023). Two-stage matching with independently tunable `buffer_ratio_first` / `buffer_ratio_second` buffer scales; inherits ByteTrack-style low-confidence second pass from BoT-SORT ([#417](https://github.com/roboflow/trackers/pull/417)).
+- **`py.typed` marker** — PEP 561 compliance; IDEs and type checkers now recognise the package as typed without `--ignore-missing-imports`.
 
 ### 🔄 Deprecated
 
@@ -30,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **`CMC.warp_xyxy_corners`** — `apply_to_xyxy` renamed to `warp_xyxy_corners`; old name kept as a deprecated wrapper until v3.0 ([#414](https://github.com/roboflow/trackers/pull/414)).
 - **`CMC.apply_batch` homogeneity guard** — now raises `TypeError` immediately when the tracklet list contains mixed state-estimator types, preventing silent state corruption ([#414](https://github.com/roboflow/trackers/pull/414)).
 - **`BoTSORTTracklet.apply_cmc` delegates to `CMC.apply_batch`** — per-track and batch paths now share identical code; behaviour is unchanged ([#414](https://github.com/roboflow/trackers/pull/414)).
+- **`Tuner` gains `enqueue_defaults`, `fixed_params`, `images_dir`, `seed`** — `enqueue_defaults=True` (default) evaluates a baseline trial using each param's `__init__` default before Optuna samples; `fixed_params` holds selected params constant across all trials; `images_dir` enables frame loading for CMC-enabled trackers; `seed` makes TPE sampling reproducible ([#427](https://github.com/roboflow/trackers/pull/427)).
 
 ### 🔧 Fixed
 
@@ -41,6 +44,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **CLI argparse crash on `BaseIoU` parameter** — `iou=` is now excluded from argparse auto-discovery; the variant must be set programmatically ([#403](https://github.com/roboflow/trackers/pull/403)).
 - **ByteTrack tracked nothing when detections lacked confidence scores** — the default-fill changed from `np.zeros` to `np.ones`, matching SORT / OC-SORT / BoT-SORT behaviour, so detectors that emit `sv.Detections` without `confidence` now produce tracks instead of empty results ([#415](https://github.com/roboflow/trackers/pull/415)).
 - **Tracker instances no longer share track ID counters** — resetting one tracker instance no longer resets another instance's ID allocator, preventing duplicate live IDs in multi-camera, class-specific, or parallel tracker workflows.
+- **HOTA per-frame alpha loop vectorized** — removes the inner Python loop; large evaluations run significantly faster with no change to numeric output ([#462](https://github.com/roboflow/trackers/pull/462)).
+- **MOT evaluation distractor handling** — ground-truth preprocessing now applies distractor class filtering consistent with TrackEval, correcting reported metrics on MOT17 and similar datasets ([#466](https://github.com/roboflow/trackers/pull/466)).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 </div>
 
-Keeping track of objects across video frames is one of those problems that sounds simple until you try it — occlusions, fast motion, similar-looking targets, and moving cameras all conspire against you. `trackers` gives you clean, benchmarked implementations of SORT, ByteTrack, OC-SORT, and BoT-SORT so you can skip the plumbing and focus on your application. It speaks `supervision.Detections` natively, which means it slots into any detector you already use — YOLO, DETR, RT-DETR, or anything else — without glue code. Whether you are a researcher comparing algorithms, an engineer shipping a production pipeline, or a hobbyist building something cool, `trackers` gives you a single consistent interface for all of them. Requires Python ≥ 3.10.
+Keeping track of objects across video frames is one of those problems that sounds simple until you try it — occlusions, fast motion, similar-looking targets, and moving cameras all conspire against you. `trackers` gives you clean, benchmarked implementations of SORT, ByteTrack, OC-SORT, BoT-SORT, and C-BIoU so you can skip the plumbing and focus on your application. It speaks `supervision.Detections` natively, which means it slots into any detector you already use — YOLO, DETR, RT-DETR, or anything else — without glue code. Whether you are a researcher comparing algorithms, an engineer shipping a production pipeline, or a hobbyist building something cool, `trackers` gives you a single consistent interface for all of them. Requires Python ≥ 3.10.
 
 ## Why trackers?
 
@@ -88,12 +88,13 @@ For all CLI options, see the [tracking guide](https://trackers.roboflow.com/deve
 
 Each tracker below is a faithful implementation of its original paper. Pick the one that fits your scene, or run the benchmark to find out which performs best on your data.
 
-|                   Algorithm                   |                           Description                           | MOT17 HOTA | SportsMOT HOTA | SoccerNet HOTA | DanceTrack HOTA |
-| :-------------------------------------------: | :-------------------------------------------------------------: | :--------: | :------------: | :------------: | :-------------: |
-|   [SORT](https://arxiv.org/abs/1602.00763)    |          Kalman filter + Hungarian matching baseline.           |    58.4    |      70.9      |      81.6      |      47.2       |
-| [ByteTrack](https://arxiv.org/abs/2110.06864) | Two-stage association using high and low confidence detections. |    60.1    |      73.0      |      84.0      |      53.3       |
-|  [OC-SORT](https://arxiv.org/abs/2203.14360)  |          Observation-centric recovery for lost tracks.          |    61.9    |      71.7      |      78.4      |      54.1       |
-| [BoT-SORT](https://arxiv.org/abs/2206.14651)  |                   Camera motion compensation                    |  **63.7**  |    **73.8**    |    **84.5**    |    **57.8**     |
+|                                                                           Algorithm                                                                           |                           Description                           | MOT17 HOTA | SportsMOT HOTA | SoccerNet HOTA | DanceTrack HOTA |
+| :-----------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------: | :--------: | :------------: | :------------: | :-------------: |
+|                                                           [SORT](https://arxiv.org/abs/1602.00763)                                                            |          Kalman filter + Hungarian matching baseline.           |    58.4    |      70.9      |      81.6      |      47.2       |
+|                                                         [ByteTrack](https://arxiv.org/abs/2110.06864)                                                         | Two-stage association using high and low confidence detections. |    60.1    |      73.0      |      84.0      |      53.3       |
+|                                                          [OC-SORT](https://arxiv.org/abs/2203.14360)                                                          |          Observation-centric recovery for lost tracks.          |    61.9    |      71.7      |      78.4      |      54.1       |
+|                                                         [BoT-SORT](https://arxiv.org/abs/2206.14651)                                                          |                   Camera motion compensation                    |  **63.7**  |    **73.8**    |    **84.5**    |    **57.8**     |
+| [C-BIoU](https://openaccess.thecvf.com/content/WACV2023/papers/Yang_Hard_To_Track_Objects_With_Irregular_Motions_and_Similar_Appearances_WACV_2023_paper.pdf) |  Cascaded buffered IoU matching for fast or irregular motion.   |    63.0    |      73.1      |      82.6      |      56.7       |
 
 All scores use default parameters on the standard split. See the [tracker comparison](https://trackers.roboflow.com/develop/trackers/comparison/) for tuned numbers and methodology.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trackers"
-version = "2.4.0"
+version = "2.5.0"
 description = "A unified library for object tracking featuring clean room re-implementations of leading multi-object tracking algorithms"
 readme = "README.md"
 maintainers = [


### PR DESCRIPTION
## 📋 Summary

trackers 2.5.0 makes the association step configurable: all four trackers now accept an `iou=` parameter and ship five built-in IoU variants. The new `CBIoUTracker` (C-BIoU, WACV 2023) extends the built-in algorithm roster with cascaded buffered matching for fast-moving or small objects. The Tuner gets four new parameters that round out the tuning workflow, and a correctness fix in HOTA evaluation brings numbers in line with TrackEval.

Track IDs are now allocated per-tracker-instance, so multi-camera and class-specific workflows no longer risk duplicate IDs across independent trackers.

## ✨ Spotlights

### 🎯 Pluggable IoU variants

All four trackers now accept an `iou=` parameter that takes any `BaseIoU` subclass. Five built-in variants:

| Variant | Score range | Best for                                       |
| ------- | ----------- | ---------------------------------------------- |
| `IoU`   | `[0, 1]`    | Default — strong baseline                      |
| `GIoU`  | `[-1, 1]`   | Boxes that frequently lose overlap (occlusion) |
| `DIoU`  | `[-1, 1]`   | Fast-moving objects; centre-distance signal    |
| `CIoU`  | `[-1, 1]`   | Same as DIoU + aspect-ratio consistency        |
| `BIoU`  | `[0, 1]`    | Small or very fast objects (buffered boxes)    |

```python
from trackers import ByteTrackTracker
from trackers.utils.iou import GIoU

tracker = ByteTrackTracker(
    iou=GIoU(),
    minimum_iou_threshold=0.1,  # re-tune for the new score range
)
detections = tracker.update(detections)
```

Subclass `BaseIoU` and override `_compute` to plug in a fully custom metric. The `normalize_for_fusion` hook handles signed-range variants correctly in BoT-SORT's score-fusion step.

### 🆕 CBIoUTracker

`CBIoUTracker` (Yang et al., [WACV 2023](https://openaccess.thecvf.com/content/WACV2023/papers/Yang_Hard_To_Track_Objects_With_Irregular_Motions_and_Similar_Appearances_WACV_2023_paper.pdf)) expands boxes by a configurable margin before computing IoU and runs two cascade passes with independently tunable buffer ratios:

```python
from trackers import CBIoUTracker

tracker = CBIoUTracker(
    buffer_ratio_first=0.1,  # first pass: small buffer (high-conf dets vs tracks)
    buffer_ratio_second=0.3,  # second pass: larger buffer (confirmed tracks vs low-conf)
)
detections = tracker.update(detections)
```

Benchmark scores on val sets (default parameters):

| Algorithm | MOT17 HOTA | SportsMOT HOTA | DanceTrack val HOTA |
| --------- | :--------: | :------------: | :-----------------: |
| SORT      |    58.4    |      70.9      |        47.2         |
| ByteTrack |    60.1    |      73.0      |        53.3         |
| OC-SORT   |    61.9    |      71.7      |        54.1         |
| BoT-SORT  |  **63.7**  |    **73.8**    |      **57.8**       |
| C-BIoU    |    59.5    |      72.1      |        55.1         |

*See [tracker comparison](https://trackers.roboflow.com/trackers/comparison/) for tuned numbers and methodology.*

### ⚙️ Tuner enhancements

Four new `Tuner` parameters:

```python
from trackers.tune import Tuner
from trackers import BoTSORTTracker

tuner = Tuner(
    tracker_class=BoTSORTTracker,
    gt_dir="data/gt/",
    detections_dir="data/det/",
    images_dir="data/img/",  # new: frames for CMC-enabled trackers
    fixed_params={"enable_cmc": True},  # new: held constant across all trials
    enqueue_defaults=True,  # new: baseline trial before Optuna samples
    seed=42,  # new: reproducible TPE sampling
)
result = tuner.tune()
```

## Migration guide

### Breaking: tracklet class-level ID counters removed

If you subclass `BaseTracker` and called a tracklet's class-level `get_next_tracker_id()`:

```python
# Before (v2.4.0)
tracker_id = SORTTracklet.get_next_tracker_id()

# After (v2.5.0)
tracker_id = self._allocate_tracker_id()  # in your BaseTracker subclass
```

Users of the public `tracker.update()` API are **not affected**.

### Deprecations (removed in v3.0)

```python
# SORTTracker.trackers → .tracks
for t in tracker.tracks:  # was: tracker.trackers

# CMC import path
from trackers.utils.cmc import CMC, CMCConfig, CMCMethod  # was: trackers.core.botsort.cmc
from trackers import CMC  # also works

# CMC.apply_to_xyxy → CMC.warp_xyxy_corners
warped = cmc.warp_xyxy_corners(H, boxes)  # was: apply_to_xyxy

# BoTSORTTracker.apply_cmc_batch → CMC.apply_batch
cmc.apply_batch(H, tracker.tracks)  # was: tracker.apply_cmc_batch(H)

# CMCTMethod → CMCMethod
from trackers.utils.cmc import CMCMethod  # was: CMCTMethod
```

## Notable changes

### 🚀 Added

- **Pluggable IoU variants** — `iou=` parameter on `SORTTracker`, `ByteTrackTracker`, `OCSORTTracker`, `BoTSORTTracker`; five built-in variants plus `BaseIoU` ABC for custom metrics. (#403)
- **`CBIoUTracker`** — Cascaded-Buffered IoU tracker (Yang et al., WACV 2023). (#417)
- **`Tuner` params** — `enqueue_defaults`, `fixed_params`, `images_dir`, `seed`. (#427)
- **`py.typed` marker** — PEP 561 compliance; downstream type checkers now recognise the package as typed.

### ⚠️ Breaking Changes

- **Tracklet class-level ID counters removed** — `*Tracklet.get_next_tracker_id()` class methods removed from all tracklet subclasses. Use `self._allocate_tracker_id()` (from `BaseTracker`) instead. Only affects custom `BaseTracker` subclassers. (#419)

### 🌱 Changed

- **`CMC`, `CMCConfig`, `CMCMethod` moved to `trackers.utils.cmc`**, re-exported from top-level `trackers`; old `trackers.core.botsort.cmc` path kept as deprecated shim. (#414)
- **`CMC.apply_batch` homogeneity guard** — raises `TypeError` on mixed state-estimator tracklet lists. (#414)
- **OC-SORT OCR step** always uses standard `IoU` regardless of configured `iou=` variant, matching the paper. (#403)

### 🗑️ Deprecated

- `SORTTracker.trackers` → `.tracks` (FutureWarning, removed in v3.0). (#460)
- `trackers.core.botsort.cmc` import path → `trackers.utils.cmc` (DeprecationWarning, removed in v3.0). (#414)
- `BoTSORTTracker.apply_cmc_batch` → `CMC.apply_batch(H, tracker.tracks)` (removed in v3.0). (#414)
- `CMCTMethod` → `CMCMethod` (removed in v3.0). (#414)
- `CMC.apply_to_xyxy` → `CMC.warp_xyxy_corners` (removed in v3.0). (#414)

### 🔧 Fixed

- **BoT-SORT score fusion** — signed IoU variants (GIoU/DIoU/CIoU) now normalised before fusion via `normalize_for_fusion`, preventing track-ranking inversion. (#403)
- **Non-finite box coordinates** — `BaseIoU.compute` raises `ValueError` with a clear message for NaN/inf inputs instead of propagating into SciPy's `linear_sum_assignment`. (#403)
- **ByteTrack `confidence=None`** — detections without confidence now treated as high-confidence (SORT-like); previously produced no tracks. (#415)
- **HOTA evaluation accuracy** — per-frame alpha loop vectorized; MOT distractor class filtering now matches TrackEval, correcting reported HOTA on MOT17. (#462, #466)
- **Tracker instances no longer share ID counters** — resetting one tracker no longer affects another's ID allocator. (#419)

---

## 🏆 Contributors

- **Alexander Bodner** (@AlexBodner, [LinkedIn](https://www.linkedin.com/in/alexanderbodner/)) — C-BIoU tracker, IoU variants, tuner enhancements, DanceTrack benchmark results
- **Tomasz Stańczyk** (@tstanczyk95) ([LinkedIn](https://www.linkedin.com/in/tomasz-stanczyk/)) — C-BIoU and IoU variants - expertise sharing and supervision
- **Christoph Deil** (@cdeil, [LinkedIn](https://www.linkedin.com/in/christophdeil/)) — per-instance ID allocators, ByteTrack confidence fix
- **Manan Gupta** (@manan152003, [LinkedIn](https://www.linkedin.com/in/manan152003/)) — SORTTracker deprecation docs
- **Ruben Haisma** (@RubenHaisma, [LinkedIn](https://www.linkedin.com/in/rubenhaisma/)) — HOTA vectorization, MOT distractor class fix
- **Jirka Borovec** (@Borda, [LinkedIn](https://linkedin.com/in/jirka-borovec)) — review, docs, test infrastructure

---

**Full changelog**: https://github.com/roboflow/trackers/compare/2.4.0...v2.5.0
