### PR TITLE
Harden ReID for production shipping

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -30,16 +30,17 @@ jobs:
           prune-cache: ${{ matrix.os != 'windows-latest' }}
 
       - name: 🚀 Install Packages
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --group dev --extra reid
 
-      - name: 🧪 Run the Import test
-        run: uv run python -c "import trackers"
+      - name: 🧪 Run base import regression (no heavy ReID imports)
+        shell: bash
+        run: uv run pytest tests/core/test_import_isolation.py -q
 
       - name: 🧪 Run the Test
         shell: bash
         run: |
           if [ -d tests ] && [ "$(find tests -type f \( -name 'test_*.py' -o -name '*_test.py' \) | wc -l)" -gt 0 ]; then
-            uv run pytest -m "not integration"
+            uv run pytest -m "not integration and not network"
           else
             echo "No tests found. Skipping pytest."
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Optional `trackers[reid]` extra** — torch/timm/Hugging Face ReID stack plus `safetensors`, `Pillow`, and `gdown` for curated FastReID checkpoints.
+- **BoT-SORT + ReID CLI** — `--tracker.reid.enable`, `--tracker.reid.model`, `--tracker.reid.architecture`, and `--tracker.reid.device` on `trackers track` (BoT-SORT only; source validated before model load).
+- **ReID evaluation helpers** — Market-1501 gallery `pid=0` distractor handling, safer CMC padding, and `ReIDMetrics.mean_average_precision` (with `map` alias). Canonical eval types are `ReIDEvaluator`, `ReIDMetrics`, `ReIDResult`, and `ReIDSplit` (`Reid*` aliases retained).
+- **FeatureBank hardening** — incompatible embedding shapes are rejected (previous state preserved); appearance similarity validates matrix shape/dimension.
+
+### Changed
+
+- **Lazy ReID imports** — `import trackers` and BoT-SORT without ReID no longer require torch; `ReIDModel` loads on first access.
+- **Proximity gating** — ReID fusion always uses standard IoU for the proximity gate, even when `iou=` is GIoU/DIoU/CIoU.
+- **BoT-SORT fusion module** — moved to `trackers.core.botsort.fusion` (shim retained under `trackers.core.reid.fusion_methods`).
+
+### Fixed
+
+- **FeatureBank** — normalises every ingest; skips non-finite/zero-norm vectors and rejects incompatible shape changes while preserving state.
+- **ReID loaders** — preserve Hugging Face errors, `weights_only=True` when supported, atomic `gd://` cache writes, stricter curated-alias load validation.
+
 ## [2.6.0] — 2026-07-08
 
 ### 🚀 Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ pip install git+https://github.com/roboflow/trackers.git
 
 For more options, see the [install guide](https://trackers.roboflow.com/develop/learn/install/).
 
+Optional appearance-based ReID for BoT-SORT:
+
+```bash
+pip install 'trackers[reid]'
+```
+
 [![Watch: Building Real-Time Multi-Object Tracking with RF-DETR and Trackers](https://storage.googleapis.com/com-roboflow-marketing/trackers/docs/roboflow-piotr-rf-detr-trackers-v1b-callout.png)](https://www.youtube.com/watch?v=u0k2dTZ0vfs)
 
 ## Quick Start

--- a/docs/api/reid.md
+++ b/docs/api/reid.md
@@ -10,6 +10,16 @@ Requires the optional extra:
 pip install 'trackers[reid]'
 ```
 
+## Protocols
+
+BoT-SORT and :class:`~trackers.core.reid.eval.evaluator.ReIDEvaluator` accept lightweight
+protocol types so tests and custom encoders do not need the full
+:class:`~trackers.core.reid.model.ReIDModel` stack:
+
+::: trackers.core.reid.protocols.ReIDEncoder
+
+::: trackers.core.reid.protocols.ReIDPathEncoder
+
 ## Model
 
 ::: trackers.core.reid.model.ReIDModel

--- a/docs/api/reid.md
+++ b/docs/api/reid.md
@@ -1,0 +1,33 @@
+---
+description: ReID model loading, evaluation, and appearance helpers in Roboflow Trackers.
+---
+
+# ReID API
+
+Requires the optional extra:
+
+```bash
+pip install 'trackers[reid]'
+```
+
+## Model
+
+::: trackers.core.reid.model.ReIDModel
+
+## Evaluation
+
+::: trackers.core.reid.eval.evaluator.ReIDEvaluator
+
+::: trackers.core.reid.eval.metrics.ReIDMetrics
+
+::: trackers.core.reid.eval.metrics.compute_reid_metrics
+
+## Datasets
+
+::: trackers.core.reid.eval.datasets.load_market1501
+
+::: trackers.core.reid.eval.datasets.load_msmt17
+
+## Feature bank
+
+::: trackers.core.reid.feature_bank.FeatureBank

--- a/docs/learn/install.md
+++ b/docs/learn/install.md
@@ -74,6 +74,16 @@ The `detection` extra installs `inference-models`, enabling the CLI to run detec
 
     For GPU support, ensure PyTorch is installed with CUDA or MPS.
 
+### ReID (BoT-SORT appearance)
+
+The `reid` extra installs PyTorch, timm, Hugging Face Hub, safetensors, Pillow, and gdown for curated FastReID checkpoints and BoT-SORT appearance association.
+
+```bash
+pip install "trackers[reid]"
+```
+
+Use programmatically with `ReIDModel.from_pretrained(...)` or via CLI flags such as `--tracker.reid.enable` and `--tracker.reid.architecture` on `trackers track` (BoT-SORT only).
+
 ---
 
 ## Development Setup

--- a/docs/trackers/botsort.md
+++ b/docs/trackers/botsort.md
@@ -89,16 +89,16 @@ CLI (requires `--source` so frames are available for embedding extraction):
 
 ```bash
 trackers track \
-  --source video.mp4 \
-  --output tracked.mp4 \
-  --tracker botsort \
-  --tracker.reid.enable \
-  --tracker.reid.model fastreid_mot17_sbs50 \
-  --tracker.reid.architecture fastreid_sbs_resnest50 \
-  --tracker.reid.device auto \
-  --tracker.appearance_threshold 0.2 \
-  --tracker.proximity_threshold 0.5 \
-  --tracker.reid_ema_alpha 0.9
+    --source video.mp4 \
+    --output tracked.mp4 \
+    --tracker botsort \
+    --tracker.reid.enable \
+    --tracker.reid.model fastreid_mot17_sbs50 \
+    --tracker.reid.architecture fastreid_sbs_resnest50 \
+    --tracker.reid.device auto \
+    --tracker.appearance_threshold 0.2 \
+    --tracker.proximity_threshold 0.5 \
+    --tracker.reid_ema_alpha 0.9
 ```
 
 For a bare local weights file, pass the matching `--tracker.reid.architecture` (for example `osnet_x1_0`).

--- a/docs/trackers/botsort.md
+++ b/docs/trackers/botsort.md
@@ -49,10 +49,61 @@ BoT-SORT keeps the same tracking-by-detection backbone as [ByteTrack](bytetrack.
 | `minimum_iou_threshold_unconfirmed_assoc` | Minimum IoU when associating unconfirmed tracks.                                                                            | Higher values make tentative tracks harder to confirm spuriously; lower values help short-lived or noisy objects survive.                                                                                                              |
 | `high_conf_det_threshold`                 | Confidence split between stage-1 and stage-2 detections.                                                                    | 0.5-0.7 common. Higher shifts more detections to recovery stage; lower gives stage-1 broader coverage.                                                                                                                                 |
 | `enable_cmc`                              | Enables camera motion compensation before association.                                                                      | Keep enabled for moving-camera footage (sports, drone, handheld). Disable mainly for static cameras if you need maximal speed.                                                                                                         |
-| `reid_model`                              | Optional ReID model for appearance-based association.                                                                       | Requires `frame` in :meth:`update`. When set, each track stores an EMA feature bank and upstream BoT-SORT min-cost ReID fusion is applied in the first and unconfirmed association stages.                                             |
 | `reid_ema_alpha`                          | EMA momentum for track appearance embeddings.                                                                               | Default `0.9`.                                                                                                                                                                                                                         |
 | `appearance_threshold`                    | Appearance distance gate θ_emb.                                                                                             | Default `0.25`. On MOT17 with a MOT-trained encoder, `0.2` matches the re-ID study Table 8 row ([SCCAI 2025](https://www-sop.inria.fr/members/Francois.Bremond/Postscript/Tomasz__SCCAI_2025.pdf)).                                    |
-| `proximity_threshold`                     | IoU distance gate before appearance is used for active tracks.                                                              | Default `0.5` (IoU > 0.5). Increase to loosen proximity gating.                                                                                                                                                                        |
+| `proximity_threshold`                     | Standard IoU distance gate before appearance is used (always true IoU, independent of `iou=`).                              | Default `0.5` (IoU > 0.5). Increase to loosen proximity gating.                                                                                                                                                                        |
+
+## ReID appearance (optional)
+
+Install the extra first:
+
+```bash
+pip install 'trackers[reid]'
+```
+
+Programmatic BoT-SORT + ReID:
+
+```python
+import cv2
+import supervision as sv
+from trackers import BoTSORTTracker, ReIDModel
+
+reid = ReIDModel.from_pretrained("fastreid_mot17_sbs50", device="auto")
+tracker = BoTSORTTracker(
+    reid_model=reid,
+    appearance_threshold=0.2,
+    proximity_threshold=0.5,
+    reid_ema_alpha=0.9,
+)
+
+cap = cv2.VideoCapture("video.mp4")
+while cap.isOpened():
+    ok, frame_bgr = cap.read()
+    if not ok:
+        break
+    detections = ...  # sv.Detections with xyxy + confidence
+    tracked = tracker.update(detections, frame=frame_bgr)
+```
+
+CLI (requires `--source` so frames are available for embedding extraction):
+
+```bash
+trackers track \
+  --source video.mp4 \
+  --output tracked.mp4 \
+  --tracker botsort \
+  --tracker.reid.enable \
+  --tracker.reid.model fastreid_mot17_sbs50 \
+  --tracker.reid.architecture fastreid_sbs_resnest50 \
+  --tracker.reid.device auto \
+  --tracker.appearance_threshold 0.2 \
+  --tracker.proximity_threshold 0.5 \
+  --tracker.reid_ema_alpha 0.9
+```
+
+For a bare local weights file, pass the matching `--tracker.reid.architecture` (for example `osnet_x1_0`).
+
+`reid_model` is constructed by the CLI from `--tracker.reid.*` flags (not exposed as a raw argparse type).
 
 ## Run on video, webcam, or RTSP stream
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
 
   - API Reference:
     - Trackers: api/trackers.md
+    - ReID: api/reid.md
     - Motion: api/motion.md
     - Datasets: api/datasets.md
     - Evals: api/evals.md

--- a/notebooks/eval_reid.ipynb
+++ b/notebooks/eval_reid.ipynb
@@ -17,8 +17,6 @@
         {
             "cell_type": "code",
             "metadata": {},
-            "execution_count": null,
-            "outputs": [],
             "source": [
                 "GIT_REF = \"git+https://github.com/roboflow/trackers.git@release/stable\"\n",
                 "\n",
@@ -26,17 +24,15 @@
                 "# Colab ships CUDA torch \u2014 avoid trackers[reid] (pulls a conflicting PyPI torch build).\n",
                 "!pip install -q timm huggingface-hub safetensors gdown matplotlib scikit-learn\n",
                 "!pip install -q --no-cache-dir --force-reinstall --no-deps \"trackers @ {GIT_REF}\"\n",
-                "!pip install -q supervision scipy opencv-python rich requests pydeprecate\n"
-            ]
+                "!pip install -q supervision scipy opencv-python rich requests pydeprecate"
+            ],
+            "execution_count": null,
+            "outputs": []
         },
         {
             "cell_type": "code",
             "metadata": {},
-            "execution_count": null,
-            "outputs": [],
             "source": [
-                "from __future__ import annotations\n",
-                "\n",
                 "import os\n",
                 "import zipfile\n",
                 "from pathlib import Path\n",
@@ -44,7 +40,7 @@
                 "import gdown\n",
                 "import torch\n",
                 "\n",
-                "from trackers.core.reid import ReidEvaluator, ReIDModel\n",
+                "from trackers.core.reid import ReIDEvaluator, ReIDModel\n",
                 "\n",
                 "try:\n",
                 "    import google.colab  # noqa: F401\n",
@@ -79,25 +75,22 @@
                 "    print(f\"{'mAP':<10}{cos.map:>9.1f}%{euc.map:>11.1f}%{zoo_map:>11.1f}%\")\n",
                 "    print(f\"{'Rank-5':<10}{cos.rank5:>9.1f}%{euc.rank5:>11.1f}%{'\u2014':>12}\")\n",
                 "    print(f\"{'Rank-10':<10}{cos.rank10:>9.1f}%{euc.rank10:>11.1f}%{'\u2014':>12}\")\n",
-                "    print(f\"{'mINP':<10}{cos.minp:>9.1f}%{euc.minp:>11.1f}%{'\u2014':>12}\")\n"
-            ]
+                "    print(f\"{'mINP':<10}{cos.minp:>9.1f}%{euc.minp:>11.1f}%{'\u2014':>12}\")"
+            ],
+            "execution_count": null,
+            "outputs": []
         },
         {
             "cell_type": "markdown",
             "metadata": {},
             "source": [
                 "---\n## 2. Market-1501\n\n**Expected numbers (OSNet x1.0 trained on Market-1501, torchreid model zoo):** Rank-1 \u2248 94.2 %  |  mAP \u2248 82.6 %\n\nThe model-zoo numbers use **raw Euclidean** distance. We report both that and our\ndefault **cosine** (L2-normalised) distance so the difference is visible.\n\nMarket-1501 is ~1.3 GB. We download it via gdown (official Google Drive mirror).\nIf gdown fails, see the alternative download cell below.\n"
-            ],
-            "execution_count": null,
-            "outputs": []
+            ]
         },
         {
             "cell_type": "code",
             "metadata": {},
             "source": [
-                "import os\n",
-                "import zipfile\n",
-                "\n",
                 "MARKET_ZIP = \"/content/Market-1501.zip\"\n",
                 "MARKET_DIR = \"/content/Market-1501-v15.09.15\"\n",
                 "\n",
@@ -108,7 +101,7 @@
                 "        zf.extractall(\"/content\")\n",
                 "    print(\"Extracted to\", MARKET_DIR)\n",
                 "else:\n",
-                "    print(\"Already downloaded.\")\n"
+                "    print(\"Already downloaded.\")"
             ],
             "execution_count": null,
             "outputs": []
@@ -131,7 +124,7 @@
                 "from trackers.core.reid import load_market1501\n",
                 "\n",
                 "query_m, gallery_m = load_market1501(MARKET_DIR)\n",
-                "print(f\"Market-1501 \u2014 query: {len(query_m):,}  |  gallery: {len(gallery_m):,}\")\n"
+                "print(f\"Market-1501 \u2014 query: {len(query_m):,}  |  gallery: {len(gallery_m):,}\")"
             ],
             "execution_count": null,
             "outputs": []
@@ -143,7 +136,7 @@
                 "# Load the OSNet x1.0 checkpoint trained on Market-1501 (torchreid model zoo).\n",
                 "market_ckpt = download_checkpoint(\"1vduhq5DpN2q1g4fYEZfPI17MJeh9qyrA\", \"osnet_x1_0_market1501.pth\")\n",
                 "model_market = ReIDModel.from_pretrained(market_ckpt, architecture=\"osnet_x1_0\")\n",
-                "evaluator_market = ReidEvaluator(model_market, batch_size=256)\n",
+                "evaluator_market = ReIDEvaluator(model_market, batch_size=256)\n",
                 "\n",
                 "# Cosine distance on L2-normalised embeddings (our default) \u2014 extracts once.\n",
                 "result_market = evaluator_market.evaluate(query_m, gallery_m, distance=\"cosine\", return_distmat=False)\n",
@@ -158,7 +151,7 @@
                 "    gallery_embeddings=result_market.gallery_embeddings,\n",
                 ")\n",
                 "\n",
-                "print_comparison(\"Market-1501\", result_market.metrics, result_market_euc.metrics, 94.2, 82.6)\n"
+                "print_comparison(\"Market-1501\", result_market.metrics, result_market_euc.metrics, 94.2, 82.6)"
             ],
             "execution_count": null,
             "outputs": []
@@ -168,9 +161,7 @@
             "metadata": {},
             "source": [
                 "---\n## 3. MSMT17\n\n**Expected numbers (OSNet x1.0 trained on MSMT17, torchreid model zoo):** Rank-1 \u2248 74.9 %  |  mAP \u2248 43.8 % (raw Euclidean; we also report cosine)\n\n### Option A \u2014 download directly in Colab (recommended)\n\nDownloads `MSMT17_V1.zip` (~2.56 GB) from the community Hugging Face mirror\n[`xianpeijie/MSMT17_V1`](https://huggingface.co/datasets/xianpeijie/MSMT17_V1)\nusing `huggingface_hub` (already installed as part of the `[reid]` extra).\n"
-            ],
-            "execution_count": null,
-            "outputs": []
+            ]
         },
         {
             "cell_type": "code",
@@ -196,7 +187,7 @@
                 "        zf.extractall(\"/content\")\n",
                 "    print(\"Done \u2192\", MSMT17_DIR)\n",
                 "else:\n",
-                "    print(\"Already extracted.\")\n"
+                "    print(\"Already extracted.\")"
             ],
             "execution_count": null,
             "outputs": []
@@ -208,7 +199,7 @@
                 "from trackers.core.reid import load_msmt17\n",
                 "\n",
                 "query_ms, gallery_ms = load_msmt17(MSMT17_DIR)\n",
-                "print(f\"MSMT17 \u2014 query: {len(query_ms):,}  |  gallery: {len(gallery_ms):,}\")\n"
+                "print(f\"MSMT17 \u2014 query: {len(query_ms):,}  |  gallery: {len(gallery_ms):,}\")"
             ],
             "execution_count": null,
             "outputs": []
@@ -223,7 +214,7 @@
                 "# it trains on the MSMT17 test identities, so scores would be inflated.\n",
                 "msmt17_ckpt = download_checkpoint(\"112EMUfBPYeYg70w-syK6V6Mx8-Qb9Q1M\", \"osnet_x1_0_msmt17.pth\")\n",
                 "model_msmt17 = ReIDModel.from_pretrained(msmt17_ckpt, architecture=\"osnet_x1_0\")\n",
-                "evaluator_msmt17 = ReidEvaluator(model_msmt17, batch_size=256)\n",
+                "evaluator_msmt17 = ReIDEvaluator(model_msmt17, batch_size=256)\n",
                 "\n",
                 "# Cosine distance on L2-normalised embeddings (our default) \u2014 extracts once.\n",
                 "result_msmt17 = evaluator_msmt17.evaluate(query_ms, gallery_ms, distance=\"cosine\", return_distmat=False)\n",
@@ -237,7 +228,7 @@
                 "    gallery_embeddings=result_msmt17.gallery_embeddings,\n",
                 ")\n",
                 "\n",
-                "print_comparison(\"MSMT17\", result_msmt17.metrics, result_msmt17_euc.metrics, 74.9, 43.8)\n"
+                "print_comparison(\"MSMT17\", result_msmt17.metrics, result_msmt17_euc.metrics, 74.9, 43.8)"
             ],
             "execution_count": null,
             "outputs": []
@@ -247,9 +238,7 @@
             "metadata": {},
             "source": [
                 "---\n## 4. BoT-SORT FastReID encoder (MOT17 SBS-S50)\n\nThe [BoT-SORT model zoo](https://github.com/niraharon/bot-sort#model-zoo) publishes a **FastReID Strong Baseline** checkpoint trained on MOT17 train-half GT crops (`mot17_sbs_S50.pth`). This is the encoder used in the paper's BoT-SORT-ReID ablation.\n\nWe load it via the curated alias `fastreid_mot17_sbs50` (ResNeSt50 + GeM + BNNeck, **384\u00d7128** input). Run **\u00a74 MSMT17** first so `query_ms` / `gallery_ms` are in memory \u2014 the cell below measures **cross-domain** retrieval (MOT-trained encoder on MSMT17), which is expected to score lower than same-domain OSNet numbers in \u00a74.\n"
-            ],
-            "execution_count": null,
-            "outputs": []
+            ]
         },
         {
             "cell_type": "code",
@@ -267,7 +256,7 @@
                 "#     architecture=\"fastreid_sbs_resnest50\",\n",
                 "# )\n",
                 "\n",
-                "print(model_fastreid.preprocessing.describe())\n"
+                "print(model_fastreid.preprocessing.describe())"
             ],
             "execution_count": null,
             "outputs": []
@@ -278,11 +267,9 @@
             "source": [
                 "# Cross-domain gallery retrieval: MOT17-trained encoder on MSMT17 query/gallery.\n",
                 "# Requires \u00a74 MSMT17 cells (query_ms, gallery_ms) to have been run.\n",
-                "evaluator_fastreid = ReidEvaluator(model_fastreid, batch_size=256)\n",
+                "evaluator_fastreid = ReIDEvaluator(model_fastreid, batch_size=256)\n",
                 "\n",
-                "result_fastreid_msmt17_cos = evaluator_fastreid.evaluate(\n",
-                "    query_ms, gallery_ms, distance=\"cosine\", return_distmat=False\n",
-                ")\n",
+                "result_fastreid_msmt17_cos = evaluator_fastreid.evaluate(query_ms, gallery_ms, distance=\"cosine\", return_distmat=False)\n",
                 "result_fastreid_msmt17_euc = evaluator_fastreid.evaluate(\n",
                 "    query_ms,\n",
                 "    gallery_ms,\n",
@@ -299,7 +286,7 @@
                 "    result_fastreid_msmt17_euc.metrics,\n",
                 "    float(\"nan\"),\n",
                 "    float(\"nan\"),\n",
-                ")\n"
+                ")"
             ],
             "execution_count": null,
             "outputs": []
@@ -309,9 +296,7 @@
             "metadata": {},
             "source": [
                 "---\n## 5. Summary table\n"
-            ],
-            "execution_count": null,
-            "outputs": []
+            ]
         },
         {
             "cell_type": "code",
@@ -336,7 +321,7 @@
                 "print(_row(\"\", \"\", \"euclidean\", result_fastreid_msmt17_euc.metrics))\n",
                 "print(\"-\" * 91)\n",
                 "print(\"Model-zoo targets (OSNet, euclidean): Market-1501 R1\u224894.2 mAP\u224882.6  |  MSMT17 R1\u224874.9 mAP\u224843.8\")\n",
-                "print(\"FastReID row is cross-domain (MOT17-trained encoder on MSMT17 gallery).\")\n"
+                "print(\"FastReID row is cross-domain (MOT17-trained encoder on MSMT17 gallery).\")"
             ],
             "execution_count": null,
             "outputs": []

--- a/notebooks/eval_reid.ipynb
+++ b/notebooks/eval_reid.ipynb
@@ -20,7 +20,7 @@
             "execution_count": null,
             "outputs": [],
             "source": [
-                "GIT_REF = \"git+https://github.com/roboflow/trackers.git@feat/core/reid\"\n",
+                "GIT_REF = \"git+https://github.com/roboflow/trackers.git@release/stable\"\n",
                 "\n",
                 "!pip install -q --upgrade pip\n",
                 "# Colab ships CUDA torch \u2014 avoid trackers[reid] (pulls a conflicting PyPI torch build).\n",

--- a/notebooks/eval_trackers_reid.ipynb
+++ b/notebooks/eval_trackers_reid.ipynb
@@ -2,7 +2,6 @@
     "cells": [
         {
             "cell_type": "markdown",
-            "id": "2d522414",
             "metadata": {},
             "source": [
                 "# Tracker ReID evaluation on MOT17 val\n",
@@ -24,24 +23,22 @@
                 "\n",
                 "> **Runtime:** T4 GPU.\n",
                 ""
-            ]
+            ],
+            "id": "2d522414"
         },
         {
             "cell_type": "markdown",
-            "id": "7bec6c65",
             "metadata": {},
             "source": [
                 "## 1. Setup\n",
                 "\n",
                 "Install `trackers` from the feature branch. On Colab, use the cells below instead of `trackers[reid]` \u2014 Colab already ships CUDA PyTorch and the extra pulls a conflicting build.\n"
-            ]
+            ],
+            "id": "7bec6c65"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "6bc2b8d8",
             "metadata": {},
-            "outputs": [],
             "source": [
                 "GIT_REF = \"git+https://github.com/roboflow/trackers.git@release/stable\"\n",
                 "\n",
@@ -50,18 +47,17 @@
                 "!pip install -q timm huggingface-hub safetensors gdown matplotlib scikit-learn\n",
                 "!pip install -q --no-cache-dir --force-reinstall --no-deps \"trackers @ {GIT_REF}\"\n",
                 "!pip install -q supervision scipy opencv-python rich requests pydeprecate"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "6bc2b8d8"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "6c2e60ad",
             "metadata": {},
-            "outputs": [],
             "source": [
-                "from __future__ import annotations\n",
-                "\n",
                 "import subprocess\n",
+                "import sys\n",
                 "import warnings\n",
                 "import zipfile\n",
                 "from pathlib import Path\n",
@@ -72,7 +68,8 @@
                 "import numpy as np\n",
                 "import supervision as sv\n",
                 "import torch\n",
-                "from IPython.display import Video, display\n",
+                "from IPython.display import Video\n",
+                "from IPython.display import display as ipy_display\n",
                 "from sklearn.decomposition import PCA\n",
                 "\n",
                 "from trackers import BoTSORTTracker\n",
@@ -107,11 +104,13 @@
                 "\n",
                 "device = torch.cuda.get_device_name(0) if torch.cuda.is_available() else \"cpu\"\n",
                 "print(f\"PyTorch {torch.__version__} | CUDA {torch.cuda.is_available()} | {device}\")"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "6c2e60ad"
         },
         {
             "cell_type": "markdown",
-            "id": "a54bb5ed",
             "metadata": {},
             "source": [
                 "## 2. ReID model\n",
@@ -120,14 +119,12 @@
                 "|---|---|---|\n",
                 "| `fastreid_mot17_sbs50` (default) | MOT17 train-half | 384\u00d7128 |\n",
                 "| `osnet_msmt17` | MSMT17 combineall | 256\u00d7128 |\n"
-            ]
+            ],
+            "id": "a54bb5ed"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "bbc892d6",
             "metadata": {},
-            "outputs": [],
             "source": [
                 "REID_ENCODER = \"fastreid_mot17_sbs50\"\n",
                 "REID_APPEARANCE_THRESHOLD = 0.2  # MOT17 re-ID study Table 8; BoT-SORT paper default 0.25\n",
@@ -141,25 +138,25 @@
                 "\n",
                 "print(f\"Encoder: {REID_ENCODER}  |  \u03b8_emb: {REID_APPEARANCE_THRESHOLD}\")\n",
                 "print(reid_model.preprocessing.describe())"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "bbc892d6"
         },
         {
             "cell_type": "markdown",
-            "id": "29afb2e0",
             "metadata": {},
             "source": [
                 "## 3. Download data\n",
                 "\n",
                 "MOT17 val GT + frames via `trackers download`. YOLOX val detections via gdown\n",
                 "(BoT-SORT / ByteTrack eval protocol). YOLOX frame IDs are remapped to 1\u2026N.\n"
-            ]
+            ],
+            "id": "29afb2e0"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "5ea423a9",
             "metadata": {},
-            "outputs": [],
             "source": [
                 "FORCE_DOWNLOAD = False\n",
                 "\n",
@@ -187,9 +184,11 @@
                 "\n",
                 "\n",
                 "if FORCE_DOWNLOAD or not mot17_val_ready():\n",
-                "    subprocess.run(\n",
+                "    subprocess.run(  # noqa: S603\n",
                 "        [\n",
-                "            \"trackers\",\n",
+                "            sys.executable,\n",
+                "            \"-m\",\n",
+                "            \"trackers.scripts\",\n",
                 "            \"download\",\n",
                 "            \"mot17\",\n",
                 "            \"--split\",\n",
@@ -232,22 +231,22 @@
                 "SEQMAP_PATH = OUTPUT_ROOT / \"MOT17-val.txt\"\n",
                 "SEQMAP_PATH.write_text(\"name\\n\" + \"\\n\".join(ACTIVE_SEQUENCES) + \"\\n\")\n",
                 "print(f\"\\n{len(ACTIVE_SEQUENCES)} sequences \u2192 outputs in {OUTPUT_ROOT}\")"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "5ea423a9"
         },
         {
             "cell_type": "markdown",
-            "id": "b57560b2",
             "metadata": {},
             "source": [
                 "## 4. Tracking helpers\n"
-            ]
+            ],
+            "id": "b57560b2"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "f38487ea",
             "metadata": {},
-            "outputs": [],
             "source": [
                 "RERUN = {\n",
                 "    \"botsort_baseline\": True,\n",
@@ -304,7 +303,7 @@
                 "\n",
                 "\n",
                 "def print_metrics(label: str, result: BenchmarkResult) -> None:\n",
-                "    hota, assa, deta, mota, idf1, idsw = fmt_metrics(result)\n",
+                "    hota, _assa, _deta, mota, idf1, idsw = fmt_metrics(result)\n",
                 "    print(f\"{label}: HOTA {hota:6.2f}  MOTA {mota:6.2f}  IDF1 {idf1:6.2f}  IDSW {idsw}\")\n",
                 "\n",
                 "\n",
@@ -381,22 +380,22 @@
                 "        if ious[i, j] >= min_iou:\n",
                 "            out[i] = int(gt_ids[j])\n",
                 "    return out"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "f38487ea"
         },
         {
             "cell_type": "markdown",
-            "id": "823b2696",
             "metadata": {},
             "source": [
                 "## 5. Run trackers\n"
-            ]
+            ],
+            "id": "823b2696"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "d09332f1",
             "metadata": {},
-            "outputs": [],
             "source": [
                 "EXPERIMENTS = [\n",
                 "    (\n",
@@ -426,22 +425,22 @@
                 "\n",
                 "result_baseline = results[\"botsort_baseline\"]\n",
                 "result_reid = results[\"botsort_reid\"]"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "d09332f1"
         },
         {
             "cell_type": "markdown",
-            "id": "ad28e88f",
             "metadata": {},
             "source": [
                 "## 6. ReID embedding visualization (optional)\n"
-            ]
+            ],
+            "id": "ad28e88f"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "6612c281",
             "metadata": {},
-            "outputs": [],
             "source": [
                 "VIZ_SEQ = \"MOT17-02-FRCNN\"\n",
                 "VIZ_STRIDE, VIZ_MAX_FRAMES, VIZ_MAX_POINTS, VIZ_MAX_CROPS = 5, 40, 300, 24\n",
@@ -515,21 +514,23 @@
                 "plt.tight_layout()\n",
                 "plt.show()\n",
                 "print(f\"{len(coords)} points, {len(unique)} GT ids\")"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "6612c281"
         },
         {
             "cell_type": "markdown",
-            "id": "b0ea623e",
             "metadata": {},
             "source": [
                 "## 7. Results\n",
                 "\n",
                 "**7.1\u20137.2** BoT-SORT vs published references.\n"
-            ]
+            ],
+            "id": "b0ea623e"
         },
         {
             "cell_type": "markdown",
-            "id": "43321292",
             "metadata": {},
             "source": [
                 "### 7.1 BoT-SORT \u2014 reference targets\n",
@@ -549,14 +550,12 @@
                 "| BoT-SORT | 69.11 | 78.39 | 81.53 |\n",
                 "| BoT-SORT + ReID | 69.17 | 78.46 | 82.07 |\n",
                 "| **ReID \u0394 (BoT-SORT paper)** | **+0.06** | **+0.07** | **+0.54** |\n"
-            ]
+            ],
+            "id": "43321292"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "d16f6483",
             "metadata": {},
-            "outputs": [],
             "source": [
                 "# MOT17 re-ID study reference \u2014 Table 8 (HOTA) + Table 13 (IDF1), COMBINED row.\n",
                 "# MOTA is not reported for the YOLOX setup in that study.\n",
@@ -667,22 +666,22 @@
                 "    f\"  \u0394IDF1  trackers {r[4] - b[4]:+6.2f}   BoT-SORT paper {BOTSORT_PAPER_REID_DELTA['idf1']:+6.2f}   \"\n",
                 "    f\"gap {(r[4] - b[4]) - BOTSORT_PAPER_REID_DELTA['idf1']:+6.2f}\"\n",
                 ")"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "d16f6483"
         },
         {
             "cell_type": "markdown",
-            "id": "8ee1ac84",
             "metadata": {},
             "source": [
                 "### 7.2 BoT-SORT \u2014 per-sequence vs reference (Table 8 HOTA + Table 13 IDF1)\n"
-            ]
+            ],
+            "id": "8ee1ac84"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "d448e555",
             "metadata": {},
-            "outputs": [],
             "source": [
                 "REID_STUDY_PER_SEQ = {\n",
                 "    \"MOT17-02\": {\n",
@@ -740,11 +739,13 @@
                 "        delta_i_s = f\"{delta_i:+6.2f}\" if delta_i == delta_i else \"   n/a\"\n",
                 "        print(f\"  {label:<28}  {hota:6.2f}  {idf1:6.2f}  {idsw:5d}  {ref_h_s}  {delta_h_s}  {ref_i_s}  {delta_i_s}\")\n",
                 "    print()"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "d448e555"
         },
         {
             "cell_type": "markdown",
-            "id": "8de54c38",
             "metadata": {},
             "source": [
                 "### 8. Visual comparison \u2014 largest ReID gain sequence\n",
@@ -752,14 +753,12 @@
                 "Side-by-side **baseline vs +ReID** video for the val sequence with the largest \u0394HOTA\n",
                 "(from the runs above). On Colab the mp4 is downloaded automatically.\n",
                 ""
-            ]
+            ],
+            "id": "8de54c38"
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "9a4f4194",
             "metadata": {},
-            "outputs": [],
             "source": [
                 "# Auto-pick the sequence with the largest HOTA gain (override with COMPARE_SEQ = \"MOT17-02-FRCNN\").\n",
                 "COMPARE_SEQ: str | None = None\n",
@@ -815,7 +814,7 @@
                 "        seq_gains.append((seq, h_r - h_b, i_r - i_b, h_r))\n",
                 "\n",
                 "if not seq_gains:\n",
-                "    raise RuntimeError(\"No per-sequence metrics \u2014 run \u00a75\u2013\u00a77 first.\")\n",
+                "    raise RuntimeError(\"No per-sequence metrics - run sections 5-7 first.\")\n",
                 "\n",
                 "seq_gains.sort(key=lambda row: row[1], reverse=True)\n",
                 "print(\"Per-sequence ReID \u0394HOTA (largest first):\")\n",
@@ -864,10 +863,13 @@
                 "        sink.write_frame(np.hstack([left, right]))\n",
                 "\n",
                 "print(f\"Wrote {out_path} ({n_frames} frames @ {COMPARE_FPS} fps)\")\n",
-                "display(Video(str(out_path), embed=True, width=min(960, w)))\n",
+                "ipy_display(Video(str(out_path), embed=True, width=min(960, w)))\n",
                 "if IN_COLAB:\n",
                 "    files.download(str(out_path))"
-            ]
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "9a4f4194"
         }
     ],
     "metadata": {

--- a/notebooks/eval_trackers_reid.ipynb
+++ b/notebooks/eval_trackers_reid.ipynb
@@ -43,7 +43,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "GIT_REF = \"git+https://github.com/roboflow/trackers.git@feat/core/reid\"\n",
+                "GIT_REF = \"git+https://github.com/roboflow/trackers.git@release/stable\"\n",
                 "\n",
                 "!pip install -q --upgrade pip\n",
                 "# Colab ships CUDA torch \u2014 avoid trackers[reid] (pulls a conflicting PyPI torch build).\n",

--- a/notebooks/webcam_reid_demo.py
+++ b/notebooks/webcam_reid_demo.py
@@ -139,7 +139,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--list-cameras",
         action="store_true",
-        help="Probe camera indices 0–4 and exit.",
+        help="Probe camera indices 0-4 and exit.",
     )
     parser.add_argument(
         "--no-cmc",
@@ -158,7 +158,7 @@ def parse_args() -> argparse.Namespace:
         dest="proximity_threshold",
         type=float,
         default=0.85,
-        help=("IoU distance gate θ_iou — requires IoU > 1−θ (default: 0.85 → IoU > 0.15; paper uses 0.5 → IoU > 0.5)."),
+        help=("IoU distance gate theta_iou: requires IoU > 1-theta (default: 0.85 means IoU > 0.15; paper uses 0.5)."),
     )
     return parser.parse_args()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ reid = [
     "torchvision>=0.15.0",
     "timm>=1.0.0",
     "huggingface-hub>=0.20.0",
+    "safetensors>=0.4.0",
+    "Pillow>=10.0.0",
+    "gdown>=5.0.0",
 ]
 
 [project.scripts]
@@ -198,6 +201,7 @@ addopts = [
 doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"
 markers = [
     "integration: marks tests as integration tests (require external data download)",
+    "network: marks tests that require network access to download model weights",
 ]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ markers = [
 
 [tool.codespell]
 skip = "*.pth"
-ignore-words-list = "mot"
+ignore-words-list = "mot,iterm"
 
 [tool.mypy]
 python_version = "3.10"
@@ -224,6 +224,8 @@ module = [
     "timm",
     "timm.*",
     "huggingface_hub",
+    "gdown",
+    "safetensors",
     "firerequests",
     "scipy",
     "scipy.*",

--- a/src/trackers/__init__.py
+++ b/src/trackers/__init__.py
@@ -8,13 +8,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from trackers.core.reid._lazy import REID_INSTALL_HINT, import_reid_symbol
-
 from trackers.annotators.trace import MotionAwareTraceAnnotator
 from trackers.core.botsort.tracker import BoTSORTTracker
 from trackers.core.bytetrack.tracker import ByteTrackTracker
 from trackers.core.cbiou.tracker import CBIoUTracker
 from trackers.core.ocsort.tracker import OCSORTTracker
+from trackers.core.reid._lazy import REID_INSTALL_HINT, import_reid_symbol
 from trackers.core.sort.tracker import SORTTracker
 from trackers.datasets.download import download_dataset
 from trackers.datasets.manifest import Dataset, DatasetAsset, DatasetSplit

--- a/src/trackers/__init__.py
+++ b/src/trackers/__init__.py
@@ -6,12 +6,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from trackers.core.reid._lazy import REID_INSTALL_HINT, import_reid_symbol
+
 from trackers.annotators.trace import MotionAwareTraceAnnotator
 from trackers.core.botsort.tracker import BoTSORTTracker
 from trackers.core.bytetrack.tracker import ByteTrackTracker
 from trackers.core.cbiou.tracker import CBIoUTracker
 from trackers.core.ocsort.tracker import OCSORTTracker
-from trackers.core.reid.model import ReIDModel
 from trackers.core.sort.tracker import SORTTracker
 from trackers.datasets.download import download_dataset
 from trackers.datasets.manifest import Dataset, DatasetAsset, DatasetSplit
@@ -26,6 +29,9 @@ from trackers.motion.transformation import (
 from trackers.utils.cmc import CMC, CMCConfig, CMCMethod, CMCTMethod
 from trackers.utils.converters import xcycsr_to_xyxy, xyxy_to_xcycsr
 from trackers.utils.iou import BaseIoU, BIoU, CIoU, DIoU, GIoU, IoU
+
+if TYPE_CHECKING:
+    from trackers.core.reid.model import ReIDModel
 
 __all__ = [
     "CMC",
@@ -58,3 +64,23 @@ __all__ = [
     "xcycsr_to_xyxy",
     "xyxy_to_xcycsr",
 ]
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "ReIDModel": ("trackers.core.reid.model", "ReIDModel"),
+}
+
+
+def __getattr__(name: str) -> object:
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        try:
+            value = import_reid_symbol(module_name, attr_name)
+        except ImportError as exc:
+            raise ImportError(REID_INSTALL_HINT) from exc
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/trackers/core/base.py
+++ b/src/trackers/core/base.py
@@ -36,19 +36,25 @@ class ParameterInfo:
     description: str
 
 
+_CLI_EXCLUDED_PARAMS = frozenset({"reid_model", "iou"})
+
+
 class TrackerParameters(dict[str, ParameterInfo]):
-    """Tracker parameter mapping with CLI-only filtering for IoU metrics."""
+    """Tracker parameter mapping with CLI-only filtering for injection-only args."""
 
     def items(self) -> Iterator[tuple[str, ParameterInfo]]:  # type: ignore[override]
         try:
             from trackers.utils.iou import BaseIoU
         except ImportError:
-            yield from super().items()
-            return
+            base_iou_type: type | None = None
+        else:
+            base_iou_type = BaseIoU
 
         for name, param_info in super().items():
+            if name in _CLI_EXCLUDED_PARAMS:
+                continue
             param_type = param_info.param_type
-            if isinstance(param_type, type) and issubclass(param_type, BaseIoU):
+            if base_iou_type is not None and isinstance(param_type, type) and issubclass(param_type, base_iou_type):
                 continue
             yield name, param_info
 

--- a/src/trackers/core/botsort/fusion.py
+++ b/src/trackers/core/botsort/fusion.py
@@ -7,10 +7,10 @@
 # Adapted from NirAharon/BoT-SORT (MIT)
 # Copyright (c) 2022 Nir Aharon
 # Source: https://github.com/NirAharon/BoT-SORT
-# Reference: tracker/bot_sort.py (ReID appearance–IoU cost fusion)
+# Reference: tracker/bot_sort.py (ReID appearance-IoU cost fusion)
 # ------------------------------------------------------------------------
 
-"""Appearance–IoU fusion for BoT-SORT ReID association."""
+"""Appearance-IoU fusion for BoT-SORT ReID association."""
 
 from __future__ import annotations
 

--- a/src/trackers/core/botsort/fusion.py
+++ b/src/trackers/core/botsort/fusion.py
@@ -1,0 +1,45 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+#
+# Adapted from NirAharon/BoT-SORT (MIT)
+# Copyright (c) 2022 Nir Aharon
+# Source: https://github.com/NirAharon/BoT-SORT
+# Reference: tracker/bot_sort.py (ReID appearance–IoU cost fusion)
+# ------------------------------------------------------------------------
+
+"""Appearance–IoU fusion for BoT-SORT ReID association."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def fuse_botsort_reid_association(
+    iou_similarity_raw: np.ndarray,
+    iou_similarity_fused: np.ndarray,
+    appearance_similarity: np.ndarray,
+    *,
+    proximity_iou_similarity: np.ndarray,
+    proximity_threshold: float,
+    appearance_threshold: float,
+) -> np.ndarray:
+    """Fuse IoU and appearance the way BoT-SORT ``bot_sort.py`` does.
+
+    Computes ``min(score_fused_iou_cost, halved_appearance_cost)`` with
+    proximity and appearance caps, then returns the corresponding similarity
+    matrix (``1 - cost``).
+
+    Proximity gating always uses *standard IoU* similarity via
+    ``proximity_iou_similarity``, even when association scoring uses GIoU,
+    DIoU, or CIoU.
+    """
+    d_iou = 1.0 - iou_similarity_fused
+    d_iou_proximity = 1.0 - proximity_iou_similarity
+    d_app = 0.5 * (1.0 - appearance_similarity)
+    d_app = np.where(d_app > appearance_threshold, 1.0, d_app)
+    d_app = np.where(d_iou_proximity > proximity_threshold, 1.0, d_app)
+    fused_cost = np.minimum(d_iou, d_app)
+    return 1.0 - fused_cost

--- a/src/trackers/core/botsort/tracker.py
+++ b/src/trackers/core/botsort/tracker.py
@@ -12,12 +12,9 @@ from deprecate import deprecated
 from scipy.optimize import linear_sum_assignment
 
 from trackers.core.base import BaseTracker
+from trackers.core.botsort.fusion import fuse_botsort_reid_association
 from trackers.core.botsort.tracklet import BoTSORTTracklet
 from trackers.core.botsort.utils import _fuse_score, get_alive_tracklets
-from trackers.core.reid.distance import appearance_similarity
-from trackers.core.reid.extraction import extract_detection_embeddings
-from trackers.core.reid.feature_bank import FeatureBank
-from trackers.core.reid.fusion_methods import fuse_botsort_reid_association
 from trackers.utils.cmc import CMC, CMCConfig, CMCMethod
 from trackers.utils.detections import default_confidences
 from trackers.utils.iou import BaseIoU, IoU
@@ -99,7 +96,8 @@ class BoTSORTTracker(BaseTracker):
         appearance_threshold: Appearance distance gate θ_emb. Rejects matches when
             halved cosine distance ``0.5 * (1 - cos_sim)`` exceeds this value.
             Default ``0.25`` (BoT-SORT ``appearance_thresh``).
-        proximity_threshold: IoU distance gate before appearance is used.
+        proximity_threshold: Standard IoU distance gate before appearance is used.
+            Computed from true IoU even when ``iou=`` is GIoU/DIoU/CIoU.
             Default ``0.5`` (BoT-SORT ``proximity_thresh``; requires IoU > 0.5).
 
     Notes:
@@ -161,6 +159,7 @@ class BoTSORTTracker(BaseTracker):
         self.tracks: list[BoTSORTTracklet] = []
         self.state_estimator_class = state_estimator_class
         self.iou = iou if iou is not None else IoU()
+        self._proximity_iou = IoU()
         self.frame_id: int = 0
         self._reset_id_allocator()
 
@@ -285,6 +284,8 @@ class BoTSORTTracker(BaseTracker):
             if frame is None:
                 raise ValueError(f"{type(self).__name__}.update() requires frame when reid_model is set.")
             if len(high_boxes) > 0:
+                from trackers.core.reid.extraction import extract_detection_embeddings
+
                 det_embeddings = extract_detection_embeddings(self.reid_model, frame, high_boxes)
 
         # Step 1: associate high-confidence detections to confirmed + lost tracks.
@@ -296,15 +297,19 @@ class BoTSORTTracker(BaseTracker):
         iou_sim_fused = _fuse_score(iou_sim_raw, high_scores)
 
         if det_embeddings is not None and len(strack_pool) > 0:
+            from trackers.core.reid.distance import appearance_similarity
+
             track_feats = [
                 t.feature_bank.feature if t.feature_bank is not None and t.feature_bank.is_initialized else None
                 for t in strack_pool
             ]
             app_sim = appearance_similarity(track_feats, det_embeddings)
+            proximity_iou = self._get_proximity_iou_matrix(strack_pool, high_boxes)
             similarity_matrix = self._fuse_botsort_reid(
                 iou_sim_raw,
                 iou_sim_fused,
                 app_sim,
+                proximity_iou,
             )
         else:
             similarity_matrix = iou_sim_fused
@@ -361,16 +366,20 @@ class BoTSORTTracker(BaseTracker):
             iou_sim_fused = _fuse_score(iou_sim_raw, uh_scores)
 
             if det_embeddings is not None:
+                from trackers.core.reid.distance import appearance_similarity
+
                 uh_embeddings = det_embeddings[unmatched_high_list]
                 track_feats = [
                     t.feature_bank.feature if t.feature_bank is not None and t.feature_bank.is_initialized else None
                     for t in unconfirmed_tracks
                 ]
                 app_sim = appearance_similarity(track_feats, uh_embeddings)
+                proximity_iou = self._get_proximity_iou_matrix(unconfirmed_tracks, uh_boxes)
                 similarity_matrix = self._fuse_botsort_reid(
                     iou_sim_raw,
                     iou_sim_fused,
                     app_sim,
+                    proximity_iou,
                 )
             else:
                 similarity_matrix = iou_sim_fused
@@ -452,15 +461,24 @@ class BoTSORTTracker(BaseTracker):
         iou_similarity_raw: np.ndarray,
         iou_similarity_fused: np.ndarray,
         appearance_similarity: np.ndarray,
+        proximity_iou_similarity: np.ndarray,
     ) -> np.ndarray:
         """Fuse IoU and appearance using BoT-SORT ``bot_sort.py`` min-cost ReID."""
         return fuse_botsort_reid_association(
             iou_similarity_raw,
             iou_similarity_fused,
             appearance_similarity,
+            proximity_iou_similarity=proximity_iou_similarity,
             proximity_threshold=self.proximity_threshold,
             appearance_threshold=self.appearance_threshold,
         )
+
+    def _get_proximity_iou_matrix(self, tracklets: list[BoTSORTTracklet], detections: np.ndarray) -> np.ndarray:
+        if len(tracklets) == 0:
+            tracklet_boxes = np.empty((0, 4))
+        else:
+            tracklet_boxes = np.array([tracklet.get_state_bbox() for tracklet in tracklets])
+        return self._proximity_iou.compute(tracklet_boxes, detections)
 
     def _get_iou_matrix(self, tracklets: list[BoTSORTTracklet], detections: np.ndarray) -> np.ndarray:
         if len(tracklets) == 0:
@@ -531,6 +549,8 @@ class BoTSORTTracker(BaseTracker):
                     state_estimator_class=self.state_estimator_class,
                 )
                 if self.reid_model is not None:
+                    from trackers.core.reid.feature_bank import FeatureBank
+
                     tracklet.feature_bank = FeatureBank(self.reid_ema_alpha)
                     if det_embeddings is not None:
                         tracklet.feature_bank.update(det_embeddings[det_local_idx])

--- a/src/trackers/core/botsort/tracker.py
+++ b/src/trackers/core/botsort/tracker.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import ClassVar, cast
 
 import numpy as np
 import supervision as sv
@@ -15,6 +15,7 @@ from trackers.core.base import BaseTracker
 from trackers.core.botsort.fusion import fuse_botsort_reid_association
 from trackers.core.botsort.tracklet import BoTSORTTracklet
 from trackers.core.botsort.utils import _fuse_score, get_alive_tracklets
+from trackers.core.reid.protocols import ReIDEncoder
 from trackers.utils.cmc import CMC, CMCConfig, CMCMethod
 from trackers.utils.detections import default_confidences
 from trackers.utils.iou import BaseIoU, IoU
@@ -22,9 +23,6 @@ from trackers.utils.state_representations import (
     BaseStateEstimator,
     XCYCWHStateEstimator,
 )
-
-if TYPE_CHECKING:
-    from trackers.core.reid.model import ReIDModel
 
 
 class BoTSORTTracker(BaseTracker):
@@ -88,8 +86,9 @@ class BoTSORTTracker(BaseTracker):
             Passing ``None`` (the default) is equivalent to ``IoU()`` and is
             provided for backward compatibility with existing code that did not
             supply an ``iou`` argument.
-        reid_model: Optional :class:`~trackers.core.reid.model.ReIDModel` for
-            appearance-based association in the first high-confidence stage.
+        reid_model: Optional :class:`~trackers.core.reid.protocols.ReIDEncoder`
+            for appearance-based association in the first high-confidence stage.
+            :class:`~trackers.core.reid.model.ReIDModel` satisfies this protocol.
             Requires ``frame`` in :meth:`update`. When ``None`` (default),
             behaviour matches the geometry-only BoT-SORT baseline.
         reid_ema_alpha: EMA momentum for track appearance features. Default ``0.9``.
@@ -139,7 +138,7 @@ class BoTSORTTracker(BaseTracker):
         instant_first_frame_activation: bool = True,
         state_estimator_class: type[BaseStateEstimator] = XCYCWHStateEstimator,
         iou: BaseIoU | None = None,
-        reid_model: "ReIDModel | None" = None,
+        reid_model: ReIDEncoder | None = None,
         reid_ema_alpha: float = 0.9,
         appearance_threshold: float = 0.25,
         proximity_threshold: float = 0.5,

--- a/src/trackers/core/botsort/tracklet.py
+++ b/src/trackers/core/botsort/tracklet.py
@@ -6,9 +6,10 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
-from trackers.core.reid.feature_bank import FeatureBank
 from trackers.utils.base_tracklet import BaseTracklet
 from trackers.utils.cmc import CMC
 from trackers.utils.converters import xyxy_to_xywh
@@ -19,6 +20,9 @@ from trackers.utils.state_representations import (
     XCYCWHStateEstimator,
     XYXYStateEstimator,
 )
+
+if TYPE_CHECKING:
+    from trackers.core.reid.feature_bank import FeatureBank
 
 
 class BoTSORTTracklet(BaseTracklet):

--- a/src/trackers/core/reid/__init__.py
+++ b/src/trackers/core/reid/__init__.py
@@ -4,24 +4,22 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-from trackers.core.reid.architectures import build_architecture, list_architectures
-from trackers.core.reid.distance import appearance_similarity
-from trackers.core.reid.eval.datasets import ReidSplit, load_market1501, load_msmt17
-from trackers.core.reid.eval.evaluator import ReidEvaluator, ReidResult
-from trackers.core.reid.eval.metrics import ReidMetrics, compute_reid_metrics
-from trackers.core.reid.feature_bank import FeatureBank
-from trackers.core.reid.model import ReIDModel
-from trackers.core.reid.models.loaders import KeyReport, resolve_weights
-from trackers.core.reid.models.preprocessing import ReIDPreprocessing
-from trackers.core.reid.models.registry import FASTREID_MOT17_SBS50, ModelCard, resolve_model_card
+from __future__ import annotations
+
+from trackers.core.reid._lazy import import_reid_symbol
 
 __all__ = [
     "FASTREID_MOT17_SBS50",
     "FeatureBank",
     "KeyReport",
+    "MARKET1501_GALLERY_JUNK_PIDS",
     "ModelCard",
+    "ReIDEvaluator",
+    "ReIDMetrics",
     "ReIDModel",
     "ReIDPreprocessing",
+    "ReIDResult",
+    "ReIDSplit",
     "ReidEvaluator",
     "ReidMetrics",
     "ReidResult",
@@ -35,3 +33,44 @@ __all__ = [
     "resolve_model_card",
     "resolve_weights",
 ]
+
+# NumPy-only symbols — safe to import without torch/timm/HF.
+from trackers.core.reid.distance import appearance_similarity  # noqa: E402
+from trackers.core.reid.eval.datasets import (  # noqa: E402
+    MARKET1501_GALLERY_JUNK_PIDS,
+    ReIDSplit,
+    ReidSplit,
+    load_market1501,
+    load_msmt17,
+)
+from trackers.core.reid.eval.metrics import ReIDMetrics, ReidMetrics, compute_reid_metrics  # noqa: E402
+from trackers.core.reid.feature_bank import FeatureBank  # noqa: E402
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "ReIDModel": ("trackers.core.reid.model", "ReIDModel"),
+    "ReIDPreprocessing": ("trackers.core.reid.models.preprocessing", "ReIDPreprocessing"),
+    "ModelCard": ("trackers.core.reid.models.registry", "ModelCard"),
+    "resolve_model_card": ("trackers.core.reid.models.registry", "resolve_model_card"),
+    "FASTREID_MOT17_SBS50": ("trackers.core.reid.models.registry", "FASTREID_MOT17_SBS50"),
+    "KeyReport": ("trackers.core.reid.models.loaders", "KeyReport"),
+    "resolve_weights": ("trackers.core.reid.models.loaders", "resolve_weights"),
+    "build_architecture": ("trackers.core.reid.architectures", "build_architecture"),
+    "list_architectures": ("trackers.core.reid.architectures", "list_architectures"),
+    "ReIDEvaluator": ("trackers.core.reid.eval.evaluator", "ReIDEvaluator"),
+    "ReIDResult": ("trackers.core.reid.eval.evaluator", "ReIDResult"),
+    "ReidEvaluator": ("trackers.core.reid.eval.evaluator", "ReidEvaluator"),
+    "ReidResult": ("trackers.core.reid.eval.evaluator", "ReidResult"),
+}
+
+
+def __getattr__(name: str) -> object:
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        value = import_reid_symbol(module_name, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/trackers/core/reid/__init__.py
+++ b/src/trackers/core/reid/__init__.py
@@ -10,9 +10,9 @@ from trackers.core.reid._lazy import import_reid_symbol
 
 __all__ = [
     "FASTREID_MOT17_SBS50",
+    "MARKET1501_GALLERY_JUNK_PIDS",
     "FeatureBank",
     "KeyReport",
-    "MARKET1501_GALLERY_JUNK_PIDS",
     "ModelCard",
     "ReIDEvaluator",
     "ReIDMetrics",
@@ -35,16 +35,16 @@ __all__ = [
 ]
 
 # NumPy-only symbols — safe to import without torch/timm/HF.
-from trackers.core.reid.distance import appearance_similarity  # noqa: E402
-from trackers.core.reid.eval.datasets import (  # noqa: E402
+from trackers.core.reid.distance import appearance_similarity
+from trackers.core.reid.eval.datasets import (
     MARKET1501_GALLERY_JUNK_PIDS,
     ReIDSplit,
     ReidSplit,
     load_market1501,
     load_msmt17,
 )
-from trackers.core.reid.eval.metrics import ReIDMetrics, ReidMetrics, compute_reid_metrics  # noqa: E402
-from trackers.core.reid.feature_bank import FeatureBank  # noqa: E402
+from trackers.core.reid.eval.metrics import ReIDMetrics, ReidMetrics, compute_reid_metrics
+from trackers.core.reid.feature_bank import FeatureBank
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "ReIDModel": ("trackers.core.reid.model", "ReIDModel"),

--- a/src/trackers/core/reid/_lazy.py
+++ b/src/trackers/core/reid/_lazy.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 import importlib
 
 REID_INSTALL_HINT = (
-    "ReID features require the optional `trackers[reid]` extra. "
-    "Install with: pip install 'trackers[reid]'"
+    "ReID features require the optional `trackers[reid]` extra. Install with: pip install 'trackers[reid]'"
 )
 
 # Modules that must be importable for the ReID stack. Checked in order so the

--- a/src/trackers/core/reid/_lazy.py
+++ b/src/trackers/core/reid/_lazy.py
@@ -1,0 +1,54 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Optional ReID dependency helpers."""
+
+from __future__ import annotations
+
+import importlib
+
+REID_INSTALL_HINT = (
+    "ReID features require the optional `trackers[reid]` extra. "
+    "Install with: pip install 'trackers[reid]'"
+)
+
+# Modules that must be importable for the ReID stack. Checked in order so the
+# first missing dependency produces a clear install hint.
+_REID_DEPENDENCY_MODULES: tuple[str, ...] = (
+    "torch",
+    "torchvision",
+    "timm",
+    "huggingface_hub",
+    "safetensors",
+    "PIL",
+    "gdown",
+)
+
+
+def require_reid_extra() -> None:
+    """Raise a clear error when any ReID optional dependency is missing."""
+    for module_name in _REID_DEPENDENCY_MODULES:
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError as exc:
+            raise ImportError(REID_INSTALL_HINT) from exc
+        if module is None:
+            raise ImportError(REID_INSTALL_HINT)
+
+
+def import_reid_symbol(module_name: str, attr_name: str) -> object:
+    """Import a symbol from a heavy ReID submodule with a friendly fallback."""
+    require_reid_extra()
+    try:
+        module = importlib.import_module(module_name)
+        return getattr(module, attr_name)
+    except ImportError as exc:
+        raise ImportError(REID_INSTALL_HINT) from exc
+
+
+def load_reid_model_class():
+    """Import :class:`~trackers.core.reid.model.ReIDModel` on demand."""
+    return import_reid_symbol("trackers.core.reid.model", "ReIDModel")

--- a/src/trackers/core/reid/architectures/fastreid_sbs.py
+++ b/src/trackers/core/reid/architectures/fastreid_sbs.py
@@ -22,6 +22,8 @@ inference path as FastReID ``EmbeddingHead`` in eval.
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import timm
 import torch
 from torch import nn
@@ -49,7 +51,8 @@ def _patch_resnest50d_for_fastreid_last_stride(backbone: nn.Module) -> nn.Module
     and leaves ``avd_last`` unset on ``layer4[0]``, which shifts embeddings even
     when checkpoint keys load 100%.
     """
-    block = backbone.layer4[0]
+    backbone_any = cast(Any, backbone)
+    block = backbone_any.layer4[0]
     block.downsample[0] = nn.AvgPool2d(kernel_size=1, stride=1, padding=0)
     block.avd_last = nn.AvgPool2d(kernel_size=3, stride=1, padding=1)
     return backbone

--- a/src/trackers/core/reid/architectures/osnet.py
+++ b/src/trackers/core/reid/architectures/osnet.py
@@ -55,14 +55,14 @@ class _ConvBnRelu(nn.Module):
 
 
 class _Conv1x1(_ConvBnRelu):
-    """1×1 conv + BN + ReLU."""
+    """1x1 conv + BN + ReLU."""
 
     def __init__(self, in_channels: int, out_channels: int, stride: int = 1, groups: int = 1) -> None:
         super().__init__(in_channels, out_channels, 1, stride=stride, padding=0, groups=groups)
 
 
 class _Conv1x1Linear(nn.Module):
-    """1×1 conv + BN (no non-linearity)."""
+    """1x1 conv + BN (no non-linearity)."""
 
     def __init__(self, in_channels: int, out_channels: int, stride: int = 1) -> None:
         super().__init__()
@@ -74,7 +74,7 @@ class _Conv1x1Linear(nn.Module):
 
 
 class _LightConv3x3(nn.Module):
-    """Lightweight 3×3 conv: 1×1 linear + depthwise 3×3 + BN + ReLU."""
+    """Lightweight 3x3 conv: 1x1 linear + depthwise 3x3 + BN + ReLU."""
 
     def __init__(self, in_channels: int, out_channels: int) -> None:
         super().__init__()
@@ -112,7 +112,7 @@ class OSBlock(nn.Module):
     """Omni-scale feature learning residual block.
 
     Aggregates features from four parallel streams with different effective
-    receptive-field depths (1, 2, 3, 4 stacked lightweight 3×3 convs) gated
+    receptive-field depths (1, 2, 3, 4 stacked lightweight 3x3 convs) gated
     by a shared channel-wise gate before the residual addition.
     """
 
@@ -182,7 +182,8 @@ class OSNet(nn.Module):
         feature_dim: int = 512,
     ) -> None:
         super().__init__()
-        assert len(blocks) == len(layers) == len(channels) - 1
+        if len(blocks) != len(layers) or len(layers) != len(channels) - 1:
+            raise ValueError("blocks, layers, and channels must have consistent lengths")
 
         self.feature_dim = feature_dim
         self.conv1 = _ConvBnRelu(3, channels[0], 7, stride=2, padding=3)

--- a/src/trackers/core/reid/distance.py
+++ b/src/trackers/core/reid/distance.py
@@ -10,6 +10,22 @@ from __future__ import annotations
 
 import numpy as np
 
+from trackers.core.reid.feature_bank import FeatureBank
+
+
+def sanitize_embedding_matrix(embeddings: np.ndarray) -> np.ndarray:
+    """Replace non-finite rows with zeros so cosine similarity stays safe."""
+    if embeddings.size == 0:
+        return embeddings
+    cleaned = np.asarray(embeddings, dtype=np.float32)
+    if cleaned.ndim != 2:
+        raise ValueError(f"det_embeddings must be 2-D, got shape {cleaned.shape}")
+    row_finite = np.isfinite(cleaned).all(axis=1)
+    if not np.all(row_finite):
+        cleaned = cleaned.copy()
+        cleaned[~row_finite] = 0.0
+    return cleaned
+
 
 def appearance_similarity(
     track_features: list[np.ndarray | None],
@@ -18,7 +34,9 @@ def appearance_similarity(
     """Compute cosine similarity between track features and detection embeddings.
 
     Both inputs are expected to be L2-normalised. Tracks with ``None`` features
-    receive similarity ``0.0``.
+    receive similarity ``0.0``. Non-finite detection rows are zeroed before the
+    dot product so they cannot poison assignment. Track rows whose embedding
+    dimension does not match the detection matrix are treated as unavailable.
 
     Args:
         track_features: One embedding per track (``None`` = no feature yet).
@@ -28,21 +46,32 @@ def appearance_similarity(
         Similarity matrix of shape ``(T, N)``.
     """
     n_tracks = len(track_features)
-    n_dets = len(det_embeddings)
+    det_embeddings = sanitize_embedding_matrix(det_embeddings)
+    n_dets = det_embeddings.shape[0]
     sim = np.zeros((n_tracks, n_dets), dtype=np.float32)
 
     if n_tracks == 0 or n_dets == 0:
         return sim
 
-    # Collect indices and embeddings of tracks that have a feature.
-    valid_indices = [i for i, f in enumerate(track_features) if f is not None]
-    if not valid_indices:
+    embed_dim = det_embeddings.shape[1]
+    track_rows: list[np.ndarray] = []
+    kept_indices: list[int] = []
+    for track_idx, feature in enumerate(track_features):
+        if feature is None:
+            continue
+        normalized = FeatureBank.normalize_embedding(feature)
+        if normalized is None or normalized.shape[0] != embed_dim:
+            continue
+        track_rows.append(normalized)
+        kept_indices.append(track_idx)
+
+    if not track_rows:
         return sim
 
-    track_matrix = np.stack([track_features[i] for i in valid_indices])  # (K, D)
-    cos_sims = (track_matrix @ det_embeddings.T).astype(np.float32)  # (K, N)
+    track_matrix = np.stack(track_rows)
+    cos_sims = (track_matrix @ det_embeddings.T).astype(np.float32)
 
-    for local_idx, track_idx in enumerate(valid_indices):
+    for local_idx, track_idx in enumerate(kept_indices):
         sim[track_idx] = cos_sims[local_idx]
 
     return sim

--- a/src/trackers/core/reid/distance.py
+++ b/src/trackers/core/reid/distance.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import numpy as np
 
 from trackers.core.reid.feature_bank import FeatureBank
@@ -28,7 +30,7 @@ def sanitize_embedding_matrix(embeddings: np.ndarray) -> np.ndarray:
 
 
 def appearance_similarity(
-    track_features: list[np.ndarray | None],
+    track_features: Sequence[np.ndarray | None],
     det_embeddings: np.ndarray,
 ) -> np.ndarray:
     """Compute cosine similarity between track features and detection embeddings.

--- a/src/trackers/core/reid/eval/__init__.py
+++ b/src/trackers/core/reid/eval/__init__.py
@@ -4,11 +4,16 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-from trackers.core.reid.eval.datasets import ReidSplit, load_market1501, load_msmt17
-from trackers.core.reid.eval.evaluator import ReidEvaluator, ReidResult
-from trackers.core.reid.eval.metrics import ReidMetrics, compute_reid_metrics
+from __future__ import annotations
+
+from trackers.core.reid.eval.datasets import ReIDSplit, ReidSplit, load_market1501, load_msmt17
+from trackers.core.reid.eval.metrics import ReIDMetrics, ReidMetrics, compute_reid_metrics
 
 __all__ = [
+    "ReIDEvaluator",
+    "ReIDMetrics",
+    "ReIDResult",
+    "ReIDSplit",
     "ReidEvaluator",
     "ReidMetrics",
     "ReidResult",
@@ -17,3 +22,25 @@ __all__ = [
     "load_market1501",
     "load_msmt17",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name in ("ReIDEvaluator", "ReidEvaluator"):
+        from trackers.core.reid._lazy import import_reid_symbol
+
+        value = import_reid_symbol("trackers.core.reid.eval.evaluator", "ReIDEvaluator")
+        globals()["ReIDEvaluator"] = value
+        globals()["ReidEvaluator"] = value
+        return value
+    if name in ("ReIDResult", "ReidResult"):
+        from trackers.core.reid._lazy import import_reid_symbol
+
+        value = import_reid_symbol("trackers.core.reid.eval.evaluator", "ReIDResult")
+        globals()["ReIDResult"] = value
+        globals()["ReidResult"] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/trackers/core/reid/eval/datasets.py
+++ b/src/trackers/core/reid/eval/datasets.py
@@ -13,17 +13,30 @@ from pathlib import Path
 
 import numpy as np
 
+# Market-1501 gallery ``0000_*`` images are distractors (pid 0). Query identities
+# remain valid when pid=0 on other datasets (e.g. MSMT17).
+MARKET1501_GALLERY_JUNK_PIDS = frozenset({-1, 0})
+
 
 @dataclass
-class ReidSplit:
-    """Query or gallery split: image paths, person IDs, and camera IDs."""
+class ReIDSplit:
+    """Query or gallery split: image paths, person IDs, and camera IDs.
+
+    ``gallery_junk_pids`` controls which gallery person IDs are excluded from
+    ranking during retrieval evaluation (see :func:`compute_reid_metrics`).
+    """
 
     image_paths: list[str]
     pids: np.ndarray
     camids: np.ndarray
+    gallery_junk_pids: frozenset[int] = frozenset({-1})
 
     def __len__(self) -> int:
         return len(self.image_paths)
+
+
+# Backward-compatible alias (notebooks / early API).
+ReidSplit = ReIDSplit
 
 
 # --------------------------------------------------------------------------- #
@@ -41,7 +54,7 @@ def _parse_msmt17_camid(filename: str) -> int:
     return int(stem.split("_")[2]) - 1
 
 
-def load_msmt17(root: str | Path) -> tuple[ReidSplit, ReidSplit]:
+def load_msmt17(root: str | Path) -> tuple[ReIDSplit, ReIDSplit]:
     """Load MSMT17 query and gallery splits from *root*.
 
     Expects ``test/``, ``list_query.txt``, and ``list_gallery.txt``. List files
@@ -51,13 +64,13 @@ def load_msmt17(root: str | Path) -> tuple[ReidSplit, ReidSplit]:
         root: Path to the MSMT17 directory.
 
     Returns:
-        ``(query, gallery)`` :class:`ReidSplit` pair.
+        ``(query, gallery)`` :class:`ReIDSplit` pair.
     """
     root = Path(root)
     if not root.exists():
         raise FileNotFoundError(f"MSMT17 root not found: {root}")
 
-    def _parse_list(list_file: Path, image_root: Path) -> ReidSplit:
+    def _parse_list(list_file: Path, image_root: Path) -> ReIDSplit:
         if not list_file.exists():
             raise FileNotFoundError(f"MSMT17 list file not found: {list_file}")
         paths, pids, camids = [], [], []
@@ -74,10 +87,11 @@ def load_msmt17(root: str | Path) -> tuple[ReidSplit, ReidSplit]:
             paths.append(str(image_root / rel_path))
             pids.append(pid)
             camids.append(camid)
-        return ReidSplit(
+        return ReIDSplit(
             image_paths=paths,
             pids=np.array(pids, dtype=np.int32),
             camids=np.array(camids, dtype=np.int32),
+            gallery_junk_pids=frozenset({-1}),
         )
 
     test_root = root / "test"
@@ -100,11 +114,10 @@ def _parse_market_filename(filename: str) -> tuple[int, int]:
     parts = stem.split("_")
     pid = int(parts[0])
     camid = int(parts[1][1]) - 1  # "c1" → 0
-
     return pid, camid
 
 
-def load_market1501(root: str | Path) -> tuple[ReidSplit, ReidSplit]:
+def load_market1501(root: str | Path) -> tuple[ReIDSplit, ReIDSplit]:
     """Load Market-1501 query and gallery splits from *root*.
 
     Expects ``query/`` and ``bounding_box_test/``. Person and camera IDs are
@@ -114,13 +127,13 @@ def load_market1501(root: str | Path) -> tuple[ReidSplit, ReidSplit]:
         root: Path to the Market-1501 directory.
 
     Returns:
-        ``(query, gallery)`` :class:`ReidSplit` pair.
+        ``(query, gallery)`` :class:`ReIDSplit` pair.
     """
     root = Path(root)
     if not root.exists():
         raise FileNotFoundError(f"Market-1501 root not found: {root}")
 
-    def _load_dir(subdir: Path) -> ReidSplit:
+    def _load_dir(subdir: Path, *, gallery_junk_pids: frozenset[int]) -> ReIDSplit:
         if not subdir.exists():
             raise FileNotFoundError(f"Market-1501 sub-directory not found: {subdir}")
         paths, pids, camids = [], [], []
@@ -129,12 +142,13 @@ def load_market1501(root: str | Path) -> tuple[ReidSplit, ReidSplit]:
             paths.append(str(img_path))
             pids.append(pid)
             camids.append(camid)
-        return ReidSplit(
+        return ReIDSplit(
             image_paths=paths,
             pids=np.array(pids, dtype=np.int32),
             camids=np.array(camids, dtype=np.int32),
+            gallery_junk_pids=gallery_junk_pids,
         )
 
-    query = _load_dir(root / "query")
-    gallery = _load_dir(root / "bounding_box_test")
+    query = _load_dir(root / "query", gallery_junk_pids=frozenset({-1}))
+    gallery = _load_dir(root / "bounding_box_test", gallery_junk_pids=MARKET1501_GALLERY_JUNK_PIDS)
     return query, gallery

--- a/src/trackers/core/reid/eval/evaluator.py
+++ b/src/trackers/core/reid/eval/evaluator.py
@@ -9,35 +9,39 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from trackers.core.reid.eval.datasets import ReidSplit
-from trackers.core.reid.eval.metrics import ReidMetrics, compute_reid_metrics
-from trackers.core.reid.model import ReIDModel
+from trackers.core.reid.eval.datasets import ReIDSplit
+from trackers.core.reid.eval.metrics import ReIDMetrics, compute_reid_metrics
+
+if TYPE_CHECKING:
+    from trackers.core.reid.model import ReIDModel
 
 
 @dataclass
-class ReidResult:
+class ReIDResult:
     """Evaluation output: metrics, raw embeddings, and optional distance matrix."""
 
-    metrics: ReidMetrics
+    metrics: ReIDMetrics
     query_embeddings: np.ndarray
     gallery_embeddings: np.ndarray
     distmat: np.ndarray
 
 
+# Backward-compatible alias (notebooks / early API).
+ReidResult = ReIDResult
+
+
 def _distance_matrix(q_embs: np.ndarray, g_embs: np.ndarray, metric: str) -> np.ndarray:
     """Build a query×gallery distance matrix (``cosine`` or ``euclidean``)."""
-    # All ops below are done in place on a single (Nq, Ng) array to keep peak
-    # memory at one distance matrix — important for large galleries (e.g.
-    # MSMT17's 11.7k × 82.2k matrix is ~3.8 GB on its own).
     if metric == "cosine":
         qn = (q_embs / (np.linalg.norm(q_embs, axis=1, keepdims=True) + 1e-12)).astype(np.float32, copy=False)
         gn = (g_embs / (np.linalg.norm(g_embs, axis=1, keepdims=True) + 1e-12)).astype(np.float32, copy=False)
-        distmat = qn @ gn.T  # cosine similarity
+        distmat = qn @ gn.T
         distmat *= -1.0
-        distmat += 1.0  # → 1 − cosine similarity
+        distmat += 1.0
         return distmat
     if metric == "euclidean":
         distmat = (q_embs @ g_embs.T).astype(np.float32, copy=False)
@@ -50,7 +54,7 @@ def _distance_matrix(q_embs: np.ndarray, g_embs: np.ndarray, metric: str) -> np.
     raise ValueError(f"Unknown distance metric: {metric!r}. Use 'cosine' or 'euclidean'.")
 
 
-class ReidEvaluator:
+class ReIDEvaluator:
     """Run embedding extraction and retrieval metrics for a :class:`ReIDModel`.
 
     Args:
@@ -59,20 +63,22 @@ class ReidEvaluator:
     """
 
     def __init__(self, model: ReIDModel, batch_size: int = 64) -> None:
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
         self._model = model
         self._batch_size = batch_size
 
     def evaluate(
         self,
-        query: ReidSplit,
-        gallery: ReidSplit,
+        query: ReIDSplit,
+        gallery: ReIDSplit,
         max_rank: int = 10,
         verbose: bool = True,
         distance: str = "cosine",
         query_embeddings: np.ndarray | None = None,
         gallery_embeddings: np.ndarray | None = None,
         return_distmat: bool = True,
-    ) -> ReidResult:
+    ) -> ReIDResult:
         """Extract embeddings (unless provided) and compute retrieval metrics.
 
         Args:
@@ -86,7 +92,7 @@ class ReidEvaluator:
             return_distmat: Return the distance matrix (set ``False`` to save memory).
 
         Returns:
-            :class:`ReidResult`.
+            :class:`ReIDResult`.
         """
         if query_embeddings is None or gallery_embeddings is None:
             if verbose:
@@ -116,6 +122,7 @@ class ReidEvaluator:
             q_camids=query.camids,
             g_camids=gallery.camids,
             max_rank=max_rank,
+            gallery_junk_pids=gallery.gallery_junk_pids,
         )
 
         if verbose:
@@ -125,9 +132,13 @@ class ReidEvaluator:
             del distmat
             distmat = np.empty((0, 0), dtype=np.float32)
 
-        return ReidResult(
+        return ReIDResult(
             metrics=metrics,
             query_embeddings=q_embs,
             gallery_embeddings=g_embs,
             distmat=distmat,
         )
+
+
+# Backward-compatible alias (notebooks / early API).
+ReidEvaluator = ReIDEvaluator

--- a/src/trackers/core/reid/eval/evaluator.py
+++ b/src/trackers/core/reid/eval/evaluator.py
@@ -9,15 +9,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 import numpy as np
 
 from trackers.core.reid.eval.datasets import ReIDSplit
 from trackers.core.reid.eval.metrics import ReIDMetrics, compute_reid_metrics
-
-if TYPE_CHECKING:
-    from trackers.core.reid.model import ReIDModel
+from trackers.core.reid.protocols import ReIDPathEncoder
 
 
 @dataclass
@@ -35,7 +32,7 @@ ReidResult = ReIDResult
 
 
 def _distance_matrix(q_embs: np.ndarray, g_embs: np.ndarray, metric: str) -> np.ndarray:
-    """Build a query×gallery distance matrix (``cosine`` or ``euclidean``)."""
+    """Build a query x gallery distance matrix (``cosine`` or ``euclidean``)."""
     if metric == "cosine":
         qn = (q_embs / (np.linalg.norm(q_embs, axis=1, keepdims=True) + 1e-12)).astype(np.float32, copy=False)
         gn = (g_embs / (np.linalg.norm(g_embs, axis=1, keepdims=True) + 1e-12)).astype(np.float32, copy=False)
@@ -55,14 +52,15 @@ def _distance_matrix(q_embs: np.ndarray, g_embs: np.ndarray, metric: str) -> np.
 
 
 class ReIDEvaluator:
-    """Run embedding extraction and retrieval metrics for a :class:`ReIDModel`.
+    """Run embedding extraction and retrieval metrics for a Re-ID encoder.
 
     Args:
-        model: Appearance model to evaluate.
+        model: Encoder implementing :class:`~trackers.core.reid.protocols.ReIDPathEncoder`
+            (for example :class:`~trackers.core.reid.model.ReIDModel`).
         batch_size: Images per forward pass.
     """
 
-    def __init__(self, model: ReIDModel, batch_size: int = 64) -> None:
+    def __init__(self, model: ReIDPathEncoder, batch_size: int = 64) -> None:
         if batch_size < 1:
             raise ValueError(f"batch_size must be >= 1, got {batch_size}")
         self._model = model

--- a/src/trackers/core/reid/eval/metrics.py
+++ b/src/trackers/core/reid/eval/metrics.py
@@ -54,7 +54,7 @@ def compute_reid_metrics(
     *,
     gallery_junk_pids: frozenset[int] = frozenset({-1}),
 ) -> ReIDMetrics:
-    """Compute CMC, mAP, and mINP from a query×gallery distance matrix.
+    """Compute CMC, mAP, and mINP from a query x gallery distance matrix.
 
     Excludes same-(pid, camid) gallery matches and gallery junk person IDs
     (``pid in gallery_junk_pids``). Market-1501 gallery distractors use

--- a/src/trackers/core/reid/eval/metrics.py
+++ b/src/trackers/core/reid/eval/metrics.py
@@ -14,25 +14,34 @@ import numpy as np
 
 
 @dataclass
-class ReidMetrics:
+class ReIDMetrics:
     """CMC / mAP / mINP scores (percentages) for one evaluation run."""
 
-    map: float
+    mean_average_precision: float
     rank1: float
     rank5: float
     rank10: float
     minp: float
     num_queries: int
 
+    @property
+    def map(self) -> float:
+        """Backward-compatible alias for :attr:`mean_average_precision`."""
+        return self.mean_average_precision
+
     def __str__(self) -> str:
         return (
-            f"mAP: {self.map:.1f}%  "
+            f"mAP: {self.mean_average_precision:.1f}%  "
             f"Rank-1: {self.rank1:.1f}%  "
             f"Rank-5: {self.rank5:.1f}%  "
             f"Rank-10: {self.rank10:.1f}%  "
             f"mINP: {self.minp:.1f}%  "
             f"(n={self.num_queries})"
         )
+
+
+# Backward-compatible alias (notebooks / early API).
+ReidMetrics = ReIDMetrics
 
 
 def compute_reid_metrics(
@@ -42,10 +51,15 @@ def compute_reid_metrics(
     q_camids: np.ndarray,
     g_camids: np.ndarray,
     max_rank: int = 10,
-) -> ReidMetrics:
+    *,
+    gallery_junk_pids: frozenset[int] = frozenset({-1}),
+) -> ReIDMetrics:
     """Compute CMC, mAP, and mINP from a query×gallery distance matrix.
 
-    Excludes same-(pid, camid) gallery matches and ``pid == -1`` junk items.
+    Excludes same-(pid, camid) gallery matches and gallery junk person IDs
+    (``pid in gallery_junk_pids``). Market-1501 gallery distractors use
+    ``gallery_junk_pids=frozenset({-1, 0})``; datasets where ``pid=0`` is
+    valid should keep the default ``{-1}`` only.
 
     Args:
         distmat: Distance matrix ``(num_queries, num_gallery)`` (lower = closer).
@@ -54,9 +68,10 @@ def compute_reid_metrics(
         q_camids: Query camera IDs.
         g_camids: Gallery camera IDs.
         max_rank: Highest CMC rank to compute.
+        gallery_junk_pids: Gallery person IDs treated as junk during ranking.
 
     Returns:
-        :class:`ReidMetrics` with scores as percentages.
+        :class:`ReIDMetrics` with scores as percentages.
     """
     num_q, num_g = distmat.shape
 
@@ -64,24 +79,26 @@ def compute_reid_metrics(
         raise ValueError("q_pids / q_camids length must match distmat rows.")
     if len(g_pids) != num_g or len(g_camids) != num_g:
         raise ValueError("g_pids / g_camids length must match distmat columns.")
-    if max_rank > num_g:
-        raise ValueError(f"max_rank ({max_rank}) exceeds gallery size ({num_g}).")
+    if max_rank < 1:
+        raise ValueError(f"max_rank must be >= 1, got {max_rank}")
 
     cmc_accumulator = np.zeros(max_rank, dtype=np.float64)
     ap_list: list[float] = []
     inp_list: list[float] = []
 
+    junk_pid_array = np.array(sorted(gallery_junk_pids), dtype=g_pids.dtype) if gallery_junk_pids else np.empty(0)
+
     for q_idx in range(num_q):
         q_pid = q_pids[q_idx]
         q_camid = q_camids[q_idx]
 
-        # Sort gallery indices by ascending distance (closest first).
         order = np.argsort(distmat[q_idx])
         sorted_g_pids = g_pids[order]
         sorted_g_camids = g_camids[order]
 
-        # Junk mask: trivial same-camera matches + Market-1501 distractors.
-        junk = ((sorted_g_pids == q_pid) & (sorted_g_camids == q_camid)) | (sorted_g_pids == -1)
+        junk = (sorted_g_pids == q_pid) & (sorted_g_camids == q_camid)
+        if junk_pid_array.size > 0:
+            junk |= np.isin(sorted_g_pids, junk_pid_array)
         valid = ~junk
 
         sorted_g_pids_valid = sorted_g_pids[valid]
@@ -89,32 +106,40 @@ def compute_reid_metrics(
 
         num_rel = int(matches.sum())
         if num_rel == 0:
-            # No valid positives for this query — skip (happens on corrupted splits).
             continue
 
-        # --- CMC ---
-        # cmc_q[k] = 1 if any correct match in top (k+1).
         cmc_q = np.minimum(matches.cumsum(), 1.0)
-        cmc_accumulator += cmc_q[:max_rank]
+        if len(cmc_q) < max_rank:
+            if len(cmc_q) == 0:
+                continue
+            cmc_q = np.pad(cmc_q, (0, max_rank - len(cmc_q)), constant_values=cmc_q[-1])
+        else:
+            cmc_q = cmc_q[:max_rank]
+        cmc_accumulator += cmc_q
 
-        # --- mAP ---
         num_valid = len(matches)
         precision_at_k = matches.cumsum() / (np.arange(num_valid) + 1)
         ap = float((precision_at_k * matches).sum() / num_rel)
         ap_list.append(ap)
 
-        # --- mINP ---
-        last_true = int(np.where(matches)[0][-1]) + 1  # 1-indexed position
+        last_true = int(np.where(matches)[0][-1]) + 1
         inp_list.append(num_rel / last_true)
 
     n = len(ap_list)
     if n == 0:
-        return ReidMetrics(map=0.0, rank1=0.0, rank5=0.0, rank10=0.0, minp=0.0, num_queries=0)
+        return ReIDMetrics(
+            mean_average_precision=0.0,
+            rank1=0.0,
+            rank5=0.0,
+            rank10=0.0,
+            minp=0.0,
+            num_queries=0,
+        )
 
     cmc = (cmc_accumulator / n) * 100.0
 
-    return ReidMetrics(
-        map=float(np.mean(ap_list)) * 100.0,
+    return ReIDMetrics(
+        mean_average_precision=float(np.mean(ap_list)) * 100.0,
         rank1=float(cmc[0]),
         rank5=float(cmc[min(4, max_rank - 1)]),
         rank10=float(cmc[min(9, max_rank - 1)]),

--- a/src/trackers/core/reid/extraction.py
+++ b/src/trackers/core/reid/extraction.py
@@ -8,17 +8,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 import supervision as sv
 
-if TYPE_CHECKING:
-    from trackers.core.reid.model import ReIDModel
+from trackers.core.reid.protocols import ReIDEncoder
 
 
 def extract_detection_embeddings(
-    model: ReIDModel,
+    model: ReIDEncoder,
     frame: np.ndarray,
     boxes: np.ndarray,
 ) -> np.ndarray:

--- a/src/trackers/core/reid/feature_bank.py
+++ b/src/trackers/core/reid/feature_bank.py
@@ -14,6 +14,10 @@ import numpy as np
 class FeatureBank:
     """EMA-smoothed appearance embedding for a single track.
 
+    Every ingested vector is L2-normalised. Non-finite, zero-norm, or
+    incompatible-shape inputs are ignored: the bank keeps its previous state
+    (or stays uninitialized).
+
     Args:
         alpha: EMA momentum in ``[0, 1]`` (``0.9`` default).
     """
@@ -27,22 +31,48 @@ class FeatureBank:
     @property
     def feature(self) -> np.ndarray | None:
         """Current L2-normalised embedding, or ``None`` if never updated."""
-        return self._feature
+        return None if self._feature is None else self._feature.copy()
 
     @property
     def is_initialized(self) -> bool:
-        """``True`` once at least one embedding has been ingested."""
+        """``True`` once at least one valid embedding has been ingested."""
         return self._feature is not None
 
-    def update(self, embedding: np.ndarray) -> None:
-        """Blend *embedding* into the stored feature (L2-normalised)."""
+    @staticmethod
+    def normalize_embedding(embedding: np.ndarray) -> np.ndarray | None:
+        """Return an L2-normalised 1-D vector, or ``None`` when unusable."""
+        flat = np.asarray(embedding, dtype=np.float64).reshape(-1)
+        if flat.size == 0 or not np.all(np.isfinite(flat)):
+            return None
+        norm = float(np.linalg.norm(flat))
+        if norm < 1e-8:
+            return None
+        return (flat / norm).astype(np.float32)
+
+    def update(self, embedding: np.ndarray) -> bool:
+        """Blend a normalised *embedding* into the stored feature.
+
+        Returns:
+            ``True`` when the bank accepted the vector; ``False`` when the
+            input was skipped (non-finite, zero norm, incompatible shape, etc.).
+        """
+        normalized = self.normalize_embedding(embedding)
+        if normalized is None:
+            return False
+
         if self._feature is None:
-            self._feature = embedding.copy()
-        else:
-            self._feature = self._alpha * self._feature + (1.0 - self._alpha) * embedding
-            norm = float(np.linalg.norm(self._feature))
-            if norm > 1e-8:
-                self._feature /= norm
+            self._feature = normalized.copy()
+            return True
+
+        if self._feature.shape != normalized.shape:
+            return False
+
+        blended = self._alpha * self._feature + (1.0 - self._alpha) * normalized
+        blended_norm = self.normalize_embedding(blended)
+        if blended_norm is None:
+            return False
+        self._feature = blended_norm
+        return True
 
     def reset(self) -> None:
         """Clear the stored feature."""

--- a/src/trackers/core/reid/fusion_methods.py
+++ b/src/trackers/core/reid/fusion_methods.py
@@ -3,38 +3,11 @@
 # Copyright (c) 2026 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-#
-# Adapted from NirAharon/BoT-SORT (MIT)
-# Copyright (c) 2022 Nir Aharon
-# Source: https://github.com/NirAharon/BoT-SORT
-# Reference: tracker/bot_sort.py (ReID appearance–IoU cost fusion)
-# ------------------------------------------------------------------------
 
-"""Appearance–IoU fusion for BoT-SORT ReID association."""
+"""Backward-compatible re-export of BoT-SORT ReID fusion helpers."""
 
 from __future__ import annotations
 
-import numpy as np
+from trackers.core.botsort.fusion import fuse_botsort_reid_association
 
-
-def fuse_botsort_reid_association(
-    iou_similarity_raw: np.ndarray,
-    iou_similarity_fused: np.ndarray,
-    appearance_similarity: np.ndarray,
-    *,
-    proximity_threshold: float,
-    appearance_threshold: float,
-) -> np.ndarray:
-    """Fuse IoU and appearance the way BoT-SORT ``bot_sort.py`` does.
-
-    Computes ``min(score_fused_iou_cost, halved_appearance_cost)`` with
-    proximity and appearance caps, then returns the corresponding similarity
-    matrix (``1 - cost``).
-    """
-    d_iou = 1.0 - iou_similarity_fused
-    d_iou_raw = 1.0 - iou_similarity_raw
-    d_app = 0.5 * (1.0 - appearance_similarity)
-    d_app = np.where(d_app > appearance_threshold, 1.0, d_app)
-    d_app = np.where(d_iou_raw > proximity_threshold, 1.0, d_app)
-    fused_cost = np.minimum(d_iou, d_app)
-    return 1.0 - fused_cost
+__all__ = ["fuse_botsort_reid_association"]

--- a/src/trackers/core/reid/model.py
+++ b/src/trackers/core/reid/model.py
@@ -24,6 +24,7 @@ from trackers.core.reid.models.loaders import load_state_dict_for_architecture, 
 from trackers.core.reid.models.preprocessing import ReIDPreprocessing
 from trackers.core.reid.models.registry import (
     DEFAULT_MODEL,
+    FASTREID_MOT17_SBS50,
     ModelCard,
     default_preprocessing_for_architecture,
     resolve_model_card,
@@ -173,11 +174,13 @@ class ReIDModel:
         if resolved_weights is not None:
             local_path = resolve_weights(resolved_weights)
             arch_name = resolved_arch if isinstance(resolved_arch, str) else ""
+            required_fraction = 1.0 if source in (FASTREID_MOT17_SBS50, DEFAULT_MODEL) else None
             report = load_state_dict_for_architecture(
                 backbone,
                 local_path,
                 resolved_device,
                 arch_name,
+                required_match_fraction=required_fraction,
             )
             logger.info("ReIDModel weights (%s): %s", resolved_weights, report.summary())
 
@@ -235,6 +238,8 @@ class ReIDModel:
         """
         if not image_paths:
             return np.empty((0, 0), dtype=np.float32)
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
 
         all_embeddings: list[np.ndarray] = []
 
@@ -251,7 +256,10 @@ class ReIDModel:
                 embs = self._backbone(batch)
             if normalize:
                 embs = torch.nn.functional.normalize(embs, p=2, dim=1)
-            all_embeddings.append(embs.cpu().numpy().astype(np.float32))
+            batch_np = embs.cpu().numpy().astype(np.float32)
+            from trackers.core.reid.distance import sanitize_embedding_matrix
+
+            all_embeddings.append(sanitize_embedding_matrix(batch_np))
 
         return np.concatenate(all_embeddings, axis=0)
 
@@ -290,4 +298,6 @@ class ReIDModel:
 
         if self._preprocessing.normalize_embeddings:
             embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
-        return embeddings.cpu().numpy().astype(np.float32)
+        from trackers.core.reid.distance import sanitize_embedding_matrix
+
+        return sanitize_embedding_matrix(embeddings.cpu().numpy().astype(np.float32))

--- a/src/trackers/core/reid/model.py
+++ b/src/trackers/core/reid/model.py
@@ -134,6 +134,8 @@ class ReIDModel:
 
         elif source is None:
             # §2.2 step 5: architecture-only; no external weights loaded.
+            if architecture is None:
+                raise ValueError("architecture is required when source is None")
             resolved_arch = architecture
             resolved_weights = None
             resolved_preprocessing = (

--- a/src/trackers/core/reid/models/loaders.py
+++ b/src/trackers/core/reid/models/loaders.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -16,6 +17,7 @@ from dataclasses import dataclass, field
 import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
 from safetensors.torch import load_file
 
 from trackers.core.reid.architectures import checkpoint_remap_for_architecture
@@ -23,10 +25,8 @@ from trackers.core.reid.architectures import checkpoint_remap_for_architecture
 _HF_PREFIX = "hf://"
 _GD_PREFIX = "gd://"
 
-# State-dict key prefixes dropped before matching. Classification heads differ
-# per dataset (num_classes) and are unused at inference — re-ID reads the
-# pre-classifier embedding.
 _DEFAULT_DROP_PREFIXES = ("classifier",)
+_COMMON_KEY_PREFIXES = ("module.", "model.", "encoder.")
 
 
 @dataclass
@@ -75,7 +75,21 @@ def _resolve_hf(source: str) -> str:
     if "@" in repo_id:
         repo_id, revision = repo_id.split("@", 1)
 
-    return hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
+    try:
+        return hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
+    except (HfHubHTTPError, EntryNotFoundError, OSError) as exc:
+        raise RuntimeError(
+            f"Failed to download Hugging Face weights from {source!r} "
+            f"(repo_id={repo_id!r}, filename={filename!r})."
+        ) from exc
+
+
+def _validate_downloaded_file(path: str) -> str:
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Downloaded weights file is missing: {path}")
+    if os.path.getsize(path) < 1:
+        raise OSError(f"Downloaded weights file is empty: {path}")
+    return path
 
 
 def _resolve_gd(source: str) -> str:
@@ -91,15 +105,25 @@ def _resolve_gd(source: str) -> str:
     os.makedirs(cache_dir, exist_ok=True)
     path = os.path.join(cache_dir, filename)
     if os.path.exists(path):
-        return path
+        return _validate_downloaded_file(path)
 
     try:
         import gdown
     except ImportError as exc:
-        raise ImportError("Google Drive weights (gd://...) require gdown. Install with:  pip install gdown") from exc
+        raise ImportError("Google Drive weights (gd://...) require gdown. Install with: pip install gdown") from exc
 
-    gdown.download(id=file_id, output=path, quiet=False)
-    return path
+    fd, tmp_path = tempfile.mkstemp(prefix=f"{filename}.", suffix=".part", dir=cache_dir)
+    os.close(fd)
+    try:
+        gdown.download(id=file_id, output=tmp_path, quiet=False)
+        _validate_downloaded_file(tmp_path)
+        os.replace(tmp_path, path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+    return _validate_downloaded_file(path)
 
 
 def load_state_dict_for_architecture(
@@ -109,16 +133,36 @@ def load_state_dict_for_architecture(
     architecture: str,
     *,
     warn_threshold: float = 0.5,
+    required_match_fraction: float | None = None,
 ) -> KeyReport:
     """Load *path* using the loader appropriate for *architecture*."""
     remap = checkpoint_remap_for_architecture(architecture)
-    return load_state_dict_into(
+    report = load_state_dict_into(
         module,
         path,
         device,
         remap=remap,
         warn_threshold=warn_threshold,
     )
+    if required_match_fraction is not None and report.matched_fraction < required_match_fraction:
+        raise ValueError(
+            f"Checkpoint {path!r} matched only {report.matched_fraction:.0%} of "
+            f"{architecture!r} parameters (required >= {required_match_fraction:.0%}). "
+            f"{report.summary()}"
+        )
+    return report
+
+
+def _strip_common_prefixes(key: str) -> str:
+    stripped = key
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _COMMON_KEY_PREFIXES:
+            if stripped.startswith(prefix):
+                stripped = stripped[len(prefix) :]
+                changed = True
+    return stripped
 
 
 def _read_state_dict(path: str, device: torch.device) -> dict:
@@ -126,10 +170,13 @@ def _read_state_dict(path: str, device: torch.device) -> dict:
     if path.endswith(".safetensors"):
         return load_file(path, device=str(device))
 
-    state_dict = torch.load(path, map_location=device, weights_only=False)
-    # Some checkpoints wrap the tensors in {"state_dict": ...} (or "model").
-    for wrapper_key in ("state_dict", "model"):
-        if isinstance(state_dict, dict) and wrapper_key in state_dict:
+    try:
+        state_dict = torch.load(path, map_location=device, weights_only=True)
+    except TypeError:
+        state_dict = torch.load(path, map_location=device, weights_only=False)
+
+    for wrapper_key in ("state_dict", "model", "encoder"):
+        if isinstance(state_dict, dict) and wrapper_key in state_dict and isinstance(state_dict[wrapper_key], dict):
             state_dict = state_dict[wrapper_key]
             break
     return state_dict
@@ -152,7 +199,7 @@ def load_state_dict_into(
     else:
         cleaned: dict = {}
         for k, v in state_dict.items():
-            key = k[7:] if k.startswith("module.") else k
+            key = _strip_common_prefixes(k)
             if any(key.startswith(p) for p in drop_prefixes):
                 continue
             cleaned[key] = v

--- a/src/trackers/core/reid/models/loaders.py
+++ b/src/trackers/core/reid/models/loaders.py
@@ -79,8 +79,7 @@ def _resolve_hf(source: str) -> str:
         return hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
     except (HfHubHTTPError, EntryNotFoundError, OSError) as exc:
         raise RuntimeError(
-            f"Failed to download Hugging Face weights from {source!r} "
-            f"(repo_id={repo_id!r}, filename={filename!r})."
+            f"Failed to download Hugging Face weights from {source!r} (repo_id={repo_id!r}, filename={filename!r})."
         ) from exc
 
 

--- a/src/trackers/core/reid/models/loaders.py
+++ b/src/trackers/core/reid/models/loaders.py
@@ -79,8 +79,7 @@ def _resolve_hf(source: str) -> str:
         return hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
     except (HfHubHTTPError, EntryNotFoundError, OSError) as exc:
         raise RuntimeError(
-            f"Failed to download Hugging Face weights from {source!r} "
-            f"(repo_id={repo_id!r}, filename={filename!r})."
+            f"Failed to download Hugging Face weights from {source!r} (repo_id={repo_id!r}, filename={filename!r})."
         ) from exc
 
 
@@ -194,10 +193,11 @@ def load_state_dict_into(
     """Load *path* into *module* by name and shape (classifier keys skipped)."""
     state_dict = _read_state_dict(path, device)
 
+    cleaned: dict
     if remap is not None:
         cleaned = remap(state_dict)
     else:
-        cleaned: dict = {}
+        cleaned = {}
         for k, v in state_dict.items():
             key = _strip_common_prefixes(k)
             if any(key.startswith(p) for p in drop_prefixes):

--- a/src/trackers/core/reid/models/preprocessing.py
+++ b/src/trackers/core/reid/models/preprocessing.py
@@ -20,7 +20,7 @@ IMAGENET_MEAN = (0.485, 0.456, 0.406)
 IMAGENET_STD = (0.229, 0.224, 0.225)
 
 # Standard person re-ID input geometry (height, width). OSNet and most backbones
-# train at 256×128; BoT-SORT FastReID SBS uses 384×128 (see registry overrides).
+# train at 256x128; BoT-SORT FastReID SBS uses 384x128 (see registry overrides).
 REID_INPUT_SIZE = (256, 128)
 
 # Gray padding used by YOLO / FastReID letterbox helpers (BoT-SORT ``preprocess()``).
@@ -53,7 +53,7 @@ class ReIDPreprocessing:
         )
 
     def resize_crop(self, crop: np.ndarray) -> np.ndarray:
-        """Resize an ``H×W×C`` crop to :attr:`input_size` using OpenCV.
+        """Resize an ``HxWxC`` crop to :attr:`input_size` using OpenCV.
 
         ``stretch`` matches BoT-SORT ``FastReIDInterface`` inference
         (``cv2.resize`` to ``SIZE_TEST``, aspect ratio not preserved).
@@ -72,8 +72,8 @@ class ReIDPreprocessing:
         if self.resize_mode == "letterbox":
             height, width = crop.shape[:2]
             scale = min(target_h / height, target_w / width)
-            new_w = max(int(round(width * scale)), 1)
-            new_h = max(int(round(height * scale)), 1)
+            new_w = max(round(width * scale), 1)
+            new_h = max(round(height * scale), 1)
             resized = cv2.resize(crop, (new_w, new_h), interpolation=interpolation)
             if crop.ndim == 3:
                 padded = np.full((target_h, target_w, crop.shape[2]), self.pad_value, dtype=crop.dtype)

--- a/src/trackers/core/reid/models/registry.py
+++ b/src/trackers/core/reid/models/registry.py
@@ -43,11 +43,11 @@ _DOMAIN_WARNING = (
 DEFAULT_MODEL = "osnet_x1_0_msmt17_combineall"
 
 # Default preprocessing for registered architectures (bare `.pth` loads, no ModelCard).
-# OSNet variants use 256×128; only non-default geometries are listed explicitly.
+# OSNet variants use 256x128; only non-default geometries are listed explicitly.
 DEFAULT_ARCHITECTURE_PREPROCESSING = ReIDPreprocessing()
 
 _NON_DEFAULT_ARCHITECTURE_PREPROCESSING: dict[str, ReIDPreprocessing] = {
-    # BoT-SORT FastReIDInterface: cv2 stretch to 384×128 (letterbox exists but is commented out upstream).
+    # BoT-SORT FastReIDInterface: cv2 stretch to 384x128 (letterbox exists but is commented out upstream).
     FASTREID_SBS_ARCHITECTURE: ReIDPreprocessing(input_size=(384, 128), resize_mode="stretch"),
 }
 

--- a/src/trackers/core/reid/models/registry.py
+++ b/src/trackers/core/reid/models/registry.py
@@ -13,14 +13,11 @@ import os
 from dataclasses import dataclass
 
 from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
 
 from trackers.core.reid.architectures import list_architectures
 from trackers.core.reid.architectures.fastreid_sbs import FASTREID_SBS_ARCHITECTURE
 from trackers.core.reid.models.preprocessing import ReIDPreprocessing
-
-# ---------------------------------------------------------------------------
-# Default checkpoint URL
-# ---------------------------------------------------------------------------
 
 # OSNet x1.0 trained on MSMT17 with combineall (train + query + gallery).
 # Produces the strongest general-purpose pedestrian features, which is why it
@@ -134,8 +131,8 @@ def resolve_model_card(source: str) -> ModelCard | None:
         if len(parts) == 2:
             try:
                 return _load_hf_repo_config(source)
-            except Exception:
-                return None
+            except (HfHubHTTPError, EntryNotFoundError, OSError, ValueError) as exc:
+                raise RuntimeError(f"Failed to resolve Hugging Face repo config for {source!r}.") from exc
 
     return None
 

--- a/src/trackers/core/reid/protocols.py
+++ b/src/trackers/core/reid/protocols.py
@@ -1,0 +1,48 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Lightweight typing protocols for optional Re-ID integration."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+import numpy as np
+import supervision as sv
+
+
+class ReIDEncoder(Protocol):
+    """Minimal encoder surface for tracker appearance association.
+
+    Any object implementing :meth:`extract_features` may be passed as
+    ``reid_model`` to :class:`~trackers.core.botsort.tracker.BoTSORTTracker`.
+    The concrete :class:`~trackers.core.reid.model.ReIDModel` satisfies this
+    protocol but is not required for tests or custom encoders.
+    """
+
+    def extract_features(self, detections: sv.Detections, frame: np.ndarray) -> np.ndarray:
+        """Return L2-normalised embeddings for each detection box."""
+        ...
+
+
+class ReIDPathEncoder(Protocol):
+    """Minimal encoder surface for dataset / retrieval evaluation.
+
+    :class:`~trackers.core.reid.eval.evaluator.ReIDEvaluator` accepts any object
+    that can embed image paths in batches. :class:`~trackers.core.reid.model.ReIDModel`
+    implements this protocol.
+    """
+
+    def extract_features_from_paths(
+        self,
+        image_paths: Sequence[str],
+        *,
+        batch_size: int = 64,
+        normalize: bool = True,
+    ) -> np.ndarray:
+        """Embed images read from disk."""
+        ...

--- a/src/trackers/scripts/track.py
+++ b/src/trackers/scripts/track.py
@@ -677,9 +677,7 @@ def _apply_reid_tracker_params(
         return params, None
 
     if tracker_id != "botsort":
-        return params, (
-            f"Error: --tracker.reid.* options apply only to --tracker botsort, got {tracker_id!r}."
-        )
+        return params, (f"Error: --tracker.reid.* options apply only to --tracker botsort, got {tracker_id!r}.")
 
     if getattr(args, "source", None) is None:
         return params, (

--- a/src/trackers/scripts/track.py
+++ b/src/trackers/scripts/track.py
@@ -150,6 +150,46 @@ def add_track_subparser(subparsers: argparse._SubParsersAction) -> None:
     # Add dynamic tracker parameters
     _add_tracker_params(tracker_group)
 
+    reid_group = parser.add_argument_group("reid (BoT-SORT only; requires trackers[reid])")
+    reid_group.add_argument(
+        "--tracker.reid.enable",
+        action="store_true",
+        dest="tracker_reid_enable",
+        help="Enable appearance-based ReID association for BoT-SORT.",
+    )
+    reid_group.add_argument(
+        "--tracker.reid.model",
+        type=str,
+        default=None,
+        dest="tracker_reid_model",
+        metavar="SOURCE",
+        help=(
+            "ReID checkpoint source (curated alias, hf:// URL, local path, or "
+            "save_pretrained directory). Implies --tracker.reid.enable. "
+            "Default alias when omitted: osnet_x1_0_msmt17_combineall."
+        ),
+    )
+    reid_group.add_argument(
+        "--tracker.reid.device",
+        type=str,
+        default=DEFAULT_DEVICE,
+        dest="tracker_reid_device",
+        metavar="DEVICE",
+        help=f"ReID compute device: auto, cpu, cuda, mps. Default: {DEFAULT_DEVICE}",
+    )
+    reid_group.add_argument(
+        "--tracker.reid.architecture",
+        type=str,
+        default=None,
+        dest="tracker_reid_architecture",
+        metavar="NAME",
+        help=(
+            "Backbone architecture for bare local .pth/.safetensors weights "
+            "(e.g. osnet_x1_0, fastreid_sbs_resnest50). Required when "
+            "--tracker.reid.model points to a bare weights file."
+        ),
+    )
+
     # Output options
     output_group = parser.add_argument_group("output")
     output_group.add_argument(
@@ -308,8 +348,17 @@ def run_track(args: argparse.Namespace) -> int:
 
     track_id_filter = _resolve_track_id_filter(args.track_ids)
 
+    reid_error = _validate_reid_cli_prerequisites(args)
+    if reid_error is not None:
+        print(reid_error, file=sys.stderr)
+        return 1
+
     # Create tracker
     tracker_params = _extract_tracker_params(args.tracker, args)
+    tracker_params, reid_error = _apply_reid_tracker_params(args.tracker, args, tracker_params)
+    if reid_error is not None:
+        print(reid_error, file=sys.stderr)
+        return 1
     tracker = _init_tracker(args.tracker, **tracker_params)
 
     if args.source is not None:
@@ -363,7 +412,7 @@ def _run_frameless(
                     mask = np.isin(detections.class_id, class_filter)
                     detections = detections[mask]  # type: ignore[assignment]
 
-                tracked = tracker.update(detections)
+                tracked = tracker.update(detections, frame=None)
 
                 if track_id_filter is not None and len(tracked) > 0:
                     if tracked.tracker_id is not None:
@@ -598,6 +647,80 @@ def _run_model(model: AnyModel, frame: np.ndarray, confidence: float) -> sv.Dete
         detections = detections[mask]
 
     return detections
+
+
+def _reid_requested(args: argparse.Namespace) -> bool:
+    return bool(getattr(args, "tracker_reid_enable", False)) or getattr(args, "tracker_reid_model", None) is not None
+
+
+def _validate_reid_cli_prerequisites(args: argparse.Namespace) -> str | None:
+    """Validate ReID CLI options before loading any checkpoint."""
+    if not _reid_requested(args):
+        return None
+    if args.tracker != "botsort":
+        return f"Error: --tracker.reid.* options apply only to --tracker botsort, got {args.tracker!r}."
+    if args.source is None:
+        return (
+            "Error: ReID-enabled BoT-SORT requires --source (video/webcam/images) "
+            "so appearance embeddings can be extracted from frames."
+        )
+    return None
+
+
+def _apply_reid_tracker_params(
+    tracker_id: str,
+    args: argparse.Namespace,
+    params: dict[str, object],
+) -> tuple[dict[str, object], str | None]:
+    """Attach a CLI-instantiated ReID model to BoT-SORT tracker params."""
+    if not _reid_requested(args):
+        return params, None
+
+    if tracker_id != "botsort":
+        return params, (
+            f"Error: --tracker.reid.* options apply only to --tracker botsort, got {tracker_id!r}."
+        )
+
+    if getattr(args, "source", None) is None:
+        return params, (
+            "Error: ReID-enabled BoT-SORT requires --source (video/webcam/images) "
+            "so appearance embeddings can be extracted from frames."
+        )
+
+    try:
+        from trackers.core.reid._lazy import load_reid_model_class
+
+        reid_model_cls = load_reid_model_class()
+    except ImportError:
+        return params, (
+            "Error: ReID tracking requires the optional `trackers[reid]` extra.\n"
+            "Install with: pip install 'trackers[reid]'"
+        )
+
+    device = getattr(args, "tracker_reid_device", DEFAULT_DEVICE)
+    model_source = getattr(args, "tracker_reid_model", None)
+    architecture = getattr(args, "tracker_reid_architecture", None)
+    load_kwargs: dict[str, object] = {"device": device}
+    if model_source is not None:
+        load_kwargs["source"] = model_source
+    if architecture is not None:
+        load_kwargs["architecture"] = architecture
+
+    try:
+        reid_model = reid_model_cls.from_pretrained(**load_kwargs)
+    except KeyboardInterrupt:
+        raise
+    except ImportError:
+        return params, (
+            "Error: ReID tracking requires the optional `trackers[reid]` extra.\n"
+            "Install with: pip install 'trackers[reid]'"
+        )
+    except (OSError, ValueError, RuntimeError) as exc:
+        return params, f"Error: Failed to load ReID model: {exc}"
+
+    params = dict(params)
+    params["reid_model"] = reid_model
+    return params, None
 
 
 def _extract_tracker_params(tracker_id: str, args: argparse.Namespace) -> dict[str, object]:

--- a/tests/core/reid/test_eval_datasets.py
+++ b/tests/core/reid/test_eval_datasets.py
@@ -8,9 +8,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import numpy as np
-import pytest
-
 from trackers.core.reid.eval.datasets import (
     MARKET1501_GALLERY_JUNK_PIDS,
     ReIDSplit,

--- a/tests/core/reid/test_eval_datasets.py
+++ b/tests/core/reid/test_eval_datasets.py
@@ -1,0 +1,67 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from trackers.core.reid.eval.datasets import (
+    MARKET1501_GALLERY_JUNK_PIDS,
+    ReIDSplit,
+    _parse_market_filename,
+    _parse_msmt17_camid,
+    load_market1501,
+    load_msmt17,
+)
+
+
+class TestMarket1501Loader:
+    def test_parse_market_filename(self) -> None:
+        assert _parse_market_filename("0001_c1s1_001051_00.jpg") == (1, 0)
+        assert _parse_market_filename("0000_c1s1_000151_01.jpg") == (0, 0)
+        assert _parse_market_filename("-1_c1s1_000151_01.jpg") == (-1, 0)
+
+    def test_load_market1501_from_temp_tree(self, tmp_path: Path) -> None:
+        query_dir = tmp_path / "query"
+        gallery_dir = tmp_path / "bounding_box_test"
+        query_dir.mkdir()
+        gallery_dir.mkdir()
+        (query_dir / "0001_c1s1_001051_00.jpg").write_bytes(b"jpeg")
+        (gallery_dir / "0000_c1s1_000151_01.jpg").write_bytes(b"jpeg")
+        (gallery_dir / "0002_c2s1_000851_01.jpg").write_bytes(b"jpeg")
+
+        query, gallery = load_market1501(tmp_path)
+        assert len(query) == 1
+        assert query.pids.tolist() == [1]
+        assert gallery.pids.tolist() == [0, 2]
+        assert gallery.gallery_junk_pids == MARKET1501_GALLERY_JUNK_PIDS
+
+
+class TestMSMT17Loader:
+    def test_parse_msmt17_camid(self) -> None:
+        assert _parse_msmt17_camid("0001_019_07_0303morning_0020_1.jpg") == 6
+
+    def test_load_msmt17_from_temp_lists(self, tmp_path: Path) -> None:
+        test_root = tmp_path / "test"
+        test_root.mkdir()
+        rel = "0001/0001_019_07_0303morning_0020_1.jpg"
+        image_path = test_root / rel
+        image_path.parent.mkdir(parents=True)
+        image_path.write_bytes(b"jpeg")
+
+        (tmp_path / "list_query.txt").write_text(f"{rel} 42\n")
+        (tmp_path / "list_gallery.txt").write_text(f"{rel} 42 6\n")
+
+        query, gallery = load_msmt17(tmp_path)
+        assert isinstance(query, ReIDSplit)
+        assert query.pids.tolist() == [42]
+        assert query.camids.tolist() == [6]
+        assert gallery.pids.tolist() == [42]
+        assert gallery.camids.tolist() == [6]
+        assert gallery.gallery_junk_pids == frozenset({-1})

--- a/tests/core/reid/test_eval_metrics.py
+++ b/tests/core/reid/test_eval_metrics.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import numpy as np
 import pytest
 
@@ -92,7 +94,7 @@ class TestComputeReidMetrics:
         g_embs = np.ones((2, 4), dtype=np.float32)
 
         class _StubModel:
-            def extract_features_from_paths(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            def extract_features_from_paths(self, *args, **kwargs):
                 raise AssertionError("should not be called")
 
         ReIDEvaluator(_StubModel()).evaluate(
@@ -112,7 +114,14 @@ class TestComputeReidMetrics:
 
     def test_evaluator_rejects_invalid_batch_size(self) -> None:
         class _StubModel:
-            pass
+            def extract_features_from_paths(
+                self,
+                image_paths: Sequence[str],
+                *,
+                batch_size: int = 64,
+                normalize: bool = True,
+            ) -> np.ndarray:
+                raise NotImplementedError
 
         with pytest.raises(ValueError, match="batch_size"):
             ReIDEvaluator(_StubModel(), batch_size=0)

--- a/tests/core/reid/test_eval_metrics.py
+++ b/tests/core/reid/test_eval_metrics.py
@@ -1,0 +1,118 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from trackers.core.reid.eval.datasets import MARKET1501_GALLERY_JUNK_PIDS, ReIDSplit
+from trackers.core.reid.eval.evaluator import ReIDEvaluator
+from trackers.core.reid.eval.metrics import compute_reid_metrics
+
+
+def _split(
+    q_pid: int,
+    g_pids: list[int],
+    *,
+    gallery_junk_pids: frozenset[int] = frozenset({-1}),
+) -> tuple[ReIDSplit, ReIDSplit]:
+    query = ReIDSplit(
+        image_paths=["q.jpg"],
+        pids=np.array([q_pid], dtype=np.int32),
+        camids=np.array([0], dtype=np.int32),
+        gallery_junk_pids=frozenset({-1}),
+    )
+    gallery = ReIDSplit(
+        image_paths=[f"g{i}.jpg" for i in range(len(g_pids))],
+        pids=np.array(g_pids, dtype=np.int32),
+        camids=np.zeros(len(g_pids), dtype=np.int32),
+        gallery_junk_pids=gallery_junk_pids,
+    )
+    return query, gallery
+
+
+class TestComputeReidMetrics:
+    def test_market1501_pid_zero_is_junk_in_gallery(self) -> None:
+        distmat = np.array([[0.1, 0.2, 0.3]], dtype=np.float32)
+        metrics = compute_reid_metrics(
+            distmat,
+            q_pids=np.array([1]),
+            g_pids=np.array([0, 1, 2]),
+            q_camids=np.array([0]),
+            g_camids=np.array([0, 1, 0]),
+            max_rank=3,
+            gallery_junk_pids=MARKET1501_GALLERY_JUNK_PIDS,
+        )
+        assert metrics.rank1 == pytest.approx(100.0)
+
+    def test_pid_zero_valid_when_not_marked_junk(self) -> None:
+        distmat = np.array([[0.2, 0.1]], dtype=np.float32)
+        metrics = compute_reid_metrics(
+            distmat,
+            q_pids=np.array([0]),
+            g_pids=np.array([1, 0]),
+            q_camids=np.array([0]),
+            g_camids=np.array([0, 1]),
+            max_rank=2,
+            gallery_junk_pids=frozenset({-1}),
+        )
+        assert metrics.rank1 == pytest.approx(100.0)
+
+    def test_cmc_pads_when_valid_gallery_shorter_than_max_rank(self) -> None:
+        distmat = np.array([[0.2, 0.1]], dtype=np.float32)
+        metrics = compute_reid_metrics(
+            distmat,
+            q_pids=np.array([3]),
+            g_pids=np.array([3, 8]),
+            q_camids=np.array([0]),
+            g_camids=np.array([1, 0]),
+            max_rank=5,
+        )
+        assert metrics.rank1 == pytest.approx(0.0)
+        assert metrics.rank5 == pytest.approx(100.0)
+        assert metrics.rank10 == pytest.approx(100.0)
+
+    def test_evaluator_passes_gallery_junk_pids(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict = {}
+
+        def _fake_metrics(**kwargs):  # type: ignore[no-untyped-def]
+            captured.update(kwargs)
+            from trackers.core.reid.eval.metrics import ReIDMetrics
+
+            return ReIDMetrics(0.0, 0.0, 0.0, 0.0, 0.0, 1)
+
+        monkeypatch.setattr("trackers.core.reid.eval.evaluator.compute_reid_metrics", _fake_metrics)
+
+        query, gallery = _split(1, [0, 1], gallery_junk_pids=MARKET1501_GALLERY_JUNK_PIDS)
+        q_embs = np.ones((1, 4), dtype=np.float32)
+        g_embs = np.ones((2, 4), dtype=np.float32)
+
+        class _StubModel:
+            def extract_features_from_paths(self, *args, **kwargs):  # noqa: ANN002, ANN003
+                raise AssertionError("should not be called")
+
+        ReIDEvaluator(_StubModel()).evaluate(
+            query,
+            gallery,
+            query_embeddings=q_embs,
+            gallery_embeddings=g_embs,
+            verbose=False,
+        )
+        assert captured["gallery_junk_pids"] == MARKET1501_GALLERY_JUNK_PIDS
+
+    def test_reid_metrics_map_alias(self) -> None:
+        from trackers.core.reid.eval.metrics import ReIDMetrics
+
+        metrics = ReIDMetrics(mean_average_precision=42.0, rank1=1.0, rank5=2.0, rank10=3.0, minp=4.0, num_queries=1)
+        assert metrics.map == pytest.approx(42.0)
+
+    def test_evaluator_rejects_invalid_batch_size(self) -> None:
+        class _StubModel:
+            pass
+
+        with pytest.raises(ValueError, match="batch_size"):
+            ReIDEvaluator(_StubModel(), batch_size=0)

--- a/tests/core/reid/test_eval_metrics.py
+++ b/tests/core/reid/test_eval_metrics.py
@@ -92,7 +92,7 @@ class TestComputeReidMetrics:
         g_embs = np.ones((2, 4), dtype=np.float32)
 
         class _StubModel:
-            def extract_features_from_paths(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            def extract_features_from_paths(self, *args, **kwargs):
                 raise AssertionError("should not be called")
 
         ReIDEvaluator(_StubModel()).evaluate(

--- a/tests/core/reid/test_fastreid_integration.py
+++ b/tests/core/reid/test_fastreid_integration.py
@@ -1,0 +1,27 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.network
+def test_fastreid_mot17_alias_loads_with_finite_normalized_output() -> None:
+    pytest.importorskip("torch")
+    import numpy as np
+    import supervision as sv
+
+    from trackers.core.reid.model import ReIDModel
+
+    model = ReIDModel.from_pretrained("fastreid_mot17_sbs50", device="cpu")
+    frame = np.zeros((384, 128, 3), dtype=np.uint8)
+    dets = sv.Detections(xyxy=np.array([[0.0, 0.0, 128.0, 384.0]], dtype=np.float32))
+    embs = model.extract_features(dets, frame)
+    assert embs.shape == (1, 2048)
+    assert np.isfinite(embs).all()
+    np.testing.assert_allclose(np.linalg.norm(embs, axis=1), 1.0, atol=1e-4)
+    assert model.preprocessing.input_size == (384, 128)

--- a/tests/core/reid/test_feature_bank.py
+++ b/tests/core/reid/test_feature_bank.py
@@ -1,0 +1,70 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from trackers.core.reid.distance import appearance_similarity, sanitize_embedding_matrix
+from trackers.core.reid.feature_bank import FeatureBank
+
+
+class TestFeatureBank:
+    def test_first_update_normalizes(self) -> None:
+        bank = FeatureBank(alpha=0.9)
+        assert bank.update(np.array([3.0, 4.0], dtype=np.float32))
+        feature = bank.feature
+        assert feature is not None
+        np.testing.assert_allclose(np.linalg.norm(feature), 1.0, atol=1e-6)
+
+    def test_zero_norm_embedding_is_skipped(self) -> None:
+        bank = FeatureBank()
+        assert bank.update(np.zeros(8, dtype=np.float32)) is False
+        assert not bank.is_initialized
+
+    def test_non_finite_embedding_is_skipped(self) -> None:
+        bank = FeatureBank()
+        assert bank.update(np.array([1.0, np.nan], dtype=np.float32)) is False
+        assert not bank.is_initialized
+
+    def test_shape_change_is_rejected_and_state_preserved(self) -> None:
+        bank = FeatureBank()
+        bank.update(np.array([1.0, 0.0], dtype=np.float32))
+        before = bank.feature
+        assert before is not None
+        assert bank.update(np.array([1.0, 0.0, 0.0], dtype=np.float32)) is False
+        after = bank.feature
+        assert after is not None
+        assert after.shape == before.shape
+        np.testing.assert_allclose(before, after)
+
+    def test_reset_clears_state(self) -> None:
+        bank = FeatureBank()
+        bank.update(np.array([1.0, 0.0], dtype=np.float32))
+        bank.reset()
+        assert not bank.is_initialized
+
+
+class TestAppearanceSimilarity:
+    def test_non_finite_detection_rows_are_sanitized(self) -> None:
+        track_feats = [np.array([1.0, 0.0], dtype=np.float32)]
+        det_embeddings = np.array([[1.0, 0.0], [np.nan, 1.0]], dtype=np.float32)
+        sim = appearance_similarity(track_feats, det_embeddings)
+        assert np.isfinite(sim).all()
+        assert sim[0, 0] == pytest.approx(1.0)
+        assert sim[0, 1] == pytest.approx(0.0)
+
+    def test_rejects_non_2d_detection_matrix(self) -> None:
+        with pytest.raises(ValueError, match="2-D"):
+            sanitize_embedding_matrix(np.array([1.0, 0.0], dtype=np.float32))
+
+    def test_skips_incompatible_track_dimensions(self) -> None:
+        track_feats = [np.array([1.0, 0.0, 0.0], dtype=np.float32)]
+        det_embeddings = np.array([[1.0, 0.0]], dtype=np.float32)
+        sim = appearance_similarity(track_feats, det_embeddings)
+        assert sim.shape == (1, 1)
+        assert sim[0, 0] == pytest.approx(0.0)

--- a/tests/core/reid/test_reid.py
+++ b/tests/core/reid/test_reid.py
@@ -202,6 +202,33 @@ class TestLoaders:
         finally:
             os.unlink(tmp_path)
 
+    def test_generic_loader_preserves_backbone_prefix(self) -> None:
+        pytest.importorskip("torch")
+        import torch
+        import torch.nn as nn
+
+        from trackers.core.reid.models.loaders import load_state_dict_into
+
+        class _BackboneModel(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.backbone = nn.Linear(4, 2)
+
+        model = _BackboneModel()
+        wrapped = {
+            "backbone.weight": model.backbone.weight.detach().clone(),
+            "backbone.bias": model.backbone.bias.detach().clone(),
+        }
+        with tempfile.NamedTemporaryFile(suffix=".pth", delete=False) as f:
+            tmp_path = f.name
+        try:
+            torch.save(wrapped, tmp_path)
+            report = load_state_dict_into(model, tmp_path, torch.device("cpu"))
+            assert report.matched == report.total
+            assert report.matched_fraction == 1.0
+        finally:
+            os.unlink(tmp_path)
+
     def test_remap_fastreid_sbs_keys(self) -> None:
         pytest.importorskip("torch")
         import torch

--- a/tests/core/reid/test_reid.py
+++ b/tests/core/reid/test_reid.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -284,12 +285,15 @@ class TestLoaders:
         import torch
 
         from trackers.core.reid.architectures import build_architecture
-        from trackers.core.reid.architectures.fastreid_sbs import FASTREID_SBS_ARCHITECTURE
+        from trackers.core.reid.architectures.fastreid_sbs import (
+            FASTREID_SBS_ARCHITECTURE,
+            FastReIDSBSResNeSt50,
+        )
         from trackers.core.reid.models.loaders import load_state_dict_for_architecture
 
         mot17_gem_p = 1.7194522619247437  # heads.pool_layer.p in mot17_sbs_S50.pth
 
-        model = build_architecture(FASTREID_SBS_ARCHITECTURE)
+        model = cast(FastReIDSBSResNeSt50, build_architecture(FASTREID_SBS_ARCHITECTURE))
         assert model.pool.p.item() == pytest.approx(3.0)
 
         wrapped: dict = {"heads.pool_layer.p": torch.tensor([mot17_gem_p])}
@@ -317,10 +321,13 @@ class TestLoaders:
         import torch.nn as nn
 
         from trackers.core.reid.architectures import build_architecture
-        from trackers.core.reid.architectures.fastreid_sbs import FASTREID_SBS_ARCHITECTURE
+        from trackers.core.reid.architectures.fastreid_sbs import (
+            FASTREID_SBS_ARCHITECTURE,
+            FastReIDSBSResNeSt50,
+        )
 
-        model = build_architecture(FASTREID_SBS_ARCHITECTURE)
-        block = model.backbone.layer4[0]
+        model = cast(FastReIDSBSResNeSt50, build_architecture(FASTREID_SBS_ARCHITECTURE))
+        block = cast(Any, cast(Any, model.backbone).layer4[0])
         assert isinstance(block.downsample[0], nn.AvgPool2d)
         assert block.downsample[0].kernel_size == (1, 1) or block.downsample[0].kernel_size == 1
         assert block.downsample[0].stride == (1, 1) or block.downsample[0].stride == 1

--- a/tests/core/test_botsort_reid_e2e.py
+++ b/tests/core/test_botsort_reid_e2e.py
@@ -1,0 +1,208 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import pytest
+import supervision as sv
+
+from trackers.core.botsort.tracker import BoTSORTTracker
+from trackers.scripts.track import _apply_reid_tracker_params, add_track_subparser
+
+
+def _frame(seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.integers(0, 255, (128, 128, 3), dtype=np.uint8)
+
+
+def _det(xyxy: tuple[float, float, float, float], conf: float = 0.9) -> sv.Detections:
+    return sv.Detections(
+        xyxy=np.array([xyxy], dtype=np.float32),
+        confidence=np.array([conf], dtype=np.float32),
+    )
+
+
+def _norm(vec: np.ndarray) -> np.ndarray:
+    vec = vec.astype(np.float32)
+    return vec / np.linalg.norm(vec)
+
+
+class _KeyedReIDEncoder:
+    """Return fixed embeddings keyed by detection top-left corner."""
+
+    def __init__(self, table: dict[tuple[int, int], np.ndarray]) -> None:
+        self.table = table
+        self.calls = 0
+
+    def extract_features(self, detections: sv.Detections, frame: np.ndarray) -> np.ndarray:
+        self.calls += 1
+        if len(detections) == 0:
+            return np.empty((0, 0), dtype=np.float32)
+        rows = []
+        for box in detections.xyxy:
+            key = (int(round(float(box[0]))), int(round(float(box[1]))))
+            rows.append(self.table.get(key, _norm(np.array([float(box[0]), float(box[1]), 1.0, 0.0]))))
+        return np.stack(rows)
+
+
+class TestBoTSORTReIDE2E:
+    def test_requires_frame_when_reid_enabled(self) -> None:
+        tracker = BoTSORTTracker(enable_cmc=False, reid_model=_KeyedReIDEncoder({}))
+        with pytest.raises(ValueError, match="requires frame"):
+            tracker.update(_det((10.0, 10.0, 30.0, 30.0)))
+
+    def test_feature_bank_initializes_on_spawn(self) -> None:
+        model = _KeyedReIDEncoder({})
+        tracker = BoTSORTTracker(enable_cmc=False, reid_model=model)
+        frame = _frame()
+        tracker.update(_det((10.0, 10.0, 30.0, 30.0)), frame=frame)
+        bank = tracker.tracks[0].feature_bank
+        assert bank is not None and bank.is_initialized
+
+    def test_appearance_changes_assignment_vs_geometry_only(self) -> None:
+        """Near-equal IoU: ReID keeps the appearance match; geometry-only takes max IoU."""
+        identity = _norm(np.array([1.0, 0.0, 0.0, 0.0]))
+        impostor = _norm(np.array([0.0, 1.0, 0.0, 0.0]))
+
+        class _PhaseEncoder:
+            phase = 1
+
+            def extract_features(self, detections: sv.Detections, frame: np.ndarray) -> np.ndarray:
+                rows = []
+                for box in detections.xyxy:
+                    x1 = int(round(float(box[0])))
+                    y1 = int(round(float(box[1])))
+                    if self.phase == 1:
+                        rows.append(identity)
+                    elif (x1, y1) == (10, 10):
+                        rows.append(impostor)
+                    elif (x1, y1) == (14, 14):
+                        rows.append(identity)
+                return np.stack(rows)
+
+        encoder = _PhaseEncoder()
+        frame = _frame(1)
+        shared = dict(
+            enable_cmc=False,
+            minimum_iou_threshold_first_assoc=0.01,
+            appearance_threshold=0.6,
+            proximity_threshold=0.99,
+        )
+
+        geo = BoTSORTTracker(**shared)
+        geo.update(_det((10.0, 10.0, 30.0, 30.0)), frame=frame)
+
+        reid = BoTSORTTracker(**shared, reid_model=encoder)
+        reid.update(_det((10.0, 10.0, 30.0, 30.0)), frame=frame)
+        track_id = int(reid.tracks[0].tracker_id)
+
+        competitors = sv.Detections(
+            xyxy=np.array(
+                [
+                    [10.0, 10.0, 30.0, 30.0],
+                    [14.0, 14.0, 34.0, 34.0],
+                ],
+                dtype=np.float32,
+            ),
+            confidence=np.array([0.9, 0.9], dtype=np.float32),
+        )
+
+        encoder.phase = 2
+        geo_out = geo.update(competitors, frame=frame)
+        reid_out = reid.update(competitors, frame=frame)
+
+        def _matched_top_left(out: sv.Detections, tid: int) -> tuple[float, float]:
+            mask = out.tracker_id == tid
+            assert mask.any(), f"track {tid} not found in output"
+            box = out.xyxy[mask][0]
+            return float(box[0]), float(box[1])
+
+        assert _matched_top_left(geo_out, int(geo.tracks[0].tracker_id)) == (10.0, 10.0)
+        assert _matched_top_left(reid_out, track_id) == (14.0, 14.0)
+
+    def test_lost_track_recovers_with_appearance(self) -> None:
+        identity = _norm(np.array([1.0, 0.0, 0.0, 0.0]))
+        table = {(10, 10): identity, (12, 12): identity}
+        frame = _frame(2)
+        tracker = BoTSORTTracker(
+            enable_cmc=False,
+            reid_model=_KeyedReIDEncoder(table),
+            minimum_iou_threshold_first_assoc=0.01,
+            proximity_threshold=0.99,
+        )
+        first = tracker.update(_det((10.0, 10.0, 30.0, 30.0)), frame=frame)
+        track_id = int(first.tracker_id[0])
+
+        tracker.update(sv.Detections.empty(), frame=frame)
+        assert any(t.tracker_id == track_id for t in tracker.tracks)
+
+        recovered = tracker.update(_det((12.0, 12.0, 32.0, 32.0)), frame=frame)
+        assert track_id in recovered.tracker_id.tolist()
+
+    def test_no_reid_parity_unchanged(self) -> None:
+        boxes = sv.Detections(
+            xyxy=np.array([[10.0, 10.0, 40.0, 40.0], [100.0, 100.0, 130.0, 130.0]], dtype=np.float32),
+            confidence=np.array([0.9, 0.9], dtype=np.float32),
+        )
+        frame = _frame(3)
+        baseline = BoTSORTTracker(enable_cmc=False)
+        reid_off = BoTSORTTracker(enable_cmc=False, reid_model=None)
+        np.testing.assert_array_equal(
+            baseline.update(boxes, frame=frame).tracker_id,
+            reid_off.update(boxes, frame=frame).tracker_id,
+        )
+
+    def test_low_confidence_stage_does_not_update_feature_bank(self) -> None:
+        model = _KeyedReIDEncoder({(10, 10): _norm(np.array([1.0, 0.0, 0.0, 0.0]))})
+        tracker = BoTSORTTracker(
+            enable_cmc=False,
+            reid_model=model,
+            high_conf_det_threshold=0.8,
+            minimum_iou_threshold_second_assoc=0.01,
+        )
+        frame = _frame(4)
+        tracker.update(_det((10.0, 10.0, 30.0, 30.0)), frame=frame)
+        bank = tracker.tracks[0].feature_bank
+        assert bank is not None
+        before = bank.feature
+        assert before is not None
+
+        calls_after_high = model.calls
+        tracker.update(_det((12.0, 12.0, 32.0, 32.0), conf=0.5), frame=frame)
+        assert model.calls == calls_after_high
+        after = bank.feature
+        assert after is not None
+        np.testing.assert_allclose(before, after)
+
+    def test_reset_clears_tracks(self) -> None:
+        tracker = BoTSORTTracker(enable_cmc=False, reid_model=_KeyedReIDEncoder({}))
+        tracker.update(_det((10.0, 10.0, 30.0, 30.0)), frame=_frame(5))
+        tracker.reset()
+        assert tracker.tracks == []
+
+
+class TestTrackCLIReID:
+    def test_help_lists_reid_flags(self) -> None:
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        add_track_subparser(subparsers)
+        help_text = subparsers.choices["track"].format_help()
+        assert "--tracker.reid.enable" in help_text
+        assert "--tracker.reid.model" in help_text
+        assert "--tracker.reid.architecture" in help_text
+
+    def test_apply_reid_rejects_non_botsort_tracker(self) -> None:
+        args = argparse.Namespace(
+            tracker_reid_enable=True,
+            tracker_reid_model=None,
+            tracker_reid_device="cpu",
+            tracker_reid_architecture=None,
+        )
+        _, error = _apply_reid_tracker_params("bytetrack", args, {})
+        assert error is not None and "botsort" in error

--- a/tests/core/test_botsort_reid_e2e.py
+++ b/tests/core/test_botsort_reid_e2e.py
@@ -46,7 +46,7 @@ class _KeyedReIDEncoder:
             return np.empty((0, 0), dtype=np.float32)
         rows = []
         for box in detections.xyxy:
-            key = (int(round(float(box[0]))), int(round(float(box[1]))))
+            key = (round(float(box[0])), round(float(box[1])))
             rows.append(self.table.get(key, _norm(np.array([float(box[0]), float(box[1]), 1.0, 0.0]))))
         return np.stack(rows)
 
@@ -76,8 +76,8 @@ class TestBoTSORTReIDE2E:
             def extract_features(self, detections: sv.Detections, frame: np.ndarray) -> np.ndarray:
                 rows = []
                 for box in detections.xyxy:
-                    x1 = int(round(float(box[0])))
-                    y1 = int(round(float(box[1])))
+                    x1 = round(float(box[0]))
+                    y1 = round(float(box[1]))
                     if self.phase == 1:
                         rows.append(identity)
                     elif (x1, y1) == (10, 10):
@@ -88,17 +88,22 @@ class TestBoTSORTReIDE2E:
 
         encoder = _PhaseEncoder()
         frame = _frame(1)
-        shared = dict(
+
+        geo = BoTSORTTracker(
             enable_cmc=False,
             minimum_iou_threshold_first_assoc=0.01,
             appearance_threshold=0.6,
             proximity_threshold=0.99,
         )
-
-        geo = BoTSORTTracker(**shared)
         geo.update(_det((10.0, 10.0, 30.0, 30.0)), frame=frame)
 
-        reid = BoTSORTTracker(**shared, reid_model=encoder)
+        reid = BoTSORTTracker(
+            enable_cmc=False,
+            minimum_iou_threshold_first_assoc=0.01,
+            appearance_threshold=0.6,
+            proximity_threshold=0.99,
+            reid_model=encoder,
+        )
         reid.update(_det((10.0, 10.0, 30.0, 30.0)), frame=frame)
         track_id = int(reid.tracks[0].tracker_id)
 
@@ -118,7 +123,9 @@ class TestBoTSORTReIDE2E:
         reid_out = reid.update(competitors, frame=frame)
 
         def _matched_top_left(out: sv.Detections, tid: int) -> tuple[float, float]:
-            mask = out.tracker_id == tid
+            tracker_ids = out.tracker_id
+            assert tracker_ids is not None
+            mask = tracker_ids == tid
             assert mask.any(), f"track {tid} not found in output"
             box = out.xyxy[mask][0]
             return float(box[0]), float(box[1])
@@ -137,13 +144,17 @@ class TestBoTSORTReIDE2E:
             proximity_threshold=0.99,
         )
         first = tracker.update(_det((10.0, 10.0, 30.0, 30.0)), frame=frame)
-        track_id = int(first.tracker_id[0])
+        first_ids = first.tracker_id
+        assert first_ids is not None
+        track_id = int(first_ids[0])
 
         tracker.update(sv.Detections.empty(), frame=frame)
         assert any(t.tracker_id == track_id for t in tracker.tracks)
 
         recovered = tracker.update(_det((12.0, 12.0, 32.0, 32.0)), frame=frame)
-        assert track_id in recovered.tracker_id.tolist()
+        recovered_ids = recovered.tracker_id
+        assert recovered_ids is not None
+        assert track_id in recovered_ids.tolist()
 
     def test_no_reid_parity_unchanged(self) -> None:
         boxes = sv.Detections(

--- a/tests/core/test_import_isolation.py
+++ b/tests/core/test_import_isolation.py
@@ -33,13 +33,7 @@ def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
 
 def test_base_package_import_without_reid_extra() -> None:
     """Fresh process: base `import trackers` works with ReID heavy modules blocked."""
-    code = (
-        "import sys; "
-        f"{_block_modules_stmt()}; "
-        "import trackers; "
-        "assert trackers.BoTSORTTracker; "
-        "print('ok')"
-    )
+    code = f"import sys; {_block_modules_stmt()}; import trackers; assert trackers.BoTSORTTracker; print('ok')"
     result = _run_isolated(code)
     assert result.returncode == 0, result.stderr or result.stdout
 

--- a/tests/core/test_import_isolation.py
+++ b/tests/core/test_import_isolation.py
@@ -1,0 +1,104 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# ReID-only heavy deps. PIL is intentionally excluded: supervision (base dep) imports it.
+_REID_HEAVY_MODULES = ("torch", "torchvision", "timm", "huggingface_hub", "safetensors", "gdown")
+
+
+def _block_modules_stmt() -> str:
+    return "; ".join(f"sys.modules[{name!r}] = None" for name in _REID_HEAVY_MODULES)
+
+
+def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+        env=os.environ.copy(),
+    )
+
+
+def test_base_package_import_without_reid_extra() -> None:
+    """Fresh process: base `import trackers` works with ReID heavy modules blocked."""
+    code = (
+        "import sys; "
+        f"{_block_modules_stmt()}; "
+        "import trackers; "
+        "assert trackers.BoTSORTTracker; "
+        "print('ok')"
+    )
+    result = _run_isolated(code)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_reid_package_import_without_heavy_modules() -> None:
+    """Fresh process: `import trackers.core.reid` stays numpy-only."""
+    code = (
+        "import sys; "
+        f"{_block_modules_stmt()}; "
+        "import importlib; "
+        "reid = importlib.import_module('trackers.core.reid'); "
+        "assert reid.FeatureBank; "
+        "assert reid.compute_reid_metrics; "
+        "assert sys.modules.get('torch') is None; "
+        "print('ok')"
+    )
+    result = _run_isolated(code)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_botsort_spawn_track_without_heavy_modules() -> None:
+    """Fresh process: BoTSORT update + track spawn without loading ReID model code."""
+    code = (
+        "import sys\n"
+        f"{_block_modules_stmt()}\n"
+        "before = set(sys.modules)\n"
+        "import numpy as np\n"
+        "import supervision as sv\n"
+        "from trackers.core.botsort.tracker import BoTSORTTracker\n"
+        "tracker = BoTSORTTracker(enable_cmc=False)\n"
+        "frame = np.zeros((64, 64, 3), dtype=np.uint8)\n"
+        "d = sv.Detections("
+        "xyxy=np.array([[1.0, 1.0, 10.0, 10.0], [50.0, 50.0, 60.0, 60.0]], dtype=np.float32), "
+        "confidence=np.array([0.9, 0.9], dtype=np.float32))\n"
+        "out = tracker.update(d, frame=frame)\n"
+        "assert len(out) == 2\n"
+        "assert (out.tracker_id >= 0).all()\n"
+        "assert len(tracker.tracks) == 2\n"
+        "imported = set(sys.modules) - before\n"
+        "assert 'trackers.core.reid.model' not in imported\n"
+        "print('ok')\n"
+    )
+    result = _run_isolated(code)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_reid_model_lazy_access_gives_install_hint() -> None:
+    """Fresh process: accessing ReIDModel without deps shows trackers[reid] hint."""
+    code = (
+        "import sys\n"
+        f"{_block_modules_stmt()}\n"
+        "import trackers\n"
+        "try:\n"
+        "    _ = trackers.ReIDModel\n"
+        "except ImportError as exc:\n"
+        "    assert 'trackers[reid]' in str(exc)\n"
+        "    print('ok')\n"
+        "else:\n"
+        "    raise SystemExit('expected ImportError')\n"
+    )
+    result = _run_isolated(code)
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/core/test_import_isolation.py
+++ b/tests/core/test_import_isolation.py
@@ -22,7 +22,7 @@ def _block_modules_stmt() -> str:
 
 
 def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
+    return subprocess.run(  # noqa: S603
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
@@ -33,13 +33,7 @@ def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
 
 def test_base_package_import_without_reid_extra() -> None:
     """Fresh process: base `import trackers` works with ReID heavy modules blocked."""
-    code = (
-        "import sys; "
-        f"{_block_modules_stmt()}; "
-        "import trackers; "
-        "assert trackers.BoTSORTTracker; "
-        "print('ok')"
-    )
+    code = f"import sys; {_block_modules_stmt()}; import trackers; assert trackers.BoTSORTTracker; print('ok')"
     result = _run_isolated(code)
     assert result.returncode == 0, result.stderr or result.stdout
 

--- a/tests/core/test_reid_fusion.py
+++ b/tests/core/test_reid_fusion.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from trackers.core.botsort.fusion import fuse_botsort_reid_association
 from trackers.core.botsort.tracker import BoTSORTTracker
-from trackers.core.reid.fusion_methods import fuse_botsort_reid_association
 
 
 class TestFuseBotsortReidAssociation:
@@ -20,10 +20,12 @@ class TestFuseBotsortReidAssociation:
         iou_raw = np.array([[0.7]], dtype=np.float32)
         iou_fused = np.array([[0.63]], dtype=np.float32)
         app_sim = np.array([[0.8]], dtype=np.float32)
+        proximity_iou = np.array([[0.7]], dtype=np.float32)
         fused = fuse_botsort_reid_association(
             iou_raw,
             iou_fused,
             app_sim,
+            proximity_iou_similarity=proximity_iou,
             proximity_threshold=0.5,
             appearance_threshold=0.25,
         )
@@ -33,23 +35,43 @@ class TestFuseBotsortReidAssociation:
         iou_raw = np.array([[0.4]], dtype=np.float32)
         iou_fused = np.array([[0.36]], dtype=np.float32)
         app_sim = np.array([[0.9]], dtype=np.float32)
+        proximity_iou = np.array([[0.4]], dtype=np.float32)
         fused = fuse_botsort_reid_association(
             iou_raw,
             iou_fused,
             app_sim,
+            proximity_iou_similarity=proximity_iou,
             proximity_threshold=0.5,
             appearance_threshold=0.25,
         )
         assert fused[0, 0] == pytest.approx(0.36)
 
+    def test_proximity_uses_standard_iou_not_giou(self) -> None:
+        """GIoU can be high while standard IoU fails the proximity gate."""
+        giou_raw = np.array([[0.85]], dtype=np.float32)
+        giou_fused = np.array([[0.80]], dtype=np.float32)
+        app_sim = np.array([[0.95]], dtype=np.float32)
+        standard_iou = np.array([[0.35]], dtype=np.float32)
+        fused = fuse_botsort_reid_association(
+            giou_raw,
+            giou_fused,
+            app_sim,
+            proximity_iou_similarity=standard_iou,
+            proximity_threshold=0.5,
+            appearance_threshold=0.25,
+        )
+        assert fused[0, 0] == pytest.approx(0.80)
+
     def test_no_appearance_information_keeps_fused_iou(self) -> None:
         iou_raw = np.array([[0.55, 0.2]], dtype=np.float32)
         iou_fused = np.array([[0.50, 0.18]], dtype=np.float32)
         app_sim = np.zeros((1, 2), dtype=np.float32)
+        proximity_iou = np.array([[0.55, 0.2]], dtype=np.float32)
         fused = fuse_botsort_reid_association(
             iou_raw,
             iou_fused,
             app_sim,
+            proximity_iou_similarity=proximity_iou,
             proximity_threshold=0.5,
             appearance_threshold=0.25,
         )
@@ -62,7 +84,8 @@ class TestBoTSORTReidFusion:
         iou_raw = np.array([[0.7]], dtype=np.float32)
         iou_fused = np.array([[0.63]], dtype=np.float32)
         app_sim = np.array([[0.8]], dtype=np.float32)
-        fused = tracker._fuse_botsort_reid(iou_raw, iou_fused, app_sim)
+        proximity_iou = np.array([[0.7]], dtype=np.float32)
+        fused = tracker._fuse_botsort_reid(iou_raw, iou_fused, app_sim, proximity_iou)
         assert fused[0, 0] == pytest.approx(0.9)
 
     def test_reid_threshold_defaults(self) -> None:

--- a/tests/scripts/test_track_reid.py
+++ b/tests/scripts/test_track_reid.py
@@ -1,0 +1,249 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from trackers.scripts.track import (
+    _apply_reid_tracker_params,
+    _reid_requested,
+    _validate_reid_cli_prerequisites,
+    add_track_subparser,
+    run_track,
+)
+
+
+class _FakeReIDModel:
+    last_kwargs: dict | None = None
+
+    @classmethod
+    def from_pretrained(cls, **kwargs: object) -> _FakeReIDModel:
+        cls.last_kwargs = dict(kwargs)
+        return cls()
+
+
+def test_reid_model_source_implies_enable() -> None:
+    args = argparse.Namespace(tracker_reid_enable=False, tracker_reid_model="osnet_x1_0_msmt17_combineall")
+    assert _reid_requested(args)
+
+
+def test_validate_reid_requires_source_before_load(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeReIDModel.last_kwargs = None
+    monkeypatch.setattr(
+        "trackers.scripts.track.load_reid_model_class",
+        lambda: _FakeReIDModel,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "trackers.core.reid._lazy.load_reid_model_class",
+        lambda: _FakeReIDModel,
+    )
+
+    args = argparse.Namespace(
+        tracker="botsort",
+        tracker_reid_enable=True,
+        tracker_reid_model=None,
+        tracker_reid_device="cpu",
+        tracker_reid_architecture=None,
+        source=None,
+        detections=None,
+        output=None,
+        display=False,
+        overwrite=False,
+        model="rfdetr-nano",
+        model_confidence=0.5,
+        model_device="cpu",
+        model_api_key=None,
+        classes=None,
+        track_ids=None,
+        mot_output=None,
+        show_boxes=True,
+        show_masks=False,
+        show_labels=False,
+        show_ids=True,
+        show_confidence=False,
+        show_trajectories=False,
+    )
+
+    err = _validate_reid_cli_prerequisites(args)
+    assert err is not None and "--source" in err
+
+    params, load_err = _apply_reid_tracker_params("botsort", args, {})
+    assert load_err is not None and "--source" in load_err
+    assert params == {}
+
+
+def test_apply_reid_passes_architecture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("trackers.core.reid._lazy.load_reid_model_class", lambda: _FakeReIDModel)
+    args = argparse.Namespace(
+        tracker_reid_enable=False,
+        tracker_reid_model="/tmp/weights.pth",
+        tracker_reid_device="cpu",
+        tracker_reid_architecture="osnet_x1_0",
+        source="video.mp4",
+    )
+    params, err = _apply_reid_tracker_params("botsort", args, {})
+    assert err is None
+    assert _FakeReIDModel.last_kwargs is not None
+    assert _FakeReIDModel.last_kwargs["source"] == "/tmp/weights.pth"
+    assert _FakeReIDModel.last_kwargs["architecture"] == "osnet_x1_0"
+    assert "reid_model" in params
+
+
+def test_apply_reid_model_load_error_is_concise(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FailingModel:
+        @classmethod
+        def from_pretrained(cls, **kwargs: object) -> None:
+            raise ValueError("architecture is required")
+
+    monkeypatch.setattr("trackers.core.reid._lazy.load_reid_model_class", lambda: _FailingModel)
+    args = argparse.Namespace(
+        tracker_reid_enable=True,
+        tracker_reid_model="/tmp/bare.pth",
+        tracker_reid_device="cpu",
+        tracker_reid_architecture=None,
+        source="video.mp4",
+    )
+    _, err = _apply_reid_tracker_params("botsort", args, {})
+    assert err is not None and "Failed to load ReID model" in err
+    assert "architecture is required" in err
+
+
+def test_run_track_checks_source_before_reid_load(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    load_called = False
+
+    def _fail_load(**kwargs: object) -> object:
+        nonlocal load_called
+        load_called = True
+        raise AssertionError("from_pretrained should not run without --source")
+
+    monkeypatch.setattr("trackers.core.reid._lazy.load_reid_model_class", lambda: _FakeReIDModel)
+    monkeypatch.setattr(_FakeReIDModel, "from_pretrained", _fail_load)
+
+    mot_file = tmp_path / "dets.txt"
+    mot_file.write_text("1,1,10,10,20,20,1,-1,-1,-1\n")
+
+    args = argparse.Namespace(
+        tracker="botsort",
+        tracker_reid_enable=True,
+        tracker_reid_model=None,
+        tracker_reid_device="cpu",
+        tracker_reid_architecture=None,
+        source=None,
+        detections=mot_file,
+        output=None,
+        display=False,
+        overwrite=False,
+        model="rfdetr-nano",
+        model_confidence=0.5,
+        model_device="cpu",
+        model_api_key=None,
+        classes=None,
+        track_ids=None,
+        mot_output=None,
+        show_boxes=True,
+        show_masks=False,
+        show_labels=False,
+        show_ids=True,
+        show_confidence=False,
+        show_trajectories=False,
+    )
+    for key, value in {
+        "tracker_lost_track_buffer": 30,
+        "tracker_frame_rate": 30.0,
+        "tracker_track_activation_threshold": 0.7,
+        "tracker_minimum_consecutive_frames": 2,
+        "tracker_minimum_iou_threshold_first_assoc": 0.2,
+        "tracker_minimum_iou_threshold_second_assoc": 0.5,
+        "tracker_minimum_iou_threshold_unconfirmed_assoc": 0.3,
+        "tracker_high_conf_det_threshold": 0.6,
+        "tracker_enable_cmc": True,
+        "tracker_cmc_method": "sparseOptFlow",
+        "tracker_cmc_downscale": 2,
+        "tracker_instant_first_frame_activation": True,
+        "tracker_reid_ema_alpha": 0.9,
+        "tracker_appearance_threshold": 0.25,
+        "tracker_proximity_threshold": 0.5,
+    }.items():
+        setattr(args, key, value)
+
+    exit_code = run_track(args)
+    assert exit_code == 1
+    assert load_called is False
+
+
+def test_cli_exposes_reid_architecture_and_tracker_thresholds() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    add_track_subparser(subparsers)
+    track_parser = subparsers.choices["track"]
+    help_text = track_parser.format_help()
+    assert "--tracker.reid.architecture" in help_text
+    assert "--tracker.appearance_threshold" in help_text
+    assert "--tracker.proximity_threshold" in help_text
+    assert "--tracker.reid_ema_alpha" in help_text
+
+
+def test_run_track_propagates_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _InterruptModel:
+        @classmethod
+        def from_pretrained(cls, **kwargs: object) -> object:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr("trackers.core.reid._lazy.load_reid_model_class", lambda: _InterruptModel)
+    monkeypatch.setattr("trackers.scripts.track._init_model", lambda *a, **k: MagicMock(class_names=[]))
+
+    args = argparse.Namespace(
+        tracker="botsort",
+        tracker_reid_enable=True,
+        tracker_reid_model=None,
+        tracker_reid_device="cpu",
+        tracker_reid_architecture=None,
+        source="video.mp4",
+        detections=None,
+        output=None,
+        display=False,
+        overwrite=False,
+        model="rfdetr-nano",
+        model_confidence=0.5,
+        model_device="cpu",
+        model_api_key=None,
+        classes=None,
+        track_ids=None,
+        mot_output=None,
+        show_boxes=True,
+        show_masks=False,
+        show_labels=False,
+        show_ids=True,
+        show_confidence=False,
+        show_trajectories=False,
+    )
+    for key, value in {
+        "tracker_lost_track_buffer": 30,
+        "tracker_frame_rate": 30.0,
+        "tracker_track_activation_threshold": 0.7,
+        "tracker_minimum_consecutive_frames": 2,
+        "tracker_minimum_iou_threshold_first_assoc": 0.2,
+        "tracker_minimum_iou_threshold_second_assoc": 0.5,
+        "tracker_minimum_iou_threshold_unconfirmed_assoc": 0.3,
+        "tracker_high_conf_det_threshold": 0.6,
+        "tracker_enable_cmc": True,
+        "tracker_cmc_method": "sparseOptFlow",
+        "tracker_cmc_downscale": 2,
+        "tracker_instant_first_frame_activation": True,
+        "tracker_reid_ema_alpha": 0.9,
+        "tracker_appearance_threshold": 0.25,
+        "tracker_proximity_threshold": 0.5,
+    }.items():
+        setattr(args, key, value)
+
+    with pytest.raises(KeyboardInterrupt):
+        run_track(args)

--- a/tests/scripts/test_track_reid.py
+++ b/tests/scripts/test_track_reid.py
@@ -81,11 +81,13 @@ def test_validate_reid_requires_source_before_load(monkeypatch: pytest.MonkeyPat
     assert params == {}
 
 
-def test_apply_reid_passes_architecture(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_reid_passes_architecture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr("trackers.core.reid._lazy.load_reid_model_class", lambda: _FakeReIDModel)
+    weights = tmp_path / "weights.pth"
+    weights.touch()
     args = argparse.Namespace(
         tracker_reid_enable=False,
-        tracker_reid_model="/tmp/weights.pth",
+        tracker_reid_model=str(weights),
         tracker_reid_device="cpu",
         tracker_reid_architecture="osnet_x1_0",
         source="video.mp4",
@@ -93,21 +95,23 @@ def test_apply_reid_passes_architecture(monkeypatch: pytest.MonkeyPatch) -> None
     params, err = _apply_reid_tracker_params("botsort", args, {})
     assert err is None
     assert _FakeReIDModel.last_kwargs is not None
-    assert _FakeReIDModel.last_kwargs["source"] == "/tmp/weights.pth"
+    assert _FakeReIDModel.last_kwargs["source"] == str(weights)
     assert _FakeReIDModel.last_kwargs["architecture"] == "osnet_x1_0"
     assert "reid_model" in params
 
 
-def test_apply_reid_model_load_error_is_concise(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_reid_model_load_error_is_concise(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     class _FailingModel:
         @classmethod
         def from_pretrained(cls, **kwargs: object) -> None:
             raise ValueError("architecture is required")
 
     monkeypatch.setattr("trackers.core.reid._lazy.load_reid_model_class", lambda: _FailingModel)
+    bare_weights = tmp_path / "bare.pth"
+    bare_weights.touch()
     args = argparse.Namespace(
         tracker_reid_enable=True,
-        tracker_reid_model="/tmp/bare.pth",
+        tracker_reid_model=str(bare_weights),
         tracker_reid_device="cpu",
         tracker_reid_architecture=None,
         source="video.mp4",

--- a/uv.lock
+++ b/uv.lock
@@ -159,12 +159,25 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "bitsandbytes"
 version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "torch", marker = "sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/eb/477d6b5602f469c7305fd43eec71d890c39909f615c1d7138f6e7d226eff/bitsandbytes-0.47.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:2f805b76891a596025e9e13318b675d08481b9ee650d65e5d2f9d844084c6521", size = 30004641, upload-time = "2025-08-11T18:51:20.524Z" },
@@ -241,7 +254,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "pycparser", marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
@@ -279,7 +292,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "pycparser", marker = "(python_full_version >= '3.14' and implementation_name != 'PyPy') or (implementation_name != 'PyPy' and sys_platform != 'darwin')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -531,8 +544,8 @@ name = "cryptography"
 version = "48.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 's390x' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' and platform_machine != 's390x' and sys_platform != 'darwin'" },
+    { name = "cffi", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
 wheels = [
@@ -593,7 +606,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/fe/7351d7e586a8b4c9f89731bfe4cf0148223e8f9903ff09571f78b3fb0682/cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08b395f79cb89ce0cd8effff07c4a1e20101b873c256a1aeb286e8fd7bd0f556", size = 5744254, upload-time = "2026-03-11T00:12:29.798Z" },
@@ -628,34 +641,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -736,7 +749,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -828,6 +841,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821, upload-time = "2024-10-26T00:50:33.425Z" },
+]
+
+[[package]]
+name = "gdown"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "filelock" },
+    { name = "requests", extra = ["socks"] },
+    { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/b5/a45f62f20664031bf74a6aeb6f8d8cd5910e411bf90d756bd6b09bdc6c35/gdown-6.1.0.tar.gz", hash = "sha256:361c6e04c6ca335df50b9d71f40bcfe9ab70fb26a1b0e890a427267781389553", size = 269670, upload-time = "2026-05-30T11:56:21.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/56/a99f0f159cce5b26d267317d436afee184f45fc7911938757d7cbbd2d10c/gdown-6.1.0-py3-none-any.whl", hash = "sha256:38a36a94275b8272f684db469bbd73b4d1f64cbbc1751bcb993a1b2be8f013c8", size = 19216, upload-time = "2026-05-30T11:56:20.016Z" },
 ]
 
 [[package]]
@@ -1138,7 +1167,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "(python_full_version < '3.12' and platform_machine != 's390x') or (python_full_version < '3.11' and platform_machine == 's390x')" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1219,7 +1248,7 @@ name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools", marker = "platform_machine != 's390x'" },
+    { name = "more-itertools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
 wheels = [
@@ -1231,7 +1260,7 @@ name = "jaraco-context"
 version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12' and platform_machine != 's390x'" },
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload-time = "2024-08-20T03:39:27.358Z" }
 wheels = [
@@ -1243,7 +1272,7 @@ name = "jaraco-functools"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools", marker = "platform_machine != 's390x'" },
+    { name = "more-itertools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz", hash = "sha256:70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d", size = 19159, upload-time = "2024-09-27T19:47:09.122Z" }
 wheels = [
@@ -1282,13 +1311,13 @@ name = "keyring"
 version = "25.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12' and platform_machine != 's390x'" },
-    { name = "jaraco-classes", marker = "platform_machine != 's390x'" },
-    { name = "jaraco-context", marker = "platform_machine != 's390x'" },
-    { name = "jaraco-functools", marker = "platform_machine != 's390x'" },
-    { name = "jeepney", marker = "platform_machine != 's390x' and sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "platform_machine != 's390x' and sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "platform_machine != 's390x' and sys_platform == 'linux'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750, upload-time = "2024-12-25T15:26:45.782Z" }
 wheels = [
@@ -1993,7 +2022,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2032,7 +2061,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2044,7 +2073,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2074,9 +2103,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2088,7 +2117,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2786,6 +2815,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3265,6 +3303,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
+]
+
 [[package]]
 name = "requests-file"
 version = "3.0.1"
@@ -3502,8 +3545,8 @@ name = "secretstorage"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "platform_machine != 's390x' and sys_platform != 'darwin'" },
-    { name = "jeepney", marker = "platform_machine != 's390x' and sys_platform != 'darwin'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
 wheels = [
@@ -3759,6 +3802,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
@@ -3863,7 +3915,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
 wheels = [
@@ -3897,7 +3949,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/32/38498d2a1a5d70f33f6c3909bbad48557c9a54b0e33a9307ff06b6d416ba/tifffile-2026.1.28.tar.gz", hash = "sha256:537ae6466a8bb555c336108bb1878d8319d52c9c738041d3349454dea6956e1c", size = 374675, upload-time = "2026-01-29T05:17:24.992Z" }
 wheels = [
@@ -4132,7 +4184,10 @@ detection = [
     { name = "inference-models" },
 ]
 reid = [
+    { name = "gdown" },
     { name = "huggingface-hub" },
+    { name = "pillow" },
+    { name = "safetensors" },
     { name = "timm" },
     { name = "torch" },
     { name = "torchvision" },
@@ -4170,14 +4225,17 @@ mypy-types = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gdown", marker = "extra == 'reid'", specifier = ">=5.0.0" },
     { name = "huggingface-hub", marker = "extra == 'reid'", specifier = ">=0.20.0" },
     { name = "inference-models", marker = "extra == 'detection'", specifier = ">=0.19.0" },
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "opencv-python", specifier = ">=4.8.0" },
     { name = "optuna", marker = "extra == 'tune'", specifier = ">=3.0.0" },
+    { name = "pillow", marker = "extra == 'reid'", specifier = ">=10.0.0" },
     { name = "pydeprecate", specifier = ">=0.7.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "safetensors", marker = "extra == 'reid'", specifier = ">=0.4.0" },
     { name = "scipy", specifier = ">=1.13.1" },
     { name = "supervision", specifier = ">=0.26.1" },
     { name = "timm", marker = "extra == 'reid'", specifier = ">=1.0.0" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- isolate optional ReID dependencies from base tracking and expose friendly lazy imports
- add complete BoT-SORT ReID CLI support, including model source, architecture, device, and existing fusion thresholds
- introduce lightweight encoder protocols for custom and test implementations without coupling BoT-SORT to PyTorch
- fix Market-1501 junk handling, CMC rank padding, embedding validation, true-IoU proximity gating, and checkpoint loading safety
- add end-to-end tracker, CLI, evaluation, loader, feature-bank, import-isolation, and network-marked checkpoint tests
- document installation, Python/CLI usage, API surface, and release changes

## Verification
- `uv sync --frozen --group dev --extra reid`
- `uv run pytest -m "not integration and not network" -q` — 993 passed, 5 skipped, 15 deselected
- `pre-commit run --all-files` — all hooks passed, including Ruff, mypy, codespell, notebook formatting, and metadata validation
- `python -m compileall -q src tests`
- real FastReID checkpoint validation remains opt-in via the `network` marker
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f62c7-a84f-7afb-9043-52922f8b941e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f62c7-a84f-7afb-9043-52922f8b941e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

