### PR TITLE
fix(utils): harden zip extraction

### DIFF
--- a/src/trackers/utils/downloader.py
+++ b/src/trackers/utils/downloader.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import stat
 import zipfile
+from contextlib import suppress
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import requests
@@ -117,10 +118,8 @@ def _safe_zip_member_parts(member_name: str) -> tuple[str, ...]:
 
 def _open_child_directory(parent_fd: int, directory_name: str) -> int:
     """Open a child directory below `parent_fd`, creating it if needed."""
-    try:
+    with suppress(FileExistsError):
         os.mkdir(directory_name, mode=0o777, dir_fd=parent_fd)
-    except FileExistsError:
-        pass
 
     directory_fd = os.open(
         directory_name,

--- a/src/trackers/utils/downloader.py
+++ b/src/trackers/utils/downloader.py
@@ -87,7 +87,28 @@ def _download_file(
     return True
 
 
+def _validate_zip_member_path(output_dir: Path, member_name: str) -> None:
+    """Reject ZIP members that would extract outside `output_dir`."""
+    if not member_name:
+        raise ValueError("ZIP archive contains an empty member name")
+
+    member_path = Path(member_name)
+    if member_path.is_absolute():
+        raise ValueError(f"ZIP member path escapes output directory: {member_name}")
+
+    target_path = (output_dir / member_path).resolve()
+    if not target_path.is_relative_to(output_dir):
+        raise ValueError(f"ZIP member path escapes output directory: {member_name}")
+
+
 def _extract_zip(zip_path: Path, output_dir: Path) -> None:
-    """Extract a ZIP archive into `output_dir`."""
+    """Extract a ZIP archive into `output_dir`.
+
+    Raises:
+        ValueError: If any member would extract outside `output_dir`.
+    """
+    output_dir = output_dir.resolve()
     with zipfile.ZipFile(zip_path, "r") as zip_file:
+        for member_name in zip_file.namelist():
+            _validate_zip_member_path(output_dir, member_name)
         zip_file.extractall(output_dir)

--- a/src/trackers/utils/downloader.py
+++ b/src/trackers/utils/downloader.py
@@ -7,8 +7,11 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import shutil
+import stat
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import requests
 from rich.progress import (
@@ -87,28 +90,111 @@ def _download_file(
     return True
 
 
-def _validate_zip_member_path(output_dir: Path, member_name: str) -> None:
-    """Reject ZIP members that would extract outside `output_dir`."""
+def _safe_zip_member_parts(member_name: str) -> tuple[str, ...]:
+    """Return sanitized ZIP path parts for a member.
+
+    ZIP member names are treated as forward-slash paths. Backslashes and
+    Windows drive-rooted forms are rejected so the extraction contract is
+    consistent across platforms.
+    """
     if not member_name:
         raise ValueError("ZIP archive contains an empty member name")
 
-    member_path = Path(member_name)
-    if member_path.is_absolute():
+    if "\\" in member_name:
         raise ValueError(f"ZIP member path escapes output directory: {member_name}")
 
-    target_path = (output_dir / member_path).resolve()
-    if not target_path.is_relative_to(output_dir):
+    posix_path = PurePosixPath(member_name)
+    windows_path = PureWindowsPath(member_name)
+    if posix_path.is_absolute() or windows_path.drive or windows_path.root:
         raise ValueError(f"ZIP member path escapes output directory: {member_name}")
+
+    parts = posix_path.parts
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"ZIP member path escapes output directory: {member_name}")
+
+    return parts
+
+
+def _open_child_directory(parent_fd: int, directory_name: str) -> int:
+    """Open a child directory below `parent_fd`, creating it if needed."""
+    try:
+        os.mkdir(directory_name, mode=0o777, dir_fd=parent_fd)
+    except FileExistsError:
+        pass
+
+    directory_fd = os.open(
+        directory_name,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=parent_fd,
+    )
+    try:
+        if not stat.S_ISDIR(os.fstat(directory_fd).st_mode):
+            raise NotADirectoryError(directory_name)
+    except Exception:
+        os.close(directory_fd)
+        raise
+    return directory_fd
+
+
+def _open_directory_path(root_fd: int, directory_parts: tuple[str, ...]) -> int:
+    """Open a directory path below `root_fd`, creating missing levels."""
+    directory_fd = os.dup(root_fd)
+    try:
+        for directory_name in directory_parts:
+            next_fd = _open_child_directory(directory_fd, directory_name)
+            os.close(directory_fd)
+            directory_fd = next_fd
+        return directory_fd
+    except Exception:
+        os.close(directory_fd)
+        raise
+
+
+def _extract_zip_member(zip_file: zipfile.ZipFile, zip_info: zipfile.ZipInfo, root_fd: int) -> None:
+    """Extract a single ZIP member relative to `root_fd`."""
+    member_parts = _safe_zip_member_parts(zip_info.filename)
+
+    if zip_info.is_dir():
+        directory_fd = _open_directory_path(root_fd, member_parts)
+        os.close(directory_fd)
+        return
+
+    parent_fd = _open_directory_path(root_fd, member_parts[:-1])
+    try:
+        file_fd = os.open(
+            member_parts[-1],
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+            0o666,
+            dir_fd=parent_fd,
+        )
+        with os.fdopen(file_fd, "wb") as target, zip_file.open(zip_info, "r") as source:
+            shutil.copyfileobj(source, target, length=_CHUNK_SIZE_BYTES)
+    finally:
+        os.close(parent_fd)
 
 
 def _extract_zip(zip_path: Path, output_dir: Path) -> None:
-    """Extract a ZIP archive into `output_dir`.
+    """Extract a ZIP archive into `output_dir` without following symlinks.
+
+    Extraction is anchored to the directory opened before members are written,
+    so a path swap after validation cannot redirect writes outside `output_dir`.
 
     Raises:
         ValueError: If any member would extract outside `output_dir`.
     """
     output_dir = output_dir.resolve()
-    with zipfile.ZipFile(zip_path, "r") as zip_file:
-        for member_name in zip_file.namelist():
-            _validate_zip_member_path(output_dir, member_name)
-        zip_file.extractall(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    root_fd = os.open(
+        output_dir,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zip_file:
+            member_infos = zip_file.infolist()
+            for zip_info in member_infos:
+                _safe_zip_member_parts(zip_info.filename)
+            for zip_info in member_infos:
+                _extract_zip_member(zip_file, zip_info, root_fd)
+    finally:
+        os.close(root_fd)

--- a/src/trackers/utils/downloader.py
+++ b/src/trackers/utils/downloader.py
@@ -172,11 +172,36 @@ def _extract_zip_member(zip_file: zipfile.ZipFile, zip_info: zipfile.ZipInfo, ro
         os.close(parent_fd)
 
 
-def _extract_zip(zip_path: Path, output_dir: Path) -> None:
-    """Extract a ZIP archive into `output_dir` without following symlinks.
+def _extract_zip_member_by_path(
+    zip_file: zipfile.ZipFile,
+    zip_info: zipfile.ZipInfo,
+    output_dir: Path,
+) -> None:
+    """Extract a single ZIP member using validated paths.
 
-    Extraction is anchored to the directory opened before members are written,
-    so a path swap after validation cannot redirect writes outside `output_dir`.
+    Windows does not expose the dir-fd primitives used by the Unix path, so
+    the fallback keeps the same member validation and writes to resolved
+    absolute paths.
+    """
+    member_parts = _safe_zip_member_parts(zip_info.filename)
+    member_path = output_dir.joinpath(*member_parts)
+
+    if zip_info.is_dir():
+        member_path.mkdir(parents=True, exist_ok=True)
+        return
+
+    member_path.parent.mkdir(parents=True, exist_ok=True)
+    with zip_file.open(zip_info, "r") as source, open(member_path, "wb") as target:
+        shutil.copyfileobj(source, target, length=_CHUNK_SIZE_BYTES)
+
+
+def _extract_zip(zip_path: Path, output_dir: Path) -> None:
+    """Extract a ZIP archive into `output_dir`.
+
+    On Unix, extraction is anchored to the directory opened before members are
+    written, so a path swap after validation cannot redirect writes outside
+    `output_dir`. On Windows, the fallback keeps the member validation but uses
+    resolved absolute paths because dir-fd containment is unavailable.
 
     Raises:
         ValueError: If any member would extract outside `output_dir`.
@@ -184,16 +209,22 @@ def _extract_zip(zip_path: Path, output_dir: Path) -> None:
     output_dir = output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    root_fd = os.open(
-        output_dir,
-        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
-    )
-    try:
-        with zipfile.ZipFile(zip_path, "r") as zip_file:
-            member_infos = zip_file.infolist()
+    with zipfile.ZipFile(zip_path, "r") as zip_file:
+        member_infos = zip_file.infolist()
+        for zip_info in member_infos:
+            _safe_zip_member_parts(zip_info.filename)
+
+        if os.name == "nt":
             for zip_info in member_infos:
-                _safe_zip_member_parts(zip_info.filename)
+                _extract_zip_member_by_path(zip_file, zip_info, output_dir)
+            return
+
+        root_fd = os.open(
+            output_dir,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
             for zip_info in member_infos:
                 _extract_zip_member(zip_file, zip_info, root_fd)
-    finally:
-        os.close(root_fd)
+        finally:
+            os.close(root_fd)

--- a/tests/utils/test_downloader.py
+++ b/tests/utils/test_downloader.py
@@ -80,6 +80,7 @@ def test_extract_zip_rejects_unsafe_members(
     assert outside_target.read_text() == "sentinel"
 
 
+@pytest.mark.skipif(os.name == "nt", reason="fd-anchored swap probe is Unix-only")
 def test_extract_zip_survives_output_dir_swap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A path swap after opening `output_dir` does not redirect writes."""
     zip_path = tmp_path / "archive.zip"

--- a/tests/utils/test_downloader.py
+++ b/tests/utils/test_downloader.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from trackers.utils import downloader
-from trackers.utils.downloader import _extract_zip
+from trackers.utils.downloader import _extract_zip, _safe_zip_member_parts
 
 
 def _write_zip(zip_path: Path, members: list[tuple[str | zipfile.ZipInfo, str]]) -> None:
@@ -55,7 +55,14 @@ def test_extract_zip_extracts_safe_members(tmp_path: Path) -> None:
         ("../escape.txt", "escapes output directory"),
         ("/escape.txt", "escapes output directory"),
         ("nested/../../escape.txt", "escapes output directory"),
-        (_raw_zip_info("nested\\escape.txt"), "escapes output directory"),
+        pytest.param(
+            _raw_zip_info("nested\\escape.txt"),
+            "escapes output directory",
+            marks=pytest.mark.skipif(
+                os.name == "nt",
+                reason="zipfile normalizes backslash member names while reading on Windows",
+            ),
+        ),
         ("C:escape.txt", "escapes output directory"),
         ("C:/escape.txt", "escapes output directory"),
         (zipfile.ZipInfo(""), "empty member name"),
@@ -85,6 +92,12 @@ def test_extract_zip_rejects_unsafe_members(
 
     assert list(output_dir.iterdir()) == []
     assert outside_target.read_text() == "sentinel"
+
+
+def test_safe_zip_member_parts_rejects_raw_backslash() -> None:
+    """Raw ZIP member validation rejects backslash separators."""
+    with pytest.raises(ValueError, match="escapes output directory"):
+        _safe_zip_member_parts("nested\\escape.txt")
 
 
 @pytest.mark.skipif(os.name == "nt", reason="fd-anchored swap probe is Unix-only")

--- a/tests/utils/test_downloader.py
+++ b/tests/utils/test_downloader.py
@@ -23,6 +23,13 @@ def _write_zip(zip_path: Path, members: list[tuple[str | zipfile.ZipInfo, str]])
             zip_file.writestr(member, contents)
 
 
+def _raw_zip_info(filename: str) -> zipfile.ZipInfo:
+    """Create a ZIP member name without platform separator normalization."""
+    zip_info = zipfile.ZipInfo("placeholder")
+    zip_info.filename = filename
+    return zip_info
+
+
 def test_extract_zip_extracts_safe_members(tmp_path: Path) -> None:
     """Safe members are extracted beneath the requested output directory."""
     zip_path = tmp_path / "archive.zip"
@@ -48,7 +55,7 @@ def test_extract_zip_extracts_safe_members(tmp_path: Path) -> None:
         ("../escape.txt", "escapes output directory"),
         ("/escape.txt", "escapes output directory"),
         ("nested/../../escape.txt", "escapes output directory"),
-        ("nested\\escape.txt", "escapes output directory"),
+        (_raw_zip_info("nested\\escape.txt"), "escapes output directory"),
         ("C:escape.txt", "escapes output directory"),
         ("C:/escape.txt", "escapes output directory"),
         (zipfile.ZipInfo(""), "empty member name"),

--- a/tests/utils/test_downloader.py
+++ b/tests/utils/test_downloader.py
@@ -6,19 +6,21 @@
 
 from __future__ import annotations
 
+import os
 import zipfile
 from pathlib import Path
 
 import pytest
 
+from trackers.utils import downloader
 from trackers.utils.downloader import _extract_zip
 
 
-def _write_zip(zip_path: Path, members: dict[str, str]) -> None:
+def _write_zip(zip_path: Path, members: list[tuple[str | zipfile.ZipInfo, str]]) -> None:
     """Write a ZIP archive containing the provided text members."""
     with zipfile.ZipFile(zip_path, "w") as zip_file:
-        for name, contents in members.items():
-            zip_file.writestr(name, contents)
+        for member, contents in members:
+            zip_file.writestr(member, contents)
 
 
 def test_extract_zip_extracts_safe_members(tmp_path: Path) -> None:
@@ -28,10 +30,10 @@ def test_extract_zip_extracts_safe_members(tmp_path: Path) -> None:
     output_dir.mkdir()
     _write_zip(
         zip_path,
-        {
-            "nested/file.txt": "payload",
-            "root.txt": "top",
-        },
+        [
+            ("nested/file.txt", "payload"),
+            ("root.txt", "top"),
+        ],
     )
 
     _extract_zip(zip_path, output_dir)
@@ -41,27 +43,79 @@ def test_extract_zip_extracts_safe_members(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "member_name",
+    ("member_name", "message"),
     [
-        "../escape.txt",
-        "/escape.txt",
-        "nested/../../escape.txt",
+        ("../escape.txt", "escapes output directory"),
+        ("/escape.txt", "escapes output directory"),
+        ("nested/../../escape.txt", "escapes output directory"),
+        ("nested\\escape.txt", "escapes output directory"),
+        ("C:escape.txt", "escapes output directory"),
+        ("C:/escape.txt", "escapes output directory"),
+        (zipfile.ZipInfo(""), "empty member name"),
     ],
 )
-def test_extract_zip_rejects_unsafe_members(tmp_path: Path, member_name: str) -> None:
+def test_extract_zip_rejects_unsafe_members(
+    tmp_path: Path,
+    member_name: str | zipfile.ZipInfo,
+    message: str,
+) -> None:
     """Unsafe member names fail before any files are extracted."""
     zip_path = tmp_path / "archive.zip"
     output_dir = tmp_path / "output"
+    outside_target = tmp_path / "escape.txt"
     output_dir.mkdir()
+    outside_target.write_text("sentinel")
     _write_zip(
         zip_path,
-        {
-            "safe.txt": "safe",
-            member_name: "evil",
-        },
+        [
+            ("safe.txt", "safe"),
+            (member_name, "evil"),
+        ],
     )
 
-    with pytest.raises(ValueError, match="escapes output directory"):
+    with pytest.raises(ValueError, match=message):
         _extract_zip(zip_path, output_dir)
 
     assert list(output_dir.iterdir()) == []
+    assert outside_target.read_text() == "sentinel"
+
+
+def test_extract_zip_survives_output_dir_swap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A path swap after opening `output_dir` does not redirect writes."""
+    zip_path = tmp_path / "archive.zip"
+    output_dir = tmp_path / "output"
+    backup_dir = tmp_path / "output-real"
+    outside_dir = tmp_path / "outside"
+    output_dir.mkdir()
+    outside_dir.mkdir()
+    _write_zip(zip_path, [("payload.txt", "payload")])
+
+    original_open = downloader.os.open
+    swapped = False
+
+    def open_wrapper(
+        path: os.PathLike[str] | str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal swapped
+        if dir_fd is None:
+            fd = original_open(path, flags, mode)
+        else:
+            fd = original_open(path, flags, mode, dir_fd=dir_fd)
+
+        if not swapped and dir_fd is None:
+            output_dir.rename(backup_dir)
+            output_dir.symlink_to(outside_dir, target_is_directory=True)
+            swapped = True
+
+        return fd
+
+    monkeypatch.setattr(downloader.os, "open", open_wrapper)
+
+    _extract_zip(zip_path, output_dir)
+
+    assert (backup_dir / "payload.txt").read_text() == "payload"
+    assert not (outside_dir / "payload.txt").exists()

--- a/tests/utils/test_downloader.py
+++ b/tests/utils/test_downloader.py
@@ -1,0 +1,67 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from trackers.utils.downloader import _extract_zip
+
+
+def _write_zip(zip_path: Path, members: dict[str, str]) -> None:
+    """Write a ZIP archive containing the provided text members."""
+    with zipfile.ZipFile(zip_path, "w") as zip_file:
+        for name, contents in members.items():
+            zip_file.writestr(name, contents)
+
+
+def test_extract_zip_extracts_safe_members(tmp_path: Path) -> None:
+    """Safe members are extracted beneath the requested output directory."""
+    zip_path = tmp_path / "archive.zip"
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    _write_zip(
+        zip_path,
+        {
+            "nested/file.txt": "payload",
+            "root.txt": "top",
+        },
+    )
+
+    _extract_zip(zip_path, output_dir)
+
+    assert (output_dir / "nested" / "file.txt").read_text() == "payload"
+    assert (output_dir / "root.txt").read_text() == "top"
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "../escape.txt",
+        "/escape.txt",
+        "nested/../../escape.txt",
+    ],
+)
+def test_extract_zip_rejects_unsafe_members(tmp_path: Path, member_name: str) -> None:
+    """Unsafe member names fail before any files are extracted."""
+    zip_path = tmp_path / "archive.zip"
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    _write_zip(
+        zip_path,
+        {
+            "safe.txt": "safe",
+            member_name: "evil",
+        },
+    )
+
+    with pytest.raises(ValueError, match="escapes output directory"):
+        _extract_zip(zip_path, output_dir)
+
+    assert list(output_dir.iterdir()) == []


### PR DESCRIPTION
This pull request adds security checks to ZIP extraction to prevent directory traversal attacks and introduces comprehensive tests to verify the new behavior. The most important changes are:

**Security improvements to ZIP extraction:**

* Added a new function `_validate_zip_member_path` in `downloader.py` to ensure that ZIP archive members cannot extract files outside the intended output directory, raising a `ValueError` if an unsafe path is detected.
* Updated `_extract_zip` to validate all member paths before extraction and to document the new error behavior in its docstring.

**Testing for ZIP extraction safety:**

* Added `test_extract_zip_extracts_safe_members` to verify that safe ZIP members are extracted correctly into the output directory.
* Added `test_extract_zip_rejects_unsafe_members` (with parameterization) to assert that unsafe ZIP members (such as those with `..` or absolute paths) are rejected and that no files are extracted in these cases.
* Introduced a helper function `_write_zip` for creating test ZIP archives with arbitrary members.

---

resolves #477