### PR TITLE
fix(cmc): prevent cv2.resize crash on tiny downscaled images

### DIFF
--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -412,8 +412,8 @@ class CMC:
         try:
             kps = self.detector.detect(gray, mask)  # type: ignore[union-attr]
             kps, desc = self.extractor.compute(gray, kps)  # type: ignore[union-attr]
-        except cv2.error:
-            logger.warning("CMC: Feature detection failed (image too small), using identity")
+        except cv2.error as e:
+            logger.warning("CMC: Feature detection failed (%s), using identity", e)
             self.frames_failed += 1
             return affine_mtx
 

--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -379,7 +379,9 @@ class CMC:
         gray = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2GRAY)
 
         if self.downscale > 1:
-            gray = cv2.resize(gray, (img_w // self.downscale, img_h // self.downscale))
+            new_w = max(1, img_w // self.downscale)
+            new_h = max(1, img_h // self.downscale)
+            gray = cv2.resize(gray, (new_w, new_h))
         H, W = gray.shape[:2]
 
         # Build mask: central ROI + remove detections (background features)
@@ -404,11 +406,16 @@ class CMC:
                 if x2b > x1b and y2b > y1b:
                     mask[y1b:y2b, x1b:x2b] = 0
 
-        # Detect + describe (ORB / SIFT). Mypy cannot narrow instance attrs here.
-        kps = self.detector.detect(gray, mask)  # type: ignore[union-attr]
-        kps, desc = self.extractor.compute(gray, kps)  # type: ignore[union-attr]
-
         affine_mtx = np.eye(2, 3, dtype=np.float32)
+
+        # Detect + describe (ORB / SIFT). Mypy cannot narrow instance attrs here.
+        try:
+            kps = self.detector.detect(gray, mask)  # type: ignore[union-attr]
+            kps, desc = self.extractor.compute(gray, kps)  # type: ignore[union-attr]
+        except cv2.error:
+            logger.warning("CMC: Feature detection failed (image too small), using identity")
+            self.frames_failed += 1
+            return affine_mtx
 
         # First frame init
         if not self._initialized:
@@ -500,7 +507,9 @@ class CMC:
 
         # Downscale
         if self.downscale > 1:
-            frame = cv2.resize(frame, (img_w // self.downscale, img_h // self.downscale))
+            new_w = max(1, img_w // self.downscale)
+            new_h = max(1, img_h // self.downscale)
+            frame = cv2.resize(frame, (new_w, new_h))
 
         # Find keypoints in current frame
         keypoints = cv2.goodFeaturesToTrack(frame, mask=None, **self.feature_params)
@@ -600,7 +609,9 @@ class CMC:
 
         if self.downscale > 1:
             frame = cv2.GaussianBlur(frame, (3, 3), 1.5)
-            frame = cv2.resize(frame, (img_w // self.downscale, img_h // self.downscale))
+            new_w = max(1, img_w // self.downscale)
+            new_h = max(1, img_h // self.downscale)
+            frame = cv2.resize(frame, (new_w, new_h))
 
         if not self._initialized:
             self._prev_frame_gray = frame.copy()

--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -65,7 +65,8 @@ class CMCConfig:
             - Speeds up feature extraction / optical flow.
 
             Behavior:
-            - Frames are resized to (W//downscale, H//downscale) for motion estimation.
+            - Frames are resized to (max(1, W//downscale), max(1, H//downscale))
+              for motion estimation so tiny inputs still produce a valid image.
             - The resulting affine translation components H[0,2], H[1,2] are scaled back
               by multiplying by `downscale`, so the transform is in original image
               coordinates.

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 import numpy as np
 import pytest
 
@@ -12,19 +18,19 @@ def test_cmc_downscale_zero_dimension(method: str) -> None:
     """Test that cmc downscaling does not crash when passed an image smaller than the downscale factor."""
     cfg = CMCConfig(method=method, downscale=2)
     cmc = CMC(cfg)
-    
+
     # 1x1 image - would result in 0x0 dimension if img_w // 2 is used
     frame = np.zeros((1, 1, 3), dtype=np.uint8)
-    
+
     # First frame always returns identity (init)
     H1 = cmc.estimate(frame)
     assert H1.shape == (2, 3)
     np.testing.assert_array_equal(H1, np.eye(2, 3, dtype=np.float32))
-    
+
     # Second frame triggers the actual feature matching / alignment logic
     # Should not crash with cv2.error
     H2 = cmc.estimate(frame)
-    
+
     assert H2.shape == (2, 3)
     # The result should be identity since it's the exact same 1x1 black frame
     np.testing.assert_array_equal(H2, np.eye(2, 3, dtype=np.float32))

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -28,10 +28,10 @@ def test_cmc_downscale_tiny_frame_first_call_returns_identity(
     cmc = CMC(cfg)
     frame = np.zeros((*frame_shape, 3), dtype=np.uint8)
 
-    H = cmc.estimate(frame)
+    affine_mtx = cmc.estimate(frame)
 
-    assert H.shape == (2, 3)
-    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))
+    assert affine_mtx.shape == (2, 3)
+    np.testing.assert_array_equal(affine_mtx, np.eye(2, 3, dtype=np.float32))
 
 
 @pytest.mark.parametrize("method", CMC_METHODS)
@@ -46,10 +46,10 @@ def test_cmc_downscale_tiny_frame_second_call_returns_identity(
     frame = np.zeros((*frame_shape, 3), dtype=np.uint8)
 
     cmc.estimate(frame)
-    H = cmc.estimate(frame)
+    affine_mtx = cmc.estimate(frame)
 
-    assert H.shape == (2, 3)
-    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))
+    assert affine_mtx.shape == (2, 3)
+    np.testing.assert_array_equal(affine_mtx, np.eye(2, 3, dtype=np.float32))
 
 
 @pytest.mark.parametrize("method", CMC_METHODS)
@@ -63,10 +63,10 @@ def test_cmc_recovers_after_tiny_frame_first_call_returns_identity(
     normal_frame = np.zeros((64, 64, 3), dtype=np.uint8)
     normal_frame[16:48, 16:48] = 255
 
-    H = cmc.estimate(normal_frame)
+    affine_mtx = cmc.estimate(normal_frame)
 
-    assert H.shape == (2, 3)
-    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))
+    assert affine_mtx.shape == (2, 3)
+    np.testing.assert_array_equal(affine_mtx, np.eye(2, 3, dtype=np.float32))
 
 
 @pytest.mark.parametrize("method", CMC_METHODS)
@@ -84,10 +84,10 @@ def test_cmc_recovers_after_tiny_frame_tiny_call_returns_identity(
     tiny_frame = np.zeros((*frame_shape, 3), dtype=np.uint8)
 
     cmc.estimate(normal_frame)
-    H = cmc.estimate(tiny_frame)
+    affine_mtx = cmc.estimate(tiny_frame)
 
-    assert H.shape == (2, 3)
-    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))
+    assert affine_mtx.shape == (2, 3)
+    np.testing.assert_array_equal(affine_mtx, np.eye(2, 3, dtype=np.float32))
 
 
 @pytest.mark.parametrize("method", CMC_METHODS)
@@ -106,7 +106,7 @@ def test_cmc_recovers_after_tiny_frame_followup_call_returns_identity(
 
     cmc.estimate(normal_frame)
     cmc.estimate(tiny_frame)
-    H = cmc.estimate(normal_frame)
+    affine_mtx = cmc.estimate(normal_frame)
 
-    assert H.shape == (2, 3)
-    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))
+    assert affine_mtx.shape == (2, 3)
+    np.testing.assert_array_equal(affine_mtx, np.eye(2, 3, dtype=np.float32))

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from trackers.utils.cmc import CMC, CMCConfig
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["sparseOptFlow", "orb", "sift", "ecc"],
+)
+def test_cmc_downscale_zero_dimension(method: str) -> None:
+    """Test that cmc downscaling does not crash when passed an image smaller than the downscale factor."""
+    cfg = CMCConfig(method=method, downscale=2)
+    cmc = CMC(cfg)
+    
+    # 1x1 image - would result in 0x0 dimension if img_w // 2 is used
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+    
+    # First frame always returns identity (init)
+    H1 = cmc.estimate(frame)
+    assert H1.shape == (2, 3)
+    np.testing.assert_array_equal(H1, np.eye(2, 3, dtype=np.float32))
+    
+    # Second frame triggers the actual feature matching / alignment logic
+    # Should not crash with cv2.error
+    H2 = cmc.estimate(frame)
+    
+    assert H2.shape == (2, 3)
+    # The result should be identity since it's the exact same 1x1 black frame
+    np.testing.assert_array_equal(H2, np.eye(2, 3, dtype=np.float32))

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -4,6 +4,8 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from __future__ import annotations
+
 from typing import Literal
 
 import numpy as np

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -4,13 +4,13 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from typing import Literal
+
 import numpy as np
 import pytest
 
 from trackers.utils.cmc import CMC, CMCConfig
 
-
-from typing import Literal
 
 @pytest.mark.parametrize(
     "method",

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -13,47 +13,100 @@ import pytest
 
 from trackers.utils.cmc import CMC, CMCConfig
 
+CMC_METHODS = ["sparseOptFlow", "orb", "sift", "ecc"]
+TINY_FRAME_SHAPES = [(1, 1), (1, 3), (3, 1)]
 
-@pytest.mark.parametrize("method", ["sparseOptFlow", "orb", "sift", "ecc"])
-@pytest.mark.parametrize("frame_shape", [(1, 1), (1, 3), (3, 1)])
-def test_cmc_downscale_tiny_frames(
+
+@pytest.mark.parametrize("method", CMC_METHODS)
+@pytest.mark.parametrize("frame_shape", TINY_FRAME_SHAPES)
+def test_cmc_downscale_tiny_frame_first_call_returns_identity(
     method: Literal["sparseOptFlow", "orb", "sift", "ecc"],
     frame_shape: tuple[int, int],
 ) -> None:
-    """Test that tiny frames below the downscale factor still produce identity transforms."""
+    """Test that the first tiny frame still initializes CMC with identity."""
     cfg = CMCConfig(method=method, downscale=2)
     cmc = CMC(cfg)
     frame = np.zeros((*frame_shape, 3), dtype=np.uint8)
-    expected = np.eye(2, 3, dtype=np.float32)
 
-    H1 = cmc.estimate(frame)
-    assert H1.shape == (2, 3)
-    np.testing.assert_array_equal(H1, expected)
+    H = cmc.estimate(frame)
 
-    H2 = cmc.estimate(frame)
-    assert H2.shape == (2, 3)
-    np.testing.assert_array_equal(H2, expected)
+    assert H.shape == (2, 3)
+    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))
 
 
-@pytest.mark.parametrize("method", ["sparseOptFlow", "orb", "sift", "ecc"])
-def test_cmc_recovers_after_tiny_frame(method: Literal["sparseOptFlow", "orb", "sift", "ecc"]) -> None:
-    """Test that a tiny frame does not poison the next normal estimate."""
+@pytest.mark.parametrize("method", CMC_METHODS)
+@pytest.mark.parametrize("frame_shape", TINY_FRAME_SHAPES)
+def test_cmc_downscale_tiny_frame_second_call_returns_identity(
+    method: Literal["sparseOptFlow", "orb", "sift", "ecc"],
+    frame_shape: tuple[int, int],
+) -> None:
+    """Test that repeating the same tiny frame still returns identity."""
     cfg = CMCConfig(method=method, downscale=2)
     cmc = CMC(cfg)
-    expected = np.eye(2, 3, dtype=np.float32)
+    frame = np.zeros((*frame_shape, 3), dtype=np.uint8)
+
+    cmc.estimate(frame)
+    H = cmc.estimate(frame)
+
+    assert H.shape == (2, 3)
+    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))
+
+
+@pytest.mark.parametrize("method", CMC_METHODS)
+def test_cmc_recovers_after_tiny_frame_first_call_returns_identity(
+    method: Literal["sparseOptFlow", "orb", "sift", "ecc"],
+) -> None:
+    """Test that the first normal frame still initializes CMC with identity."""
+    cfg = CMCConfig(method=method, downscale=2)
+    cmc = CMC(cfg)
 
     normal_frame = np.zeros((64, 64, 3), dtype=np.uint8)
     normal_frame[16:48, 16:48] = 255
-    tiny_frame = np.zeros((1, 1, 3), dtype=np.uint8)
 
-    H1 = cmc.estimate(normal_frame)
-    assert H1.shape == (2, 3)
-    np.testing.assert_array_equal(H1, expected)
+    H = cmc.estimate(normal_frame)
 
-    H2 = cmc.estimate(tiny_frame)
-    assert H2.shape == (2, 3)
-    np.testing.assert_array_equal(H2, expected)
+    assert H.shape == (2, 3)
+    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))
 
-    H3 = cmc.estimate(normal_frame)
-    assert H3.shape == (2, 3)
-    np.testing.assert_array_equal(H3, expected)
+
+@pytest.mark.parametrize("method", CMC_METHODS)
+@pytest.mark.parametrize("frame_shape", TINY_FRAME_SHAPES)
+def test_cmc_recovers_after_tiny_frame_tiny_call_returns_identity(
+    method: Literal["sparseOptFlow", "orb", "sift", "ecc"],
+    frame_shape: tuple[int, int],
+) -> None:
+    """Test that a tiny frame after initialization still returns identity."""
+    cfg = CMCConfig(method=method, downscale=2)
+    cmc = CMC(cfg)
+
+    normal_frame = np.zeros((64, 64, 3), dtype=np.uint8)
+    normal_frame[16:48, 16:48] = 255
+    tiny_frame = np.zeros((*frame_shape, 3), dtype=np.uint8)
+
+    cmc.estimate(normal_frame)
+    H = cmc.estimate(tiny_frame)
+
+    assert H.shape == (2, 3)
+    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))
+
+
+@pytest.mark.parametrize("method", CMC_METHODS)
+@pytest.mark.parametrize("frame_shape", TINY_FRAME_SHAPES)
+def test_cmc_recovers_after_tiny_frame_followup_call_returns_identity(
+    method: Literal["sparseOptFlow", "orb", "sift", "ecc"],
+    frame_shape: tuple[int, int],
+) -> None:
+    """Test that a normal frame after a tiny frame still returns identity."""
+    cfg = CMCConfig(method=method, downscale=2)
+    cmc = CMC(cfg)
+
+    normal_frame = np.zeros((64, 64, 3), dtype=np.uint8)
+    normal_frame[16:48, 16:48] = 255
+    tiny_frame = np.zeros((*frame_shape, 3), dtype=np.uint8)
+
+    cmc.estimate(normal_frame)
+    cmc.estimate(tiny_frame)
+    H = cmc.estimate(normal_frame)
+
+    assert H.shape == (2, 3)
+    np.testing.assert_array_equal(H, np.eye(2, 3, dtype=np.float32))

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -14,27 +14,46 @@ import pytest
 from trackers.utils.cmc import CMC, CMCConfig
 
 
-@pytest.mark.parametrize(
-    "method",
-    ["sparseOptFlow", "orb", "sift", "ecc"],
-)
-def test_cmc_downscale_zero_dimension(method: Literal["sparseOptFlow", "orb", "sift", "ecc"]) -> None:
-    """Test that cmc downscaling does not crash when passed an image smaller than the downscale factor."""
+@pytest.mark.parametrize("method", ["sparseOptFlow", "orb", "sift", "ecc"])
+@pytest.mark.parametrize("frame_shape", [(1, 1), (1, 3), (3, 1)])
+def test_cmc_downscale_tiny_frames(
+    method: Literal["sparseOptFlow", "orb", "sift", "ecc"],
+    frame_shape: tuple[int, int],
+) -> None:
+    """Test that tiny frames below the downscale factor still produce identity transforms."""
     cfg = CMCConfig(method=method, downscale=2)
     cmc = CMC(cfg)
+    frame = np.zeros((*frame_shape, 3), dtype=np.uint8)
+    expected = np.eye(2, 3, dtype=np.float32)
 
-    # 1x1 image - would result in 0x0 dimension if img_w // 2 is used
-    frame = np.zeros((1, 1, 3), dtype=np.uint8)
-
-    # First frame always returns identity (init)
     H1 = cmc.estimate(frame)
     assert H1.shape == (2, 3)
-    np.testing.assert_array_equal(H1, np.eye(2, 3, dtype=np.float32))
+    np.testing.assert_array_equal(H1, expected)
 
-    # Second frame triggers the actual feature matching / alignment logic
-    # Should not crash with cv2.error
     H2 = cmc.estimate(frame)
-
     assert H2.shape == (2, 3)
-    # The result should be identity since it's the exact same 1x1 black frame
-    np.testing.assert_array_equal(H2, np.eye(2, 3, dtype=np.float32))
+    np.testing.assert_array_equal(H2, expected)
+
+
+@pytest.mark.parametrize("method", ["sparseOptFlow", "orb", "sift", "ecc"])
+def test_cmc_recovers_after_tiny_frame(method: Literal["sparseOptFlow", "orb", "sift", "ecc"]) -> None:
+    """Test that a tiny frame does not poison the next normal estimate."""
+    cfg = CMCConfig(method=method, downscale=2)
+    cmc = CMC(cfg)
+    expected = np.eye(2, 3, dtype=np.float32)
+
+    normal_frame = np.zeros((64, 64, 3), dtype=np.uint8)
+    normal_frame[16:48, 16:48] = 255
+    tiny_frame = np.zeros((1, 1, 3), dtype=np.uint8)
+
+    H1 = cmc.estimate(normal_frame)
+    assert H1.shape == (2, 3)
+    np.testing.assert_array_equal(H1, expected)
+
+    H2 = cmc.estimate(tiny_frame)
+    assert H2.shape == (2, 3)
+    np.testing.assert_array_equal(H2, expected)
+
+    H3 = cmc.estimate(normal_frame)
+    assert H3.shape == (2, 3)
+    np.testing.assert_array_equal(H3, expected)

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -10,11 +10,13 @@ import pytest
 from trackers.utils.cmc import CMC, CMCConfig
 
 
+from typing import Literal
+
 @pytest.mark.parametrize(
     "method",
     ["sparseOptFlow", "orb", "sift", "ecc"],
 )
-def test_cmc_downscale_zero_dimension(method: str) -> None:
+def test_cmc_downscale_zero_dimension(method: Literal["sparseOptFlow", "orb", "sift", "ecc"]) -> None:
     """Test that cmc downscaling does not crash when passed an image smaller than the downscale factor."""
     cfg = CMCConfig(method=method, downscale=2)
     cmc = CMC(cfg)


### PR DESCRIPTION
## What does this PR do?

Fixes a robustness bug in the Camera Motion Compensation (`CMC`) module where providing a very small frame or bounding box crop would cause an unhandled crash.

When `img_w` or `img_h` was smaller than the `downscale` factor (default `2`), the dimension evaluated to `0`. Passing `(0, 0)` into `cv2.resize` triggered an unhandled OpenCV C++ assertion error (`cv2.error`). 

This PR:
1. Adds defensive dimension bounding (`max(1, img_w // self.downscale)`) across `_estimate_feature_affine`, `_estimate_sparse_optflow`, and `_estimate_ecc` to ensure valid dimensions.
2. Wraps the SIFT/ORB feature computation in a `try/except cv2.error` block to cleanly catch a secondary native crash that occurs when `SIFT` is asked to process an image smaller than 3x3 pixels. 

**Related Issue(s):** Fixes #487

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
Added `test_cmc_downscale_zero_dimension` parameterized over all CMC methods (`sparseOptFlow`, `orb`, `sift`, `ecc`) to assert that feeding a `1x1` image to the estimator gracefully returns the identity matrix instead of crashing. 

`uv run pytest tests/` → 855 passed, 2 skipped, 0 failures.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

See the linked issue #487 for full tracebacks and a reproduction script demonstrating the `cv2.error`.
Attached is a screenshot demonstrating the fix in action on this branch. As shown, the reproduction script now executes successfully without throwing the cv2.error exception, and the newly added unit tests successfully pass for all four CMC estimation methods 
After resolving this in new branch:- 
<img width="1080" height="425" alt="image" src="https://github.com/user-attachments/assets/c00b293f-ffc0-406b-80e2-649518061efb" />
<img width="1080" height="425" alt="image" src="https://github.com/user-attachments/assets/c00b293f-ffc0-406b-80e2-649518061efb" />
