### PR TITLE
ci(docs): block pre-release tags from deploying versioned docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -63,10 +63,14 @@ jobs:
           REF_NAME="${{ github.event.inputs.ref }}"
           # If it's a full ref like refs/heads/branch or refs/tags/tag, extract the name
           CLEAN_REF=$(echo "$REF_NAME" | sed 's|^refs/[^/]*/||')
+          if echo "$CLEAN_REF" | grep -qE '(rc|dev|alpha|beta|\.a[0-9]|\.b[0-9])'; then
+            echo "Skipping pre-release ref: $CLEAN_REF"
+            exit 0
+          fi
           uv run mike deploy --push $CLEAN_REF
 
       - name: 🚀 Deploy Release Docs
-        if: github.event_name == 'release' && github.event.action == 'published'
+        if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -63,11 +63,11 @@ jobs:
           REF_NAME="${{ github.event.inputs.ref }}"
           # If it's a full ref like refs/heads/branch or refs/tags/tag, extract the name
           CLEAN_REF=$(echo "$REF_NAME" | sed 's|^refs/[^/]*/||')
-          if echo "$CLEAN_REF" | grep -qE '(rc|dev|alpha|beta|\.a[0-9]|\.b[0-9])'; then
+          if echo "$CLEAN_REF" | grep -qE '(^|[._-]|[0-9])(rc[0-9]*|dev[0-9]*|alpha[0-9]*|beta[0-9]*|a[0-9]+|b[0-9]+)([._-]|$)'; then
             echo "Skipping pre-release ref: $CLEAN_REF"
             exit 0
           fi
-          uv run mike deploy --push $CLEAN_REF
+          uv run mike deploy --push "$CLEAN_REF"
 
       - name: 🚀 Deploy Release Docs
         if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -56,6 +56,7 @@ jobs:
         run: uv run mike deploy --push develop
 
       - name: 🚀 Deploy Custom Ref Docs
+        id: deploy-custom-ref
         if: github.event_name == 'workflow_dispatch'
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
@@ -65,6 +66,7 @@ jobs:
           CLEAN_REF=$(echo "$REF_NAME" | sed 's|^refs/[^/]*/||')
           if echo "$CLEAN_REF" | grep -qE '(^|[._-]|[0-9])(rc[0-9]*|dev[0-9]*|alpha[0-9]*|beta[0-9]*|a[0-9]+|b[0-9]+)([._-]|$)'; then
             echo "Skipping pre-release ref: $CLEAN_REF"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           uv run mike deploy --push "$CLEAN_REF"
@@ -84,7 +86,7 @@ jobs:
         # these at the site root, so copy them to the gh-pages root after every deploy.
         # IndexNow key: bc061e8ae9e449d7acb9f86d29637e58
         # Must stay in sync: docs/bc061e8ae9e449d7acb9f86d29637e58.txt + main.html meta tag + notify step below.
-        if: success()
+        if: success() && steps.deploy-custom-ref.outputs.skipped != 'true'
         run: |
           cp docs/robots.txt /tmp/robots.txt
           cp docs/llms.txt /tmp/llms.txt
@@ -101,7 +103,7 @@ jobs:
           git checkout -
 
       - name: 📡 Notify IndexNow
-        if: success()
+        if: success() && steps.deploy-custom-ref.outputs.skipped != 'true'
         run: |
           curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.indexnow.org/IndexNow" \
             -H "Content-Type: application/json; charset=utf-8" \

--- a/uv.lock
+++ b/uv.lock
@@ -4119,7 +4119,7 @@ wheels = [
 
 [[package]]
 name = "trackers"
-version = "2.4.0"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
This pull request updates the documentation publishing workflow to prevent documentation from being deployed for pre-release branches or tags (such as release candidates or development versions). The changes add early exits for pre-release refs and ensure that only full releases trigger the deployment of release docs.

**Deployment workflow improvements:**

* Added a check in `.github/workflows/publish-docs.yml` to skip deploying documentation for pre-release refs (matching patterns like `rc`, `dev`, `alpha`, `beta`, `.a[0-9]`, or `.b[0-9]`).
* Updated the condition for the "Deploy Release Docs" step to ensure it only runs for published, non-prerelease releases.