### PR TITLE
ci: update workflow to publish on 'release' events, exclude pre-releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,11 +1,8 @@
 name: Publish Trackers Releases to PyPI
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
   release:
-    types: [created]
+    types: [published]
   pull_request:
     branches: ['release/*', 'develop']
     paths:
@@ -23,7 +20,7 @@ jobs:
   publish-release:
     name: Publish Release Package
     needs: build
-    if: github.event_name == 'push'
+    if: github.event_name == 'release' && github.event.release.prerelease != true
     runs-on: ubuntu-latest
     environment:
       name: release
@@ -42,15 +39,15 @@ jobs:
         run: ls -lh dist/
 
       - name: 🚀 Publish to PyPi
-        if: github.event_name != 'pull_request'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        # We only want to publish to PyPi if the event is a release and it's not a pre-release.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true
 
   publish-github-release:
     name: Upload GitHub Release Artifacts
     needs: build
-    if: github.event_name == 'release' && github.event.action == 'created'
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required to create and update GitHub Releases


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing releases to PyPI and GitHub. The main focus is to ensure that packages are only published when a release is officially published (not just created or pushed), and to avoid publishing pre-releases to PyPI. The logic for triggering jobs and publishing has been refined for greater accuracy and safety.

**Workflow trigger and job logic improvements:**

* The workflow now triggers on the `published` release event instead of `created`, and no longer triggers on tag pushes. This ensures the publish step only runs for official published releases.
* The `publish-release` job now checks that the event is a release and not a pre-release before running, preventing accidental publishing of pre-releases to PyPI.
* The PyPI publish step is now explicitly commented and only runs for published (non-pre-release) releases, clarifying intent and avoiding unintentional publishes.
* The `publish-github-release` job runs on any release event, not just when a release is created, aligning artifact uploads with the new trigger logic.