### PR TITLE
[McByte part 6] Mask manager lifecycle wiring

### DIFF
--- a/src/trackers/core/mcbyte/mask_manager.py
+++ b/src/trackers/core/mcbyte/mask_manager.py
@@ -17,11 +17,12 @@ from trackers.core.mcbyte.masks.base import (
 
 
 class MaskManager:
-    """Manage McByte mask generation and propagation.
+    """Coordinate McByte mask generation and temporal propagation.
 
-    The manager follows the original McByte timing: masks for the current frame
-    are prepared before association, but they are initialized/updated from tracker
-    outputs produced on the previous frame.
+    The manager follows the original McByte timing: masks for frame ``t`` are
+    prepared before association on frame ``t``, using tracker outputs from frame
+    ``t-1``. New and removed tracklets are therefore passed in as lifecycle
+    events from the previous tracker update.
     """
 
     def __init__(
@@ -34,6 +35,7 @@ class MaskManager:
         self._initialized = False
 
     def reset(self) -> None:
+        """Reset mask-manager state and the underlying propagator."""
         self._initialized = False
         if self.mask_propagator is not None:
             self.mask_propagator.reset()
@@ -43,15 +45,36 @@ class MaskManager:
         frame: np.ndarray,
         previous_frame: np.ndarray | None,
         previous_tracklets: list[TrackletSnapshot],
+        new_tracklets: list[TrackletSnapshot] | None = None,
+        removed_tracklet_ids: list[int] | None = None,
     ) -> MaskOutput | None:
-        """Return masks for the current frame.
+        """Return propagated masks for the current frame.
 
-        No masks are returned until at least one previous frame and previous
-        tracker output are available.
+        The method consumes tracker state from the previous frame. On the first
+        valid call, masks are generated from ``previous_tracklets`` on
+        ``previous_frame`` and used to initialize the propagator. On later calls,
+        masks for ``new_tracklets`` are generated on ``previous_frame`` and added to
+        the propagator, while ``removed_tracklet_ids`` are removed from propagation
+        memory.
 
-        If a propagator is configured, masks are initialized from the previous
-        frame and propagated to the current frame. If propagation is unavailable
-        or fails, ``None`` is returned to avoid using stale or misaligned masks.
+        After lifecycle updates are applied, the propagator advances masks to
+        ``frame`` and returns the resulting ``MaskOutput``.
+
+        Args:
+            frame: Current RGB frame for which masks should be produced.
+            previous_frame: Previous RGB frame used for initialization or adding new
+                masks. If ``None``, no masks are returned.
+            previous_tracklets: Tracklet snapshots produced by the tracker on the
+                previous frame.
+            new_tracklets: Tracklets created on the previous frame that should be
+                added to propagation memory.
+            removed_tracklet_ids: Tracklet IDs terminated on the previous frame that
+                should be removed from propagation memory.
+
+        Returns:
+            Propagated mask output for ``frame``. Returns ``None`` when there is no
+            previous frame/tracklet state, no propagator is configured, or
+            propagation fails.
         """
         if previous_frame is None or len(previous_tracklets) == 0:
             return None
@@ -59,10 +82,20 @@ class MaskManager:
         if self.mask_propagator is None:
             return None
 
+        new_tracklets = [] if new_tracklets is None else new_tracklets
+        removed_tracklet_ids = [] if removed_tracklet_ids is None else removed_tracklet_ids
+
         if not self._initialized:
             mask_output = self.mask_generator.generate(previous_frame, previous_tracklets)
             self.mask_propagator.initialize(previous_frame, mask_output)
             self._initialized = True
+        else:
+            if len(new_tracklets) > 0:
+                new_mask_output = self.mask_generator.generate(previous_frame, new_tracklets)
+                self.mask_propagator.add_masks(previous_frame, new_mask_output)
+
+            if len(removed_tracklet_ids) > 0:
+                self.mask_propagator.remove_masks(removed_tracklet_ids)
 
         propagated_output = self.mask_propagator.propagate(frame)
         if propagated_output is not None:

--- a/src/trackers/core/mcbyte/mask_manager.py
+++ b/src/trackers/core/mcbyte/mask_manager.py
@@ -76,7 +76,10 @@ class MaskManager:
             previous frame/tracklet state, no propagator is configured, or
             propagation fails.
         """
-        if previous_frame is None or len(previous_tracklets) == 0:
+        if previous_frame is None:
+            return None
+
+        if not self._initialized and len(previous_tracklets) == 0:
             return None
 
         if self.mask_propagator is None:

--- a/src/trackers/core/mcbyte/masks/base.py
+++ b/src/trackers/core/mcbyte/masks/base.py
@@ -62,3 +62,18 @@ class MaskPropagator(ABC):
         frame: np.ndarray,
     ) -> MaskOutput | None:
         """Propagate masks to the current frame."""
+
+    @abstractmethod
+    def add_masks(
+        self,
+        frame: np.ndarray,
+        mask_output: MaskOutput,
+    ) -> None:
+        """Add masks to existing propagation state."""
+
+    @abstractmethod
+    def remove_masks(
+        self,
+        tracklet_ids: list[int],
+    ) -> None:
+        """Remove masks from existing propagation state."""

--- a/src/trackers/core/mcbyte/masks/dummy.py
+++ b/src/trackers/core/mcbyte/masks/dummy.py
@@ -47,12 +47,19 @@ class DummyBoxMaskGenerator(MaskGenerator):
 
 
 class DummyIdentityMaskPropagator(MaskPropagator):
-    """Return the last initialized mask output unchanged."""
+    """In-memory mask propagator used for lightweight MaskManager tests.
+
+    The propagator keeps the last initialized ``MaskOutput`` and returns copies
+    of it during propagation. It also supports simple add/remove lifecycle
+    operations so MaskManager tests can validate mask indexing without requiring
+    SAM, Cutie, checkpoints, or GPU.
+    """
 
     def __init__(self) -> None:
         self._mask_output: MaskOutput | None = None
 
     def reset(self) -> None:
+        """Clear the stored mask output."""
         self._mask_output = None
 
     def initialize(
@@ -60,6 +67,7 @@ class DummyIdentityMaskPropagator(MaskPropagator):
         frame: np.ndarray,
         mask_output: MaskOutput,
     ) -> None:
+        """Store a copy of the initial mask output."""
         self._mask_output = MaskOutput(
             masks=None if mask_output.masks is None else mask_output.masks.copy(),
             tracklet_mask_dict=mask_output.tracklet_mask_dict.copy(),
@@ -72,6 +80,7 @@ class DummyIdentityMaskPropagator(MaskPropagator):
         self,
         frame: np.ndarray,
     ) -> MaskOutput | None:
+        """Return a copy of the current stored mask output."""
         if self._mask_output is None:
             return None
 
@@ -81,4 +90,59 @@ class DummyIdentityMaskPropagator(MaskPropagator):
             mask_avg_prob_dict=(
                 None if self._mask_output.mask_avg_prob_dict is None else self._mask_output.mask_avg_prob_dict.copy()
             ),
+        )
+
+    def add_masks(
+        self,
+        frame: np.ndarray,
+        mask_output: MaskOutput,
+    ) -> None:
+        """Append new masks and remap their tracklet indices."""
+        if self._mask_output is None:
+            self.initialize(frame, mask_output)
+            return
+
+        if self._mask_output.masks is None or mask_output.masks is None:
+            return
+
+        offset = self._mask_output.masks.shape[0]
+        added_mapping = {
+            tracklet_id: offset + local_index
+            for tracklet_id, local_index in mask_output.tracklet_mask_dict.items()
+        }
+
+        self._mask_output = MaskOutput(
+            masks=np.concatenate([self._mask_output.masks, mask_output.masks], axis=0),
+            tracklet_mask_dict={
+                **self._mask_output.tracklet_mask_dict,
+                **added_mapping,
+            },
+            mask_avg_prob_dict=None,
+        )
+
+    def remove_masks(
+        self,
+        tracklet_ids: list[int],
+    ) -> None:
+        """Remove masks for the given tracklet IDs and compact local indices."""
+        if self._mask_output is None or self._mask_output.masks is None:
+            return
+
+        tracklet_id_set = set(tracklet_ids)
+        remaining_items = [
+            (tracklet_id, mask_index)
+            for tracklet_id, mask_index in self._mask_output.tracklet_mask_dict.items()
+            if tracklet_id not in tracklet_id_set
+        ]
+
+        kept_indices = [mask_index for _, mask_index in remaining_items]
+        new_mapping = {
+            tracklet_id: new_index
+            for new_index, (tracklet_id, _) in enumerate(remaining_items)
+        }
+
+        self._mask_output = MaskOutput(
+            masks=self._mask_output.masks[kept_indices],
+            tracklet_mask_dict=new_mapping,
+            mask_avg_prob_dict=None,
         )

--- a/src/trackers/core/mcbyte/masks/dummy.py
+++ b/src/trackers/core/mcbyte/masks/dummy.py
@@ -107,8 +107,7 @@ class DummyIdentityMaskPropagator(MaskPropagator):
 
         offset = self._mask_output.masks.shape[0]
         added_mapping = {
-            tracklet_id: offset + local_index
-            for tracklet_id, local_index in mask_output.tracklet_mask_dict.items()
+            tracklet_id: offset + local_index for tracklet_id, local_index in mask_output.tracklet_mask_dict.items()
         }
 
         self._mask_output = MaskOutput(
@@ -136,10 +135,7 @@ class DummyIdentityMaskPropagator(MaskPropagator):
         ]
 
         kept_indices = [mask_index for _, mask_index in remaining_items]
-        new_mapping = {
-            tracklet_id: new_index
-            for new_index, (tracklet_id, _) in enumerate(remaining_items)
-        }
+        new_mapping = {tracklet_id: new_index for new_index, (tracklet_id, _) in enumerate(remaining_items)}
 
         self._mask_output = MaskOutput(
             masks=self._mask_output.masks[kept_indices],

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -8,7 +8,7 @@ from typing import cast
 
 import numpy as np
 import supervision as sv
-from deprecate import deprecated
+from deprecate import deprecated  # type: ignore[import-untyped]
 from scipy.optimize import linear_sum_assignment
 
 from trackers.core.base import BaseTracker
@@ -32,9 +32,15 @@ from trackers.utils.state_representations import (
 class McByteTracker(BaseTracker):
     """McByte-style multi-object tracker.
 
-    This tracker currently provides the initial McByte integration skeleton,
-    built on top of IoU association, Kalman-filter-based tracklets, optional camera
-    motion compensation, and optional mask-manager infrastructure.
+    This tracker builds on ByteTrack-style two-stage IoU association with
+    Kalman-filter-based tracklets, optional camera motion compensation, and optional
+    McByte mask-manager support.
+
+    When a mask manager is configured, the tracker follows the original McByte
+    timing: masks for frame ``t`` are prepared before association on frame ``t``,
+    using tracker outputs from frame ``t-1``. Tracklets that are temporarily lost
+    but still alive keep their masks; masks are removed only when tracklets are
+    terminated by tracker pruning.
 
     Args:
         lost_track_buffer: Time buffer, in frames at 30 FPS, for keeping lost
@@ -113,32 +119,35 @@ class McByteTracker(BaseTracker):
         self._previous_frame: np.ndarray | None = None
         self._previous_tracklets: list[TrackletSnapshot] = []
         self._last_mask_output: MaskOutput | None = None
+        self._previous_new_tracklets: list[TrackletSnapshot] = []
+        self._previous_removed_tracklet_ids: list[int] = []
+        self._mask_tracklet_ids: set[int] = set()
 
     def update(
         self,
         detections: sv.Detections,
         frame: np.ndarray | None = None,
     ) -> sv.Detections:
-        """
-        Update the tracker with detections from the current frame.
+        """Update the tracker with detections from the current frame.
 
-        This is the main per-frame entry point.
+        This is the main per-frame entry point. If a mask manager is configured and a
+        frame is provided, masks are updated before association using tracker lifecycle
+        events stored from the previous call. After association, the method stores the
+        current frame's visible tracklets, newly created tracklets, and explicitly
+        terminated tracklet IDs for the next frame's mask update.
 
         Args:
             detections: Supervision detections for the current frame. Must include
                 ``.xyxy``. Confidence (`detections.confidence`) is optional but
-                recommended. This method does not mutate the input detections;
-                it returns a new ``sv.Detections`` with ``tracker_id`` assigned.
+                recommended. This method does not mutate the input detections; it
+                returns a new ``sv.Detections`` with ``tracker_id`` assigned.
+            frame: Current RGB frame. Required for camera motion compensation and for
+                mask-manager propagation.
 
         Returns:
-            New sv.Detections with tracker_id assigned for each detection.
-            Confirmed tracks have tracker_id >= 0; unconfirmed tracks have
+            New sv.Detections with tracker_id assigned for each output detection.
+            Confirmed tracks have tracker_id >= 0; unmatched/unconfirmed detections have
             tracker_id of -1.
-
-        Notes:
-            - If CMC is enabled, pass the current video frame via ``frame`` so the
-              tracker can estimate a global affine transform and warp predicted
-              track states before association.
         """
         self.frame_id += 1
 
@@ -146,12 +155,15 @@ class McByteTracker(BaseTracker):
         # frame and current frame. It is better to keep the method argument as "frame",
         # as in case of the other trackers.
         current_frame = frame
+        terminated_tracklet_ids: list[int] = []
 
         if self.mask_manager is not None and current_frame is not None:
             self._last_mask_output = self.mask_manager.get_updated_masks(
                 frame=current_frame,
                 previous_frame=self._previous_frame,
                 previous_tracklets=self._previous_tracklets,
+                new_tracklets=self._previous_new_tracklets,
+                removed_tracklet_ids=self._previous_removed_tracklet_ids,
             )
         else:
             self._last_mask_output = None
@@ -159,7 +171,11 @@ class McByteTracker(BaseTracker):
         if len(self.tracks) == 0 and len(detections) == 0:
             result = sv.Detections.empty()
             result.tracker_id = np.array([], dtype=int)
-            self._store_previous_mask_inputs(current_frame, result)
+            self._store_previous_mask_inputs(
+                frame=current_frame,
+                detections=result,
+                removed_tracklet_ids=terminated_tracklet_ids,
+            )
             return result
 
         out_det_indices: list[int] = []
@@ -286,56 +302,130 @@ class McByteTracker(BaseTracker):
             is_first_frame=(self.frame_id == 1),
         )
 
-        # Kill lost tracks
+        # Kill terminated tracks. Temporarily lost tracks remain alive and keep masks.
+        tracklet_ids_before_pruning = {
+            int(track.tracker_id)
+            for track in self.tracks
+            if track.tracker_id >= 0
+        }
         self.tracks = get_alive_tracklets(
             tracklets=self.tracks,
             maximum_frames_without_update=self.maximum_frames_without_update,
             minimum_consecutive_frames=self.minimum_consecutive_frames,
+        )
+        tracklet_ids_after_pruning = {
+            int(track.tracker_id)
+            for track in self.tracks
+            if track.tracker_id >= 0
+        }
+        terminated_tracklet_ids = sorted(
+            tracklet_ids_before_pruning - tracklet_ids_after_pruning
         )
 
         # Build final detections
         if not out_det_indices:
             result = sv.Detections.empty()
             result.tracker_id = np.array([], dtype=int)
-            self._store_previous_mask_inputs(current_frame, result)
+            self._store_previous_mask_inputs(
+                frame=current_frame,
+                detections=result,
+                removed_tracklet_ids=terminated_tracklet_ids,
+            )
             return result
 
         idx = np.array(out_det_indices)
         result = cast(sv.Detections, detections[idx])
         result.tracker_id = np.array(out_tracker_ids, dtype=int)
-        self._store_previous_mask_inputs(current_frame, result)
+        self._store_previous_mask_inputs(
+            frame=current_frame,
+            detections=result,
+            removed_tracklet_ids=terminated_tracklet_ids,
+        )
         return result
+
+    """Convert tracker output detections into mask-manager tracklet snapshots.
+
+    Only detections with valid non-negative tracker IDs are converted. The returned
+    snapshots contain the tracker ID and ``xyxy`` box needed by mask generators.
+    """
+    def _detections_to_tracklet_snapshots(
+        self,
+        detections: sv.Detections,
+    ) -> list[TrackletSnapshot]:
+        if detections.tracker_id is None:
+            return []
+
+        return [
+            TrackletSnapshot(
+                tracker_id=int(tracker_id),
+                xyxy=xyxy.astype(np.float32),
+            )
+            for xyxy, tracker_id in zip(detections.xyxy, detections.tracker_id)
+            if tracker_id >= 0
+        ]
 
     def _store_previous_mask_inputs(
         self,
         frame: np.ndarray | None,
         detections: sv.Detections,
+        removed_tracklet_ids: list[int],
     ) -> None:
-        """Store current tracker output for mask preparation on the next frame."""
-        self._previous_frame = None
-        self._previous_tracklets = []
+        """Store tracker outputs and mask lifecycle events for the next frame.
 
-        if self.mask_manager is None or frame is None or detections.tracker_id is None:
+        The mask manager consumes these values at the beginning of the next ``update()``
+        call. New tracklets are detected among current visible outputs that do not yet
+        have masks. Removed tracklets are provided explicitly from tracker pruning, so
+        temporarily lost but still alive tracklets keep their masks.
+        """
+        if self.mask_manager is None or frame is None:
+            self._previous_frame = None
+            self._previous_tracklets = []
+            self._previous_new_tracklets = []
+            self._previous_removed_tracklet_ids = []
+            self._mask_tracklet_ids = set()
             return
 
-        previous_tracklets = []
-        for xyxy, tracker_id in zip(detections.xyxy, detections.tracker_id):
-            if tracker_id < 0:
-                continue
-            previous_tracklets.append(
-                TrackletSnapshot(
-                    tracker_id=int(tracker_id),
-                    xyxy=xyxy.copy(),
-                )
-            )
+        # Convert current output detections into TrackletSnapshots.
+        # Only valid tracker IDs are kept.
+        current_tracklets = self._detections_to_tracklet_snapshots(detections)
 
-        if len(previous_tracklets) == 0:
-            return
+        # Remove from the “tracks that already have masks” set
+        # only the IDs that were truly terminated/pruned.
+        removed_tracklet_id_set = set(removed_tracklet_ids)
+        self._mask_tracklet_ids -= removed_tracklet_id_set
 
-        self._previous_frame = frame.copy()
-        self._previous_tracklets = previous_tracklets
+        # Find current visible tracklets that do not yet have masks.
+        # These will be passed to SAM/Cutie on the next frame.
+        new_tracklets = [
+            tracklet
+            for tracklet in current_tracklets
+            if tracklet.tracker_id not in self._mask_tracklet_ids
+        ]
+
+        # Mark those new tracklets as now mask-managed, so if they disappear temporarily
+        # and later reappear, they are not treated as new again.
+        self._mask_tracklet_ids.update(
+            tracklet.tracker_id
+            for tracklet in new_tracklets
+        )
+
+        # Store lifecycle events from this frame. At the next update(),
+        # MaskManager receives these and calls add_masks() / remove_masks().
+        self._previous_new_tracklets = new_tracklets
+        self._previous_removed_tracklet_ids = removed_tracklet_ids
+
+        # Stores the current frame and current visible tracklets
+        # as “previous” inputs for the next frame.
+        self._previous_frame = frame
+        self._previous_tracklets = current_tracklets
 
     def _get_iou_matrix(self, tracklets: list[McByteTracklet], detections: np.ndarray) -> np.ndarray:
+        """Compute IoU similarity between tracklet states and detection boxes.
+
+        Returns an ``(N, M)`` matrix where ``N`` is the number of tracklets and ``M`` is
+        the number of detections. Empty inputs are handled by returning an empty matrix
+        with the expected shape.
+        """
         if len(tracklets) == 0:
             tracklet_boxes = np.empty((0, 4))
         else:
@@ -414,9 +504,11 @@ class McByteTracker(BaseTracker):
                 out_tracker_ids.append(tracklet.tracker_id)
 
     def reset(self) -> None:
-        """Reset tracker state by clearing all tracks, resetting ID counter, camera
-        motion compensation and mask manager. Call this method when switching to a new
-        video or scene.
+        """Reset tracker, camera-motion, and mask-manager state.
+
+        This clears active tracklets, resets the global McByte track ID counter, clears
+        stored mask lifecycle inputs, and resets optional camera motion compensation and
+        mask-manager components. Call this when switching to a new video or scene.
         """
         self.tracks = []
         self.frame_id = 0
@@ -428,6 +520,9 @@ class McByteTracker(BaseTracker):
             self.mask_manager.reset()
         if self.cmc is not None:
             self.cmc.reset()
+        self._previous_new_tracklets = []
+        self._previous_removed_tracklet_ids = []
+        self._mask_tracklet_ids = set()
 
     @deprecated(target=None, deprecated_in="2.5", remove_in="3.0")
     def apply_cmc_batch(self, H: np.ndarray | None) -> None:

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -303,24 +303,14 @@ class McByteTracker(BaseTracker):
         )
 
         # Kill terminated tracks. Temporarily lost tracks remain alive and keep masks.
-        tracklet_ids_before_pruning = {
-            int(track.tracker_id)
-            for track in self.tracks
-            if track.tracker_id >= 0
-        }
+        tracklet_ids_before_pruning = {int(track.tracker_id) for track in self.tracks if track.tracker_id >= 0}
         self.tracks = get_alive_tracklets(
             tracklets=self.tracks,
             maximum_frames_without_update=self.maximum_frames_without_update,
             minimum_consecutive_frames=self.minimum_consecutive_frames,
         )
-        tracklet_ids_after_pruning = {
-            int(track.tracker_id)
-            for track in self.tracks
-            if track.tracker_id >= 0
-        }
-        terminated_tracklet_ids = sorted(
-            tracklet_ids_before_pruning - tracklet_ids_after_pruning
-        )
+        tracklet_ids_after_pruning = {int(track.tracker_id) for track in self.tracks if track.tracker_id >= 0}
+        terminated_tracklet_ids = sorted(tracklet_ids_before_pruning - tracklet_ids_after_pruning)
 
         # Build final detections
         if not out_det_indices:
@@ -348,6 +338,7 @@ class McByteTracker(BaseTracker):
     Only detections with valid non-negative tracker IDs are converted. The returned
     snapshots contain the tracker ID and ``xyxy`` box needed by mask generators.
     """
+
     def _detections_to_tracklet_snapshots(
         self,
         detections: sv.Detections,
@@ -397,17 +388,12 @@ class McByteTracker(BaseTracker):
         # Find current visible tracklets that do not yet have masks.
         # These will be passed to SAM/Cutie on the next frame.
         new_tracklets = [
-            tracklet
-            for tracklet in current_tracklets
-            if tracklet.tracker_id not in self._mask_tracklet_ids
+            tracklet for tracklet in current_tracklets if tracklet.tracker_id not in self._mask_tracklet_ids
         ]
 
         # Mark those new tracklets as now mask-managed, so if they disappear temporarily
         # and later reappear, they are not treated as new again.
-        self._mask_tracklet_ids.update(
-            tracklet.tracker_id
-            for tracklet in new_tracklets
-        )
+        self._mask_tracklet_ids.update(tracklet.tracker_id for tracklet in new_tracklets)
 
         # Store lifecycle events from this frame. At the next update(),
         # MaskManager receives these and calls add_masks() / remove_masks().

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -333,16 +333,15 @@ class McByteTracker(BaseTracker):
         )
         return result
 
-    """Convert tracker output detections into mask-manager tracklet snapshots.
-
-    Only detections with valid non-negative tracker IDs are converted. The returned
-    snapshots contain the tracker ID and ``xyxy`` box needed by mask generators.
-    """
-
     def _detections_to_tracklet_snapshots(
         self,
         detections: sv.Detections,
     ) -> list[TrackletSnapshot]:
+        """Convert tracker output detections into mask-manager tracklet snapshots.
+
+        Only detections with valid non-negative tracker IDs are converted. The returned
+        snapshots contain the tracker ID and ``xyxy`` box needed by mask generators.
+        """
         if detections.tracker_id is None:
             return []
 

--- a/tests/core/test_mcbyte_mask_manager.py
+++ b/tests/core/test_mcbyte_mask_manager.py
@@ -126,6 +126,31 @@ def test_mask_manager_uses_propagator_after_initialization() -> None:
     assert second_output.tracklet_mask_dict == first_output.tracklet_mask_dict
 
 
+def test_mask_manager_propagates_after_initialization_without_visible_tracklets() -> None:
+    manager = MaskManager(
+        mask_generator=DummyBoxMaskGenerator(),
+        mask_propagator=DummyIdentityMaskPropagator(),
+    )
+
+    first_output = manager.get_updated_masks(
+        frame=_make_frame(),
+        previous_frame=_make_frame(),
+        previous_tracklets=[
+            TrackletSnapshot(3, np.array([5, 6, 25, 30], dtype=np.float32)),
+        ],
+    )
+
+    second_output = manager.get_updated_masks(
+        frame=_make_frame(),
+        previous_frame=_make_frame(),
+        previous_tracklets=[],
+    )
+
+    assert first_output is not None
+    assert second_output is not None
+    assert second_output.tracklet_mask_dict == {3: 0}
+
+
 def test_mask_manager_reset_clears_state() -> None:
     manager = MaskManager(
         mask_generator=DummyBoxMaskGenerator(),

--- a/tests/core/test_mcbyte_mask_manager.py
+++ b/tests/core/test_mcbyte_mask_manager.py
@@ -159,3 +159,66 @@ def test_mask_manager_reset_clears_state() -> None:
     assert output_before_reset is not None
     assert output_after_reset is not None
     assert output_after_reset.tracklet_mask_dict == {9: 0}
+
+
+def test_mask_manager_adds_new_tracklets_after_initialization() -> None:
+    manager = MaskManager(
+        mask_generator=DummyBoxMaskGenerator(),
+        mask_propagator=DummyIdentityMaskPropagator(),
+    )
+
+    first_output = manager.get_updated_masks(
+        frame=_make_frame(),
+        previous_frame=_make_frame(),
+        previous_tracklets=[
+            TrackletSnapshot(3, np.array([5, 6, 25, 30], dtype=np.float32)),
+        ],
+    )
+
+    second_output = manager.get_updated_masks(
+        frame=_make_frame(),
+        previous_frame=_make_frame(),
+        previous_tracklets=[
+            TrackletSnapshot(3, np.array([5, 6, 25, 30], dtype=np.float32)),
+        ],
+        new_tracklets=[
+            TrackletSnapshot(9, np.array([40, 40, 60, 60], dtype=np.float32)),
+        ],
+    )
+
+    assert first_output is not None
+    assert second_output is not None
+    assert second_output.masks is not None
+    assert second_output.masks.shape == (2, 100, 120)
+    assert second_output.tracklet_mask_dict == {3: 0, 9: 1}
+
+
+def test_mask_manager_removes_tracklets_after_initialization() -> None:
+    manager = MaskManager(
+        mask_generator=DummyBoxMaskGenerator(),
+        mask_propagator=DummyIdentityMaskPropagator(),
+    )
+
+    manager.get_updated_masks(
+        frame=_make_frame(),
+        previous_frame=_make_frame(),
+        previous_tracklets=[
+            TrackletSnapshot(3, np.array([5, 6, 25, 30], dtype=np.float32)),
+            TrackletSnapshot(9, np.array([40, 40, 60, 60], dtype=np.float32)),
+        ],
+    )
+
+    output = manager.get_updated_masks(
+        frame=_make_frame(),
+        previous_frame=_make_frame(),
+        previous_tracklets=[
+            TrackletSnapshot(3, np.array([5, 6, 25, 30], dtype=np.float32)),
+            TrackletSnapshot(9, np.array([40, 40, 60, 60], dtype=np.float32)),
+        ],
+        removed_tracklet_ids=[3],
+    )
+
+    assert output is not None
+    assert output.masks is not None
+    assert output.masks.shape == (1, 100, 120)
+    assert output.tracklet_mask_dict == {9: 0}

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -9,7 +9,35 @@ from __future__ import annotations
 import numpy as np
 import supervision as sv
 
+from trackers.core.mcbyte.masks.base import MaskOutput, TrackletSnapshot
 from trackers.core.mcbyte.tracker import McByteTracker
+
+
+class SpyMaskManager:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def get_updated_masks(
+        self,
+        frame: np.ndarray,
+        previous_frame: np.ndarray | None,
+        previous_tracklets: list[TrackletSnapshot],
+        new_tracklets: list[TrackletSnapshot] | None = None,
+        removed_tracklet_ids: list[int] | None = None,
+    ) -> MaskOutput | None:
+        self.calls.append(
+            {
+                "frame": frame,
+                "previous_frame": previous_frame,
+                "previous_tracklets": previous_tracklets,
+                "new_tracklets": [] if new_tracklets is None else new_tracklets,
+                "removed_tracklet_ids": [] if removed_tracklet_ids is None else removed_tracklet_ids,
+            }
+        )
+        return None
+
+    def reset(self) -> None:
+        pass
 
 
 def _detection(xyxy: tuple[float, float, float, float], conf: float = 0.9) -> sv.Detections:
@@ -25,7 +53,6 @@ def _make_frame(h: int = 480, w: int = 640, seed: int = 42) -> np.ndarray:
 
 
 def test_mcbyte_instantiates_and_updates_with_frame_and_sparse_opt_flow_cmc_returns_ids() -> None:
-    """McByteTracker can update with a frame and CMC enabled, returning track IDs."""
     tracker = McByteTracker(
         enable_cmc=True,
         cmc_method="sparseOptFlow",
@@ -44,7 +71,6 @@ def test_mcbyte_instantiates_and_updates_with_frame_and_sparse_opt_flow_cmc_retu
 
 
 def test_mcbyte_reset_clears_mask_state() -> None:
-    """reset() clears tracker and mask-manager temporal state."""
     tracker = McByteTracker(
         enable_cmc=False,
         enable_mask_manager=True,
@@ -68,7 +94,6 @@ def test_mcbyte_reset_clears_mask_state() -> None:
 
 
 def test_mcbyte_does_not_store_previous_frame_without_mask_manager() -> None:
-    """McByteTracker avoids frame copies when mask manager is disabled."""
     tracker = McByteTracker(
         enable_cmc=False,
         enable_mask_manager=False,
@@ -81,3 +106,87 @@ def test_mcbyte_does_not_store_previous_frame_without_mask_manager() -> None:
 
     assert tracker._previous_frame is None
     assert tracker._previous_tracklets == []
+
+
+def test_mcbyte_passes_new_tracklets_to_mask_manager_on_next_frame() -> None:
+    mask_manager = SpyMaskManager()
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=False,
+        mask_manager=mask_manager,  # type: ignore[arg-type]
+        minimum_consecutive_frames=1,
+    )
+
+    frame = _make_frame()
+
+    tracker.update(_detection((100.0, 100.0, 200.0, 200.0)), frame)
+    tracker.update(_detection((102.0, 102.0, 202.0, 202.0)), frame)
+
+    assert len(mask_manager.calls) == 2
+
+    first_call = mask_manager.calls[0]
+    assert first_call["previous_frame"] is None
+    assert first_call["previous_tracklets"] == []
+    assert first_call["new_tracklets"] == []
+    assert first_call["removed_tracklet_ids"] == []
+
+    second_call = mask_manager.calls[1]
+    assert second_call["previous_frame"] is frame
+
+    previous_tracklets = second_call["previous_tracklets"]
+    new_tracklets = second_call["new_tracklets"]
+
+    assert isinstance(previous_tracklets, list)
+    assert isinstance(new_tracklets, list)
+    assert len(previous_tracklets) == 1
+    assert len(new_tracklets) == 1
+    assert previous_tracklets[0].tracker_id == new_tracklets[0].tracker_id
+    assert second_call["removed_tracklet_ids"] == []
+
+
+def test_mcbyte_mask_lifecycle_keeps_missing_tracklet_until_explicit_removal() -> None:
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=True,
+        mask_manager=None,
+        minimum_consecutive_frames=1,
+    )
+
+    frame = _make_frame()
+
+    visible_result = sv.Detections(
+        xyxy=np.array([[10.0, 20.0, 30.0, 40.0]], dtype=np.float32),
+    )
+    visible_result.tracker_id = np.array([7], dtype=int)
+
+    empty_result = sv.Detections.empty()
+    empty_result.tracker_id = np.array([], dtype=int)
+
+    tracker._store_previous_mask_inputs(
+        frame=frame,
+        detections=visible_result,
+        removed_tracklet_ids=[],
+    )
+
+    assert tracker._previous_new_tracklets[0].tracker_id == 7
+    assert tracker._mask_tracklet_ids == {7}
+
+    tracker._store_previous_mask_inputs(
+        frame=frame,
+        detections=empty_result,
+        removed_tracklet_ids=[],
+    )
+
+    assert tracker._previous_new_tracklets == []
+    assert tracker._previous_removed_tracklet_ids == []
+    assert tracker._mask_tracklet_ids == {7}
+
+    tracker._store_previous_mask_inputs(
+        frame=frame,
+        detections=empty_result,
+        removed_tracklet_ids=[7],
+    )
+
+    assert tracker._previous_new_tracklets == []
+    assert tracker._previous_removed_tracklet_ids == [7]
+    assert tracker._mask_tracklet_ids == set()

--- a/visual_tests/visualize_mask_manager.py
+++ b/visual_tests/visualize_mask_manager.py
@@ -1,0 +1,524 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Visual sanity check for McByte MaskManager with SAM + Cutie.
+
+This script validates the real MaskManager orchestration:
+- initialize masks from previous-frame tracklets,
+- propagate masks to the current frame,
+- add masks for new tracklets,
+- remove masks for terminated tracklets.
+
+It intentionally calls MaskManager.get_updated_masks(), not Cutie directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+
+from trackers.core.mcbyte.mask_manager import MaskManager
+from trackers.core.mcbyte.masks.base import MaskOutput, TrackletSnapshot
+from trackers.core.mcbyte.masks.cutie import CutieMaskPropagator
+from trackers.core.mcbyte.masks.sam import SAMBoxMaskGenerator
+
+DEFAULT_OUTPUT_ROOT = Path("visual_tests/outputs/mask_manager")
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+
+
+@dataclass(frozen=True)
+class AddTrackletEvent:
+    """Manual new-tracklet event parsed from ``--add-at``."""
+
+    frame_file: str
+    xyxy: tuple[float, float, float, float]
+
+
+@dataclass(frozen=True)
+class RemoveTrackletEvent:
+    """Manual removed-tracklet event parsed from ``--remove-at``."""
+
+    frame_file: str
+    tracker_id: int
+
+
+def parse_xyxy_box(box: str) -> tuple[float, float, float, float]:
+    """Parse one command-line bounding box in ``x1,y1,x2,y2`` format."""
+    values = [float(value) for value in box.split(",")]
+    if len(values) != 4:
+        raise argparse.ArgumentTypeError("Each box must contain exactly 4 comma-separated values: x1,y1,x2,y2.")
+    return values[0], values[1], values[2], values[3]
+
+
+def parse_add_tracklet_event(event: str) -> AddTrackletEvent:
+    """Parse ``filename:x1,y1,x2,y2`` add-tracklet event."""
+    parts = event.split(":")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("Add event must have format filename:x1,y1,x2,y2.")
+
+    frame_file, box_str = parts
+    try:
+        xyxy = parse_xyxy_box(box_str)
+    except (ValueError, argparse.ArgumentTypeError) as exc:
+        raise argparse.ArgumentTypeError("Add event must have format filename:x1,y1,x2,y2.") from exc
+
+    return AddTrackletEvent(frame_file=frame_file, xyxy=xyxy)
+
+
+def parse_remove_tracklet_event(event: str) -> RemoveTrackletEvent:
+    """Parse ``filename:tracklet_id`` remove-tracklet event."""
+    parts = event.split(":")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("Remove event must have format filename:tracklet_id.")
+
+    frame_file, tracker_id_str = parts
+    try:
+        tracker_id = int(tracker_id_str)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Remove event must have format filename:tracklet_id.") from exc
+
+    if tracker_id <= 0:
+        raise argparse.ArgumentTypeError("tracklet_id must be a positive integer.")
+
+    return RemoveTrackletEvent(frame_file=frame_file, tracker_id=tracker_id)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the MaskManager visualizer."""
+    parser = argparse.ArgumentParser(description="Visualize McByte MaskManager with SAM + Cutie.")
+    parser.add_argument("--image-dir", type=Path, required=True)
+    parser.add_argument("--start-file", type=str, required=True)
+    parser.add_argument("--end-file", type=str, required=True)
+    parser.add_argument(
+        "--box",
+        type=parse_xyxy_box,
+        action="append",
+        required=True,
+        help="Initial tracklet box on the first selected frame: x1,y1,x2,y2. Can be repeated.",
+    )
+    parser.add_argument(
+        "--add-at",
+        type=parse_add_tracklet_event,
+        action="append",
+        default=[],
+        help=(
+            "Add a new tracklet from the given frame box. Format: filename:x1,y1,x2,y2. "
+            "The box is treated as a tracker output on that frame and added by MaskManager "
+            "before propagating to the next frame."
+        ),
+    )
+    parser.add_argument(
+        "--remove-at",
+        type=parse_remove_tracklet_event,
+        action="append",
+        default=[],
+        help=(
+            "Remove a tracklet before propagating to the given frame. "
+            "Format: filename:tracklet_id."
+        ),
+    )
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--sam-model-type", type=str, default="vit_b")
+    parser.add_argument("--cutie-model-type", type=str, default="base-mega")
+    parser.add_argument("--cutie-config-path", type=Path, default=None)
+    parser.add_argument("--cutie-config-name", type=str, default="eval_config")
+    return parser.parse_args()
+
+
+def list_selected_frame_paths(image_dir: Path, start_file: str, end_file: str) -> list[Path]:
+    """List sorted frame paths from ``start_file`` to ``end_file`` inclusive."""
+    frame_paths = sorted(
+        path for path in image_dir.iterdir() if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS
+    )
+    filenames = [path.name for path in frame_paths]
+
+    if start_file not in filenames:
+        raise FileNotFoundError(f"Start file not found in {image_dir}: {start_file}")
+    if end_file not in filenames:
+        raise FileNotFoundError(f"End file not found in {image_dir}: {end_file}")
+
+    start_index = filenames.index(start_file)
+    end_index = filenames.index(end_file)
+    if end_index < start_index:
+        raise ValueError(f"end-file must not come before start-file. Got {start_file=} and {end_file=}.")
+
+    return frame_paths[start_index : end_index + 1]
+
+
+def load_rgb_image(image_path: Path) -> np.ndarray:
+    """Load an image from disk and return it in RGB format."""
+    image_bgr = cv2.imread(str(image_path))
+    if image_bgr is None:
+        raise FileNotFoundError(f"Could not read image: {image_path}")
+    return cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+
+
+def validate_and_clip_xyxy_box(
+    box: tuple[float, float, float, float],
+    image_shape: tuple[int, int],
+) -> np.ndarray:
+    """Validate and clip an ``xyxy`` box to image boundaries."""
+    height, width = image_shape
+    x1, y1, x2, y2 = box
+
+    if x2 <= x1 or y2 <= y1:
+        raise ValueError(f"Invalid xyxy box with non-positive size: {box}")
+
+    x1 = np.clip(x1, 0, width)
+    x2 = np.clip(x2, 0, width)
+    y1 = np.clip(y1, 0, height)
+    y2 = np.clip(y2, 0, height)
+
+    if x2 <= x1 or y2 <= y1:
+        raise ValueError(f"Box is outside image after clipping: {box}")
+
+    return np.array([x1, y1, x2, y2], dtype=np.float32)
+
+
+def validate_device(device: str) -> str:
+    """Validate that the requested execution device is available."""
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        raise RuntimeError(
+            "CUDA was requested, but torch.cuda.is_available() is False. "
+            "Use --device cpu or install CUDA-enabled PyTorch."
+        )
+    return device
+
+
+def group_add_events_by_source_frame(
+    frame_paths: list[Path],
+    events: list[AddTrackletEvent],
+) -> dict[str, list[AddTrackletEvent]]:
+    """Group add events by the frame where new tracklets are created.
+
+    The grouped events are converted into ``previous_new_tracklets`` after the
+    MaskManager call for that frame. They are then consumed by MaskManager on
+    the next frame, matching the original McByte timing.
+    """
+    filenames = [path.name for path in frame_paths]
+    grouped: dict[str, list[AddTrackletEvent]] = defaultdict(list)
+
+    for event in events:
+        source_index = filenames.index(event.frame_file)
+        target_file = filenames[source_index]
+        grouped[target_file].append(event)
+
+    return dict(grouped)
+
+
+def group_remove_events(events: list[RemoveTrackletEvent]) -> dict[str, list[int]]:
+    """Group remove events by the frame where tracklets are terminated.
+
+    The grouped events are converted into ``previous_removed_tracklet_ids`` after
+    the MaskManager call for that frame. They are then consumed by MaskManager on
+    the next frame, matching the original McByte timing.
+    """
+    grouped: dict[str, list[int]] = defaultdict(list)
+    for event in events:
+        grouped[event.frame_file].append(event.tracker_id)
+    return dict(grouped)
+
+
+def validate_lifecycle_events(
+    frame_paths: list[Path],
+    add_events: list[AddTrackletEvent],
+    remove_events: list[RemoveTrackletEvent],
+) -> None:
+    """Validate that add/remove events are compatible with the selected frame range."""
+    filenames = [path.name for path in frame_paths]
+    filename_set = set(filenames)
+
+    for add_event in add_events:
+        if add_event.frame_file not in filename_set:
+            raise ValueError(f"Add event frame is outside selected range: {add_event.frame_file}")
+        if add_event.frame_file == filenames[-1]:
+            raise ValueError("Add events cannot be scheduled on the last selected frame.")
+
+    for remove_event in remove_events:
+        if remove_event.frame_file not in filename_set:
+            raise ValueError(f"Remove event frame is outside selected range: {remove_event.frame_file}")
+        if remove_event.frame_file == filenames[0]:
+            raise ValueError("Remove events cannot be scheduled on the first selected frame.")
+
+
+def color_from_id(object_id: int) -> np.ndarray:
+    """Return a deterministic RGB color for a stable tracklet ID."""
+    rng = np.random.default_rng(object_id)
+    return rng.integers(0, 255, size=3, dtype=np.uint8)
+
+
+def overlay_masks(
+    image: np.ndarray,
+    masks: np.ndarray,
+    tracklet_ids: list[int],
+    alpha: float = 0.45,
+) -> np.ndarray:
+    """Overlay binary masks on an RGB image.
+
+    Each tracklet is rendered using a deterministic color derived from its
+    tracklet ID. The ordering of ``tracklet_ids`` must match the ordering of
+    ``masks``.
+    """
+    if masks.shape[0] != len(tracklet_ids):
+        raise ValueError(
+            "Number of masks must match number of tracklet IDs. "
+            f"Got {masks.shape[0]} masks and {len(tracklet_ids)} tracklet IDs."
+        )
+
+    output = image.copy()
+    for mask, tracklet_id in zip(masks, tracklet_ids):
+        color = color_from_id(tracklet_id)
+        colored_mask = np.zeros_like(output)
+        colored_mask[mask] = color
+
+        output = np.where(
+            mask[..., None],
+            (alpha * colored_mask + (1.0 - alpha) * output).astype(np.uint8),
+            output,
+        )
+
+    return output
+
+
+def get_mask_tracklet_ids_in_order(tracklet_mask_dict: dict[int, int]) -> list[int]:
+    """Return tracklet IDs in the same order as ``MaskOutput.masks``."""
+    return [
+        tracklet_id
+        for tracklet_id, _ in sorted(
+            tracklet_mask_dict.items(),
+            key=lambda item: item[1],
+        )
+    ]
+
+
+def draw_boxes(image: np.ndarray, tracklets: list[TrackletSnapshot]) -> np.ndarray:
+    """Draw tracklet bounding boxes and IDs on an RGB image."""
+    output = image.copy()
+
+    for tracklet in tracklets:
+        x1, y1, x2, y2 = tracklet.xyxy.astype(int)
+        cv2.rectangle(output, (x1, y1), (x2, y2), color=(91, 10, 145), thickness=2)
+        cv2.putText(
+            output,
+            str(tracklet.tracker_id),
+            (x1, max(y1 - 5, 0)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.7,
+            (255, 0, 0),
+            2,
+            cv2.LINE_AA,
+        )
+
+    return output
+
+
+def draw_frame_label(image: np.ndarray, frame_name: str, status: str) -> np.ndarray:
+    """Draw the frame filename and lifecycle status in the top-left corner."""
+    output = image.copy()
+    label = f"{frame_name} | {status}"
+
+    cv2.putText(output, label, (20, 35), cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 255, 255), 3, cv2.LINE_AA)
+    cv2.putText(output, label, (20, 35), cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 0, 0), 1, cv2.LINE_AA)
+
+    return output
+
+
+def save_rgb_image(image_rgb: np.ndarray, output_path: Path) -> None:
+    """Save an RGB image to disk."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    image_bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
+    cv2.imwrite(str(output_path), image_bgr)
+
+
+def visualize_output(
+    frame: np.ndarray,
+    frame_name: str,
+    mask_output: MaskOutput | None,
+    tracklets: list[TrackletSnapshot],
+    output_path: Path,
+    status: str,
+) -> None:
+    """Overlay masks, optional tracklet boxes, and frame status, then save the result."""
+    visual = frame.copy()
+
+    if mask_output is not None and mask_output.masks is not None:
+        tracklet_ids = get_mask_tracklet_ids_in_order(mask_output.tracklet_mask_dict)
+        visual = overlay_masks(
+            image=visual,
+            masks=mask_output.masks,
+            tracklet_ids=tracklet_ids,
+        )
+
+    visual = draw_boxes(visual, tracklets)
+    visual = draw_frame_label(visual, frame_name, status)
+    save_rgb_image(visual, output_path)
+
+
+def main() -> None:
+    """Run MaskManager visual validation and save per-frame outputs.
+
+    The script follows the original McByte execution order.
+
+    For frame ``t``:
+
+        1. MaskManager produces masks for frame ``t`` using tracker outputs
+           from frame ``t-1``.
+        2. The tracker (emulated by this script) produces tracklets for frame
+           ``t`` using the masks from frame ``t`` (step 1).
+        3. Newly created and removed tracklets are stored and become lifecycle
+           events consumed by MaskManager on frame ``t+1``.
+
+    This mirrors the timing used by the original McByte implementation.
+    """
+    args = parse_args()
+
+    frame_paths = list_selected_frame_paths(
+        image_dir=args.image_dir,
+        start_file=args.start_file,
+        end_file=args.end_file,
+    )
+    if len(frame_paths) < 2:
+        raise ValueError("At least two frames are required for MaskManager validation.")
+
+    validate_lifecycle_events(
+        frame_paths=frame_paths,
+        add_events=args.add_at,
+        remove_events=args.remove_at,
+    )
+
+    add_events_by_file = group_add_events_by_source_frame(frame_paths, args.add_at)
+    remove_events_by_file = group_remove_events(args.remove_at)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = args.output_root / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    device = validate_device(args.device)
+
+    mask_manager = MaskManager(
+        mask_generator=SAMBoxMaskGenerator(
+            model_type=args.sam_model_type,
+            device=device,
+        ),
+        mask_propagator=CutieMaskPropagator(
+            model_type=args.cutie_model_type,
+            config_path=args.cutie_config_path,
+            config_name=args.cutie_config_name,
+            device=device,
+        ),
+    )
+
+    first_frame = load_rgb_image(frame_paths[0])
+
+    active_tracklets: dict[int, TrackletSnapshot] = {
+        index + 1: TrackletSnapshot(
+            tracker_id=index + 1,
+            xyxy=validate_and_clip_xyxy_box(
+                box=box,
+                image_shape=first_frame.shape[:2],
+            ),
+        )
+        for index, box in enumerate(args.box)
+    }
+    next_tracklet_id = len(active_tracklets) + 1
+
+    print(f"Selected {len(frame_paths)} frames.")
+    print(f"Saving outputs to {output_dir}")
+    print("Initial tracklets:")
+    for tracklet in active_tracklets.values():
+        print(f"  {tracklet.tracker_id}: {tracklet.xyxy.tolist()}")
+
+    # Previous-frame tracker state consumed by MaskManager.
+    # These variables emulate the data flow between the tracker and MaskManager
+    # in the original McByte pipeline.
+    previous_frame: np.ndarray | None = None
+    previous_tracklets: list[TrackletSnapshot] = []
+    previous_new_tracklets: list[TrackletSnapshot] = []
+    previous_removed_tracklet_ids: list[int] = []
+
+    for frame_index, frame_path in enumerate(frame_paths):
+        frame = load_rgb_image(frame_path)
+
+        mask_output = mask_manager.get_updated_masks(
+            frame=frame,
+            previous_frame=previous_frame,
+            previous_tracklets=previous_tracklets,
+            new_tracklets=previous_new_tracklets,
+            removed_tracklet_ids=previous_removed_tracklet_ids,
+        )
+
+        status_parts = []
+        if mask_output is None:
+            status_parts.append("no masks")
+        else:
+            status_parts.append(f"{0 if mask_output.masks is None else mask_output.masks.shape[0]} masks")
+
+        if len(previous_new_tracklets) > 0:
+            status_parts.append(f"added {[tracklet.tracker_id for tracklet in previous_new_tracklets]}")
+        if len(previous_removed_tracklet_ids) > 0:
+            status_parts.append(f"removed {previous_removed_tracklet_ids}")
+
+        status = ", ".join(status_parts)
+        print(f"Saved {frame_path.name}: {status}")
+
+        new_tracklets_for_next_frame: list[TrackletSnapshot] = []
+        removed_tracklet_ids_for_next_frame: list[int] = []
+
+        add_events = add_events_by_file.get(frame_path.name, [])
+        for event in add_events:
+            tracklet_id = next_tracklet_id
+            next_tracklet_id += 1
+
+            tracklet = TrackletSnapshot(
+                tracker_id=tracklet_id,
+                xyxy=validate_and_clip_xyxy_box(
+                    box=event.xyxy,
+                    image_shape=frame.shape[:2],
+                ),
+            )
+            active_tracklets[tracklet_id] = tracklet
+            new_tracklets_for_next_frame.append(tracklet)
+
+            print(
+                f"Scheduled add from {frame_path.name}: "
+                f"tracklet {tracklet_id}, box {tracklet.xyxy.tolist()}"
+            )
+
+        remove_tracklet_ids = remove_events_by_file.get(frame_path.name, [])
+        for tracklet_id in remove_tracklet_ids:
+            active_tracklets.pop(tracklet_id, None)
+            removed_tracklet_ids_for_next_frame.append(tracklet_id)
+            print(f"Scheduled removal from {frame_path.name}: tracklet {tracklet_id}")
+
+        previous_frame = frame
+        previous_tracklets = list(active_tracklets.values())
+        previous_new_tracklets = new_tracklets_for_next_frame
+        previous_removed_tracklet_ids = removed_tracklet_ids_for_next_frame
+
+
+        tracklets_vis = list(active_tracklets.values()) if frame_index == 0 else previous_new_tracklets
+        visualize_output(
+            frame=frame,
+            frame_name=frame_path.name,
+            mask_output=mask_output,
+            tracklets=tracklets_vis,
+            output_path=output_dir / frame_path.name,
+            status=status,
+        )
+
+    print(f"Done. Outputs saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/visual_tests/visualize_mask_manager.py
+++ b/visual_tests/visualize_mask_manager.py
@@ -122,10 +122,7 @@ def parse_args() -> argparse.Namespace:
         type=parse_remove_tracklet_event,
         action="append",
         default=[],
-        help=(
-            "Remove a tracklet before propagating to the given frame. "
-            "Format: filename:tracklet_id."
-        ),
+        help=("Remove a tracklet before propagating to the given frame. Format: filename:tracklet_id."),
     )
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
     parser.add_argument("--device", type=str, default="cuda")
@@ -490,10 +487,7 @@ def main() -> None:
             active_tracklets[tracklet_id] = tracklet
             new_tracklets_for_next_frame.append(tracklet)
 
-            print(
-                f"Scheduled add from {frame_path.name}: "
-                f"tracklet {tracklet_id}, box {tracklet.xyxy.tolist()}"
-            )
+            print(f"Scheduled add from {frame_path.name}: tracklet {tracklet_id}, box {tracklet.xyxy.tolist()}")
 
         remove_tracklet_ids = remove_events_by_file.get(frame_path.name, [])
         for tracklet_id in remove_tracklet_ids:
@@ -505,7 +499,6 @@ def main() -> None:
         previous_tracklets = list(active_tracklets.values())
         previous_new_tracklets = new_tracklets_for_next_frame
         previous_removed_tracklet_ids = removed_tracklet_ids_for_next_frame
-
 
         tracklets_vis = list(active_tracklets.values()) if frame_index == 0 else previous_new_tracklets
         visualize_output(


### PR DESCRIPTION
## What does this PR do?

This PR introduces the first complete `MaskManager` implementation for McByte and integrates it with `McByteTracker`.

The implementation follows the original McByte execution order, where masks are updated before association on the current frame using tracker outputs from the previous frame. The tracker now explicitly communicates tracklet lifecycle events (newly created and terminated tracklets) to the `MaskManager`, enabling future integration of the full McByte association pipeline.

Main additions:

- Implemented a complete `MaskManager` coordinating mask generation and temporal propagation
- Added explicit support for tracklet lifecycle events (`new_tracklets` and `removed_tracklet_ids`)
- Integrated `MaskManager` into `McByteTracker`
- Implemented previous-frame tracker state management required by the original McByte execution order
- Ensured that temporarily lost but still alive tracklets retain their masks, while masks are removed only after tracker termination
- Updated the dummy mask propagator to support the complete lifecycle API
- Added unit tests covering tracker-to-mask-manager interaction and lifecycle behavior
- Added a new visual integration script (`visualize_mask_manager`.py) validating the complete `MaskManager ---> SAM ---> Cutie` pipeline on real sequences
- Improved documentation and docstrings throughout the McByte mask management components

## Type of Change

- New feature (non-breaking change that adds functionality)


## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

Added and updated unit tests covering:

- `MaskManager` initialization and reset
- Mask generation and propagation workflow
- Explicit new-tracklet lifecycle handling
- Explicit terminated-tracklet lifecycle handling
- Tracker-to-mask-manager communication
- Preservation of masks for temporarily lost tracklets
- Correct removal of masks only after tracker termination
- Updated dummy propagator lifecycle behavior

Manual validation:

- Verified complete `MaskManager` lifecycle using the new visual integration script
- Verified initialization through `SAMBoxMaskGenerator`
- Verified temporal propagation through `CutieMaskPropagator`
- Verified dynamic mask addition
- Verified dynamic mask removal
- Verified tracker lifecycle timing matches the original McByte implementation
- Verified visualization output on previously tested (#459) video sequence


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] [McByte as a whole is still in the development phase] I have updated the documentation accordingly (if applicable)

## Additional Context

This PR builds on the previous CutieMaskPropagator lifecycle PR (#459 ) and introduces the first complete MaskManager implementation reproducing the original McByte execution order.

The newly added visualization script (visualize_mask_manager.py) validates the complete mask-management pipeline:

`SAMBoxMaskGenerator ---> MaskManager.initialize() ---> CutieMaskPropagator.initialize()`

`MaskManager.add_masks() ---> CutieMaskPropagator.add_masks()`

`MaskManager.remove_masks() ---> CutieMaskPropagator.remove_masks()`

`MaskManager.propagate() ---> CutieMaskPropagator.propagate()`

Unlike the previous Cutie visualization utility, this script validates the public MaskManager interface that will be used by the tracker.

No additional external dependencies beyond those introduced by the previous Cutie integration PR #452  (section Additional Context) are required.

Tested on CPU (very slow, not recommended) and on GPU (CUDA 12.6) using separate Anaconda environments.

Visual test performed on [SoccerNet-tracking](https://www.soccer-net.org/tasks/tracking):

sequence SNMOT-116
frames from 000548.jpg to 000650.jpg (inclusive)
oracle detections converted to xyxy format

Example test run:

```
python visual_tests/visualize_mask_manager.py \
  --image-dir your_dataset_path/SoccerNet/tracking/test/SNMOT-116/img1 \
  --start-file 000548.jpg \
  --end-file 000650.jpg \
  --box 177,482,249,631 \
  --box 1241,569,1297,716 \
  --box 191,344,240,459 \
  --box 686,298,751,426 \
  --box 625,469,686,623 \
  --box 1382,378,1440,497 \
  --box 1220,480,1240,498 \
  --add-at 000598.jpg:136,849,189,1047 \
  --add-at 000598.jpg:524,297,583,403 \
  --remove-at 000598.jpg:2 \
  --remove-at 000598.jpg:3 \
  --remove-at 000620.jpg:5 \
  --add-at 000632.jpg:132,404,203,510 \
  --add-at 000632.jpg:444,324,510,408 \
  --remove-at 000650.jpg:10 \
  --device cuda
```

As described in #452 (at the end of the PR description), the required model weights are downloaded automatically.
