### PR TITLE
feat(reid): standalone ReIDModel, architectures, and gallery eval

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -30,16 +30,17 @@ jobs:
           prune-cache: ${{ matrix.os != 'windows-latest' }}
 
       - name: 🚀 Install Packages
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --group dev --extra reid
 
-      - name: 🧪 Run the Import test
-        run: uv run python -c "import trackers"
+      - name: 🧪 Run base import regression (no heavy ReID imports)
+        shell: bash
+        run: uv run pytest tests/core/test_import_isolation.py -q
 
       - name: 🧪 Run the Test
         shell: bash
         run: |
           if [ -d tests ] && [ "$(find tests -type f \( -name 'test_*.py' -o -name '*_test.py' \) | wc -l)" -gt 0 ]; then
-            uv run pytest -m "not integration"
+            uv run pytest -m "not integration and not network"
           else
             echo "No tests found. Skipping pytest."
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -192,5 +192,6 @@ autotune/mot17/
 autotune/pretrained/
 autotune/*.zip
 
-# Internal design notes (kept locally, not published)
+# Local design docs (kept on disk, not published)
+rfcs/
 docs/design/dynamic-frame-rate.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Optional `trackers[reid]` extra** — torch/timm/Hugging Face ReID stack plus `safetensors`, `Pillow`, and `gdown` for curated checkpoints (OSNet and FastReID SBS).
+- **Standalone `ReIDModel`** — architecture-agnostic loading (`from_pretrained` / `save_pretrained`), OSNet + FastReID SBS + `timm:` backbones, and curated aliases (`osnet_x1_0_msmt17_combineall`, `fastreid_mot17_sbs50`).
+- **ReID evaluation helpers** — Market-1501 / MSMT17 loaders, gallery `pid=0` distractor handling, safer CMC padding, and `ReIDMetrics.mean_average_precision` (with `map` alias).
+- **FeatureBank + appearance distance** — per-track EMA embeddings with normalize/sanitize; incompatible shapes rejected while preserving state.
+
+### Changed
+
+- **Lazy ReID imports** — `import trackers` no longer requires torch; `ReIDModel` loads on first access with a `trackers[reid]` install hint.
+
+### Fixed
+
+- **ReID loaders** — preserve Hugging Face errors, `weights_only=True` when supported, atomic `gd://` cache writes, stricter curated-alias load validation.
+
 ## [2.6.0] — 2026-07-08
 
 ### 🚀 Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ pip install git+https://github.com/roboflow/trackers.git
 
 For more options, see the [install guide](https://trackers.roboflow.com/develop/learn/install/).
 
+Optional appearance ReID models:
+
+```bash
+pip install 'trackers[reid]'
+```
+
 [![Watch: Building Real-Time Multi-Object Tracking with RF-DETR and Trackers](https://storage.googleapis.com/com-roboflow-marketing/trackers/docs/roboflow-piotr-rf-detr-trackers-v1b-callout.png)](https://www.youtube.com/watch?v=u0k2dTZ0vfs)
 
 ## Quick Start

--- a/docs/api/reid.md
+++ b/docs/api/reid.md
@@ -1,0 +1,43 @@
+---
+description: ReID model loading, evaluation, and appearance helpers in Roboflow Trackers.
+---
+
+# ReID API
+
+Requires the optional extra:
+
+```bash
+pip install 'trackers[reid]'
+```
+
+## Protocols
+
+Trackers and :class:`~trackers.core.reid.eval.evaluator.ReIDEvaluator` accept lightweight
+protocol types so tests and custom encoders do not need the full
+:class:`~trackers.core.reid.model.ReIDModel` stack:
+
+::: trackers.core.reid.protocols.ReIDEncoder
+
+::: trackers.core.reid.protocols.ReIDPathEncoder
+
+## Model
+
+::: trackers.core.reid.model.ReIDModel
+
+## Evaluation
+
+::: trackers.core.reid.eval.evaluator.ReIDEvaluator
+
+::: trackers.core.reid.eval.metrics.ReIDMetrics
+
+::: trackers.core.reid.eval.metrics.compute_reid_metrics
+
+## Datasets
+
+::: trackers.core.reid.eval.datasets.load_market1501
+
+::: trackers.core.reid.eval.datasets.load_msmt17
+
+## Feature bank
+
+::: trackers.core.reid.feature_bank.FeatureBank

--- a/docs/learn/install.md
+++ b/docs/learn/install.md
@@ -74,6 +74,16 @@ The `detection` extra installs `inference-models`, enabling the CLI to run detec
 
     For GPU support, ensure PyTorch is installed with CUDA or MPS.
 
+### ReID (appearance embeddings)
+
+The `reid` extra installs PyTorch, timm, Hugging Face Hub, safetensors, Pillow, and gdown for ReID model loading (OSNet, FastReID SBS, and `timm:` backbones).
+
+```bash
+pip install "trackers[reid]"
+```
+
+Use programmatically with `ReIDModel.from_pretrained(...)`.
+
 ---
 
 ## Development Setup

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
 
   - API Reference:
     - Trackers: api/trackers.md
+    - ReID: api/reid.md
     - Motion: api/motion.md
     - Datasets: api/datasets.md
     - Evals: api/evals.md

--- a/notebooks/eval_reid.ipynb
+++ b/notebooks/eval_reid.ipynb
@@ -1,0 +1,344 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Re-ID Evaluation \u2014 OSNet on Market-1501 and MSMT17\n\nThis notebook reproduces the standard **same-domain** re-ID benchmark numbers for OSNet x1.0.\nEach dataset is evaluated with the checkpoint that was *trained on that same dataset*\n(from the [torchreid model zoo](https://kaiyangzhou.github.io/deep-person-reid/MODEL_ZOO)),\nwhich is the only fair comparison against published numbers.\n\n1. **Market-1501** (~1.3 GB, ~10 min on T4) \u2014 Expected: ~94.2 Rank-1 / 82.6 mAP.\n2. **MSMT17** (~4 GB, ~40 min on T4) \u2014 Expected: ~74.9 Rank-1 / 43.8 mAP.\n\n> **Note:** the default `ReIDModel.from_pretrained()` checkpoint is OSNet trained on\n> MSMT17 with `combineall=True` (train+test combined). Evaluating *that* checkpoint on\n> MSMT17 leaks the test set (near-100% scores) and on Market-1501 measures cross-domain\n> transfer (~61 R1). To reproduce paper numbers we instead load each dataset's own\n> same-domain checkpoint below.\n\n> **Runtime:** `Runtime \u2192 Change runtime type \u2192 T4 GPU` before running.\n\n---"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## 1. Setup\n\nInstall `trackers` and load the ReID evaluation helpers. Each dataset section below loads the matching OSNet checkpoint from the [torchreid model zoo](https://kaiyangzhou.github.io/deep-person-reid/MODEL_ZOO).\n\nOn Colab: **Runtime \u2192 Change runtime type \u2192 T4 GPU** before running.\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "GIT_REF = \"git+https://github.com/roboflow/trackers.git@release/stable\"\n",
+                "\n",
+                "!pip install -q --upgrade pip\n",
+                "# Colab ships CUDA torch \u2014 avoid trackers[reid] (pulls a conflicting PyPI torch build).\n",
+                "!pip install -q timm huggingface-hub safetensors gdown matplotlib scikit-learn\n",
+                "!pip install -q --no-cache-dir --force-reinstall --no-deps \"trackers @ {GIT_REF}\"\n",
+                "!pip install -q supervision scipy opencv-python rich requests pydeprecate"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "import os\n",
+                "import zipfile\n",
+                "from pathlib import Path\n",
+                "\n",
+                "import gdown\n",
+                "import torch\n",
+                "\n",
+                "from trackers.core.reid import ReIDEvaluator, ReIDModel\n",
+                "\n",
+                "try:\n",
+                "    import google.colab  # noqa: F401\n",
+                "\n",
+                "    IN_COLAB = True\n",
+                "    ROOT = Path(\"/content\")\n",
+                "except ImportError:\n",
+                "    IN_COLAB = False\n",
+                "    ROOT = Path(\"..\").resolve()\n",
+                "\n",
+                "CKPT_DIR = ROOT / \"checkpoints\"\n",
+                "CKPT_DIR.mkdir(parents=True, exist_ok=True)\n",
+                "\n",
+                "device = torch.cuda.get_device_name(0) if torch.cuda.is_available() else \"cpu\"\n",
+                "print(f\"PyTorch {torch.__version__} | CUDA {torch.cuda.is_available()} | {device}\")\n",
+                "\n",
+                "\n",
+                "def download_checkpoint(gdrive_id: str, filename: str) -> str:\n",
+                "    \"\"\"Download an OSNet checkpoint from the torchreid model zoo (Google Drive).\"\"\"\n",
+                "    path = CKPT_DIR / filename\n",
+                "    if not path.exists():\n",
+                "        gdown.download(id=gdrive_id, output=str(path), quiet=False)\n",
+                "    return str(path)\n",
+                "\n",
+                "\n",
+                "def print_comparison(name, cos, euc, zoo_r1, zoo_map):\n",
+                "    \"\"\"Print a cosine-vs-euclidean comparison table against model-zoo targets.\"\"\"\n",
+                "    print(f\"\\n{name} \u2014 distance metric comparison\")\n",
+                "    print(f\"{'metric':<10}{'cosine':>10}{'euclidean':>12}{'model zoo':>12}\")\n",
+                "    print(\"-\" * 44)\n",
+                "    print(f\"{'Rank-1':<10}{cos.rank1:>9.1f}%{euc.rank1:>11.1f}%{zoo_r1:>11.1f}%\")\n",
+                "    print(f\"{'mAP':<10}{cos.map:>9.1f}%{euc.map:>11.1f}%{zoo_map:>11.1f}%\")\n",
+                "    print(f\"{'Rank-5':<10}{cos.rank5:>9.1f}%{euc.rank5:>11.1f}%{'\u2014':>12}\")\n",
+                "    print(f\"{'Rank-10':<10}{cos.rank10:>9.1f}%{euc.rank10:>11.1f}%{'\u2014':>12}\")\n",
+                "    print(f\"{'mINP':<10}{cos.minp:>9.1f}%{euc.minp:>11.1f}%{'\u2014':>12}\")"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "---\n## 2. Market-1501\n\n**Expected numbers (OSNet x1.0 trained on Market-1501, torchreid model zoo):** Rank-1 \u2248 94.2 %  |  mAP \u2248 82.6 %\n\nThe model-zoo numbers use **raw Euclidean** distance. We report both that and our\ndefault **cosine** (L2-normalised) distance so the difference is visible.\n\nMarket-1501 is ~1.3 GB. We download it via gdown (official Google Drive mirror).\nIf gdown fails, see the alternative download cell below.\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "MARKET_ZIP = \"/content/Market-1501.zip\"\n",
+                "MARKET_DIR = \"/content/Market-1501-v15.09.15\"\n",
+                "\n",
+                "if not os.path.exists(MARKET_DIR):\n",
+                "    # Google Drive file ID for Market-1501-v15.09.15.zip\n",
+                "    gdown.download(id=\"0B8-rUzbwVRk0c054eEozWG9COHM\", output=MARKET_ZIP, quiet=False)\n",
+                "    with zipfile.ZipFile(MARKET_ZIP, \"r\") as zf:\n",
+                "        zf.extractall(\"/content\")\n",
+                "    print(\"Extracted to\", MARKET_DIR)\n",
+                "else:\n",
+                "    print(\"Already downloaded.\")"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "# Alternative download if gdown fails (paste the unzip path that matches your mirror):\n",
+                "# !wget -q -O /content/Market-1501.zip \"<YOUR_MIRROR_URL>\"\n",
+                "# !unzip -q /content/Market-1501.zip -d /content\n"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "from trackers.core.reid import load_market1501\n",
+                "\n",
+                "query_m, gallery_m = load_market1501(MARKET_DIR)\n",
+                "print(f\"Market-1501 \u2014 query: {len(query_m):,}  |  gallery: {len(gallery_m):,}\")"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "# Load the OSNet x1.0 checkpoint trained on Market-1501 (torchreid model zoo).\n",
+                "market_ckpt = download_checkpoint(\"1vduhq5DpN2q1g4fYEZfPI17MJeh9qyrA\", \"osnet_x1_0_market1501.pth\")\n",
+                "model_market = ReIDModel.from_pretrained(market_ckpt, architecture=\"osnet_x1_0\")\n",
+                "evaluator_market = ReIDEvaluator(model_market, batch_size=256)\n",
+                "\n",
+                "# Cosine distance on L2-normalised embeddings (our default) \u2014 extracts once.\n",
+                "result_market = evaluator_market.evaluate(query_m, gallery_m, distance=\"cosine\", return_distmat=False)\n",
+                "# Raw Euclidean distance (the torchreid model-zoo protocol) \u2014 reuse the same\n",
+                "# embeddings and just re-score, so we don't pay for extraction twice.\n",
+                "result_market_euc = evaluator_market.evaluate(\n",
+                "    query_m,\n",
+                "    gallery_m,\n",
+                "    distance=\"euclidean\",\n",
+                "    return_distmat=False,\n",
+                "    query_embeddings=result_market.query_embeddings,\n",
+                "    gallery_embeddings=result_market.gallery_embeddings,\n",
+                ")\n",
+                "\n",
+                "print_comparison(\"Market-1501\", result_market.metrics, result_market_euc.metrics, 94.2, 82.6)"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "---\n## 3. MSMT17\n\n**Expected numbers (OSNet x1.0 trained on MSMT17, torchreid model zoo):** Rank-1 \u2248 74.9 %  |  mAP \u2248 43.8 % (raw Euclidean; we also report cosine)\n\n### Option A \u2014 download directly in Colab (recommended)\n\nDownloads `MSMT17_V1.zip` (~2.56 GB) from the community Hugging Face mirror\n[`xianpeijie/MSMT17_V1`](https://huggingface.co/datasets/xianpeijie/MSMT17_V1)\nusing `huggingface_hub` (already installed as part of the `[reid]` extra).\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "# Option A: download from Hugging Face community mirror (~2.56 GB)\n",
+                "import os\n",
+                "import zipfile\n",
+                "\n",
+                "from huggingface_hub import hf_hub_download\n",
+                "\n",
+                "MSMT17_DIR = \"/content/MSMT17_V1\"\n",
+                "\n",
+                "if not os.path.exists(MSMT17_DIR):\n",
+                "    msmt17_zip = hf_hub_download(\n",
+                "        repo_id=\"xianpeijie/MSMT17_V1\",\n",
+                "        filename=\"MSMT17_V1.zip\",\n",
+                "        repo_type=\"dataset\",\n",
+                "        local_dir=\"/content\",\n",
+                "    )\n",
+                "    print(\"Extracting MSMT17 (~2.56 GB, may take a few minutes)\u2026\")\n",
+                "    with zipfile.ZipFile(msmt17_zip, \"r\") as zf:\n",
+                "        zf.extractall(\"/content\")\n",
+                "    print(\"Done \u2192\", MSMT17_DIR)\n",
+                "else:\n",
+                "    print(\"Already extracted.\")"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "from trackers.core.reid import load_msmt17\n",
+                "\n",
+                "query_ms, gallery_ms = load_msmt17(MSMT17_DIR)\n",
+                "print(f\"MSMT17 \u2014 query: {len(query_ms):,}  |  gallery: {len(gallery_ms):,}\")"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "# Load the OSNet x1.0 checkpoint trained on MSMT17 (standard split, torchreid model zoo).\n",
+                "# Note: use from_pretrained with a bare checkpoint path and the architecture name.\n",
+                "# Do NOT use the default alias (osnet_x1_0_msmt17_combineall) to benchmark MSMT17 \u2014\n",
+                "# it trains on the MSMT17 test identities, so scores would be inflated.\n",
+                "msmt17_ckpt = download_checkpoint(\"112EMUfBPYeYg70w-syK6V6Mx8-Qb9Q1M\", \"osnet_x1_0_msmt17.pth\")\n",
+                "model_msmt17 = ReIDModel.from_pretrained(msmt17_ckpt, architecture=\"osnet_x1_0\")\n",
+                "evaluator_msmt17 = ReIDEvaluator(model_msmt17, batch_size=256)\n",
+                "\n",
+                "# Cosine distance on L2-normalised embeddings (our default) \u2014 extracts once.\n",
+                "result_msmt17 = evaluator_msmt17.evaluate(query_ms, gallery_ms, distance=\"cosine\", return_distmat=False)\n",
+                "# Raw Euclidean distance (the torchreid model-zoo protocol) \u2014 reuse embeddings.\n",
+                "result_msmt17_euc = evaluator_msmt17.evaluate(\n",
+                "    query_ms,\n",
+                "    gallery_ms,\n",
+                "    distance=\"euclidean\",\n",
+                "    return_distmat=False,\n",
+                "    query_embeddings=result_msmt17.query_embeddings,\n",
+                "    gallery_embeddings=result_msmt17.gallery_embeddings,\n",
+                ")\n",
+                "\n",
+                "print_comparison(\"MSMT17\", result_msmt17.metrics, result_msmt17_euc.metrics, 74.9, 43.8)"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "---\n## 4. BoT-SORT FastReID encoder (MOT17 SBS-S50)\n\nThe [BoT-SORT model zoo](https://github.com/niraharon/bot-sort#model-zoo) publishes a **FastReID Strong Baseline** checkpoint trained on MOT17 train-half GT crops (`mot17_sbs_S50.pth`). This is the encoder used in the paper's BoT-SORT-ReID ablation.\n\nWe load it via the curated alias `fastreid_mot17_sbs50` (ResNeSt50 + GeM + BNNeck, **384\u00d7128** input). Run **\u00a74 MSMT17** first so `query_ms` / `gallery_ms` are in memory \u2014 the cell below measures **cross-domain** retrieval (MOT-trained encoder on MSMT17), which is expected to score lower than same-domain OSNet numbers in \u00a74.\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "# Load BoT-SORT / FastReID MOT17 SBS-S50 (~318 MB from Google Drive).\n",
+                "fastreid_ckpt = download_checkpoint(\"1QZFWpoa80rqo7O-HXmlss8J8CnS7IUsN\", \"mot17_sbs_S50.pth\")\n",
+                "\n",
+                "# Option A: curated alias (uses gd:// cache on repeat runs)\n",
+                "model_fastreid = ReIDModel.from_pretrained(\"fastreid_mot17_sbs50\")\n",
+                "\n",
+                "# Option B: explicit local path (equivalent)\n",
+                "# model_fastreid = ReIDModel.from_pretrained(\n",
+                "#     fastreid_ckpt,\n",
+                "#     architecture=\"fastreid_sbs_resnest50\",\n",
+                "# )\n",
+                "\n",
+                "print(model_fastreid.preprocessing.describe())"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "# Cross-domain gallery retrieval: MOT17-trained encoder on MSMT17 query/gallery.\n",
+                "# Requires \u00a74 MSMT17 cells (query_ms, gallery_ms) to have been run.\n",
+                "evaluator_fastreid = ReIDEvaluator(model_fastreid, batch_size=256)\n",
+                "\n",
+                "result_fastreid_msmt17_cos = evaluator_fastreid.evaluate(query_ms, gallery_ms, distance=\"cosine\", return_distmat=False)\n",
+                "result_fastreid_msmt17_euc = evaluator_fastreid.evaluate(\n",
+                "    query_ms,\n",
+                "    gallery_ms,\n",
+                "    distance=\"euclidean\",\n",
+                "    return_distmat=False,\n",
+                "    query_embeddings=result_fastreid_msmt17_cos.query_embeddings,\n",
+                "    gallery_embeddings=result_fastreid_msmt17_cos.gallery_embeddings,\n",
+                ")\n",
+                "\n",
+                "print(\"FastReID MOT17 SBS50 on MSMT17 (cross-domain)\")\n",
+                "print_comparison(\n",
+                "    \"MSMT17 (FastReID MOT17)\",\n",
+                "    result_fastreid_msmt17_cos.metrics,\n",
+                "    result_fastreid_msmt17_euc.metrics,\n",
+                "    float(\"nan\"),\n",
+                "    float(\"nan\"),\n",
+                ")"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "---\n## 5. Summary table\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "print(f\"{'Dataset':<14}{'encoder':<22}{'distance':<12}{'mAP':>8}{'Rank-1':>9}{'Rank-5':>9}{'Rank-10':>9}{'mINP':>8}\")\n",
+                "print(\"-\" * 91)\n",
+                "\n",
+                "\n",
+                "def _row(name, encoder, dist, m):\n",
+                "    return (\n",
+                "        f\"{name:<14}{encoder:<22}{dist:<12}{m.map:>7.1f}%{m.rank1:>8.1f}%\"\n",
+                "        f\"{m.rank5:>8.1f}%{m.rank10:>8.1f}%{m.minp:>7.1f}%\"\n",
+                "    )\n",
+                "\n",
+                "\n",
+                "print(_row(\"Market-1501\", \"OSNet\", \"cosine\", result_market.metrics))\n",
+                "print(_row(\"\", \"\", \"euclidean\", result_market_euc.metrics))\n",
+                "print(_row(\"MSMT17\", \"OSNet\", \"cosine\", result_msmt17.metrics))\n",
+                "print(_row(\"\", \"\", \"euclidean\", result_msmt17_euc.metrics))\n",
+                "print(_row(\"MSMT17\", \"FastReID MOT17\", \"cosine\", result_fastreid_msmt17_cos.metrics))\n",
+                "print(_row(\"\", \"\", \"euclidean\", result_fastreid_msmt17_euc.metrics))\n",
+                "print(\"-\" * 91)\n",
+                "print(\"Model-zoo targets (OSNet, euclidean): Market-1501 R1\u224894.2 mAP\u224882.6  |  MSMT17 R1\u224874.9 mAP\u224843.8\")\n",
+                "print(\"FastReID row is cross-domain (MOT17-trained encoder on MSMT17 gallery).\")"
+            ],
+            "execution_count": null,
+            "outputs": []
+        }
+    ],
+    "metadata": {
+        "accelerator": "GPU",
+        "colab": {
+            "gpuType": "T4",
+            "provenance": []
+        },
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,15 @@ dependencies = [
 [project.optional-dependencies]
 detection = ["inference-models>=0.19.0"]
 tune = ["optuna>=3.0.0"]
+reid = [
+    "torch>=2.0.0",
+    "torchvision>=0.15.0",
+    "timm>=1.0.0",
+    "huggingface-hub>=0.20.0",
+    "safetensors>=0.4.0",
+    "Pillow>=10.0.0",
+    "gdown>=5.0.0",
+]
 
 [project.scripts]
 trackers = "trackers.scripts.__main__:main"
@@ -192,11 +201,12 @@ addopts = [
 doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"
 markers = [
     "integration: marks tests as integration tests (require external data download)",
+    "network: marks tests that require network access to download model weights",
 ]
 
 [tool.codespell]
 skip = "*.pth"
-ignore-words-list = "mot"
+ignore-words-list = "mot,iterm"
 
 [tool.mypy]
 python_version = "3.10"
@@ -211,6 +221,11 @@ module = [
     "torch",
     "torchvision",
     "torchvision.transforms",
+    "timm",
+    "timm.*",
+    "huggingface_hub",
+    "gdown",
+    "safetensors",
     "firerequests",
     "scipy",
     "scipy.*",

--- a/src/trackers/__init__.py
+++ b/src/trackers/__init__.py
@@ -6,11 +6,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from trackers.annotators.trace import MotionAwareTraceAnnotator
 from trackers.core.botsort.tracker import BoTSORTTracker
 from trackers.core.bytetrack.tracker import ByteTrackTracker
 from trackers.core.cbiou.tracker import CBIoUTracker
 from trackers.core.ocsort.tracker import OCSORTTracker
+from trackers.core.reid._lazy import REID_INSTALL_HINT, import_reid_symbol
 from trackers.core.sort.tracker import SORTTracker
 from trackers.datasets.download import download_dataset
 from trackers.datasets.manifest import Dataset, DatasetAsset, DatasetSplit
@@ -25,6 +28,9 @@ from trackers.motion.transformation import (
 from trackers.utils.cmc import CMC, CMCConfig, CMCMethod, CMCTMethod
 from trackers.utils.converters import xcycsr_to_xyxy, xyxy_to_xcycsr
 from trackers.utils.iou import BaseIoU, BIoU, CIoU, DIoU, GIoU, IoU
+
+if TYPE_CHECKING:
+    from trackers.core.reid.model import ReIDModel
 
 __all__ = [
     "CMC",
@@ -49,6 +55,7 @@ __all__ = [
     "MotionAwareTraceAnnotator",
     "MotionEstimator",
     "OCSORTTracker",
+    "ReIDModel",
     "SORTTracker",
     "download_dataset",
     "frames_from_source",
@@ -56,3 +63,23 @@ __all__ = [
     "xcycsr_to_xyxy",
     "xyxy_to_xcycsr",
 ]
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "ReIDModel": ("trackers.core.reid.model", "ReIDModel"),
+}
+
+
+def __getattr__(name: str) -> object:
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        try:
+            value = import_reid_symbol(module_name, attr_name)
+        except ImportError as exc:
+            raise ImportError(REID_INSTALL_HINT) from exc
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/trackers/core/reid/__init__.py
+++ b/src/trackers/core/reid/__init__.py
@@ -1,0 +1,76 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from trackers.core.reid._lazy import import_reid_symbol
+
+__all__ = [
+    "FASTREID_MOT17_SBS50",
+    "MARKET1501_GALLERY_JUNK_PIDS",
+    "FeatureBank",
+    "KeyReport",
+    "ModelCard",
+    "ReIDEvaluator",
+    "ReIDMetrics",
+    "ReIDModel",
+    "ReIDPreprocessing",
+    "ReIDResult",
+    "ReIDSplit",
+    "ReidEvaluator",
+    "ReidMetrics",
+    "ReidResult",
+    "ReidSplit",
+    "appearance_similarity",
+    "build_architecture",
+    "compute_reid_metrics",
+    "list_architectures",
+    "load_market1501",
+    "load_msmt17",
+    "resolve_model_card",
+    "resolve_weights",
+]
+
+# NumPy-only symbols — safe to import without torch/timm/HF.
+from trackers.core.reid.distance import appearance_similarity
+from trackers.core.reid.eval.datasets import (
+    MARKET1501_GALLERY_JUNK_PIDS,
+    ReIDSplit,
+    ReidSplit,
+    load_market1501,
+    load_msmt17,
+)
+from trackers.core.reid.eval.metrics import ReIDMetrics, ReidMetrics, compute_reid_metrics
+from trackers.core.reid.feature_bank import FeatureBank
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "ReIDModel": ("trackers.core.reid.model", "ReIDModel"),
+    "ReIDPreprocessing": ("trackers.core.reid.models.preprocessing", "ReIDPreprocessing"),
+    "ModelCard": ("trackers.core.reid.models.registry", "ModelCard"),
+    "resolve_model_card": ("trackers.core.reid.models.registry", "resolve_model_card"),
+    "FASTREID_MOT17_SBS50": ("trackers.core.reid.models.registry", "FASTREID_MOT17_SBS50"),
+    "KeyReport": ("trackers.core.reid.models.loaders", "KeyReport"),
+    "resolve_weights": ("trackers.core.reid.models.loaders", "resolve_weights"),
+    "build_architecture": ("trackers.core.reid.architectures", "build_architecture"),
+    "list_architectures": ("trackers.core.reid.architectures", "list_architectures"),
+    "ReIDEvaluator": ("trackers.core.reid.eval.evaluator", "ReIDEvaluator"),
+    "ReIDResult": ("trackers.core.reid.eval.evaluator", "ReIDResult"),
+    "ReidEvaluator": ("trackers.core.reid.eval.evaluator", "ReidEvaluator"),
+    "ReidResult": ("trackers.core.reid.eval.evaluator", "ReidResult"),
+}
+
+
+def __getattr__(name: str) -> object:
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        value = import_reid_symbol(module_name, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/trackers/core/reid/_lazy.py
+++ b/src/trackers/core/reid/_lazy.py
@@ -1,0 +1,53 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Optional ReID dependency helpers."""
+
+from __future__ import annotations
+
+import importlib
+
+REID_INSTALL_HINT = (
+    "ReID features require the optional `trackers[reid]` extra. Install with: pip install 'trackers[reid]'"
+)
+
+# Modules that must be importable for the ReID stack. Checked in order so the
+# first missing dependency produces a clear install hint.
+_REID_DEPENDENCY_MODULES: tuple[str, ...] = (
+    "torch",
+    "torchvision",
+    "timm",
+    "huggingface_hub",
+    "safetensors",
+    "PIL",
+    "gdown",
+)
+
+
+def require_reid_extra() -> None:
+    """Raise a clear error when any ReID optional dependency is missing."""
+    for module_name in _REID_DEPENDENCY_MODULES:
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError as exc:
+            raise ImportError(REID_INSTALL_HINT) from exc
+        if module is None:
+            raise ImportError(REID_INSTALL_HINT)
+
+
+def import_reid_symbol(module_name: str, attr_name: str) -> object:
+    """Import a symbol from a heavy ReID submodule with a friendly fallback."""
+    require_reid_extra()
+    try:
+        module = importlib.import_module(module_name)
+        return getattr(module, attr_name)
+    except ImportError as exc:
+        raise ImportError(REID_INSTALL_HINT) from exc
+
+
+def load_reid_model_class():
+    """Import :class:`~trackers.core.reid.model.ReIDModel` on demand."""
+    return import_reid_symbol("trackers.core.reid.model", "ReIDModel")

--- a/src/trackers/core/reid/architectures/__init__.py
+++ b/src/trackers/core/reid/architectures/__init__.py
@@ -1,0 +1,73 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Re-ID backbone builders (OSNet, FastReID ResNeSt SBS, and ``timm:`` models)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import timm
+import torch.nn as nn
+
+from trackers.core.reid.architectures.fastreid_sbs import (
+    FASTREID_SBS_ARCHITECTURE,
+    build_fastreid_sbs_resnest50,
+    remap_fastreid_sbs_state_dict,
+)
+from trackers.core.reid.architectures.osnet import build_osnet
+
+# Width variants of the clean-room OSNet implementation.
+_OSNET_VARIANTS: dict[str, str] = {
+    "osnet_x0_25": "x0_25",
+    "osnet_x0_5": "x0_5",
+    "osnet_x0_75": "x0_75",
+    "osnet_x1_0": "x1_0",
+}
+
+_TIMM_PREFIX = "timm:"
+
+
+def build_architecture(
+    architecture: str | nn.Module,
+    *,
+    num_classes: int = 0,
+    pretrained: bool = False,
+) -> nn.Module:
+    """Build a backbone from ``osnet_*``, ``timm:<name>``, or a pre-built module."""
+    if not isinstance(architecture, str):
+        # Pre-built module: use as-is, ignoring num_classes and pretrained.
+        return architecture
+
+    if architecture.startswith(_TIMM_PREFIX):
+        name = architecture[len(_TIMM_PREFIX) :]
+        return timm.create_model(name, pretrained=pretrained, num_classes=num_classes)
+
+    if architecture in _OSNET_VARIANTS:
+        # OSNet weights are always loaded explicitly via the weights axis, so
+        # pretrained is intentionally ignored here.
+        return build_osnet(variant=_OSNET_VARIANTS[architecture], num_classes=num_classes)
+
+    if architecture == FASTREID_SBS_ARCHITECTURE:
+        return build_fastreid_sbs_resnest50(num_classes=num_classes, pretrained=pretrained)
+
+    raise ValueError(
+        f"Unknown architecture {architecture!r}. Choose a registered name "
+        f"({list_architectures()}), a timm model as 'timm:<name>' (e.g. "
+        f"'timm:resnet50'), or pass a torch.nn.Module instance."
+    )
+
+
+def list_architectures() -> list[str]:
+    """Return registered architecture names (timm models use ``timm:<name>``)."""
+    return sorted([*_OSNET_VARIANTS, FASTREID_SBS_ARCHITECTURE])
+
+
+def checkpoint_remap_for_architecture(architecture: str) -> Callable[[dict], dict] | None:
+    """Return a checkpoint key remap for *architecture*, if one is registered."""
+    if architecture == FASTREID_SBS_ARCHITECTURE:
+        return remap_fastreid_sbs_state_dict
+    return None

--- a/src/trackers/core/reid/architectures/fastreid_sbs.py
+++ b/src/trackers/core/reid/architectures/fastreid_sbs.py
@@ -1,0 +1,130 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+#
+# Adapted from JDAI-CV/fast-reid (Apache-2.0)
+# Copyright 2019 JD.com Inc. JD AI
+# Source: https://github.com/JDAI-CV/fast-reid
+#   - GeM: fastreid/layers/pooling.py (GeneralizedMeanPooling / GeneralizedMeanPoolingP)
+#   - SBS head layout: fastreid/modeling/heads/embedding_head.py
+#   - last_stride=1 ResNeSt semantics: fastreid/modeling/backbones/resnest.py
+# Also used via BoT-SORT's FastReIDInterface (NirAharon/BoT-SORT, MIT).
+# ------------------------------------------------------------------------
+
+"""FastReID Strong Baseline (SBS) inference stack for BoT-SORT checkpoints.
+
+Uses ``timm`` ``resnest50d`` with a small FastReID ``last_stride=1`` patch on
+``layer4[0]``, then Generalized Mean Pooling and a BatchNorm neck — the same
+inference path as FastReID ``EmbeddingHead`` in eval.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import timm
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+__all__ = [
+    "FASTREID_SBS_ARCHITECTURE",
+    "FastReIDSBSResNeSt50",
+    "build_fastreid_sbs_resnest50",
+    "remap_fastreid_sbs_state_dict",
+]
+
+FASTREID_SBS_ARCHITECTURE = "fastreid_sbs_resnest50"
+FASTREID_SBS_EMBED_DIM = 2048
+
+
+def _patch_resnest50d_for_fastreid_last_stride(backbone: nn.Module) -> nn.Module:
+    """Align ``timm`` ``resnest50d`` (``output_stride=16``) with FastReID ResNeSt.
+
+    FastReID ``LAST_STRIDE=1`` keeps layer4 spatial stride at 1 via:
+    - downsample avg-pool kernel 1 (identity spatial size), and
+    - average-downsampling (AVD) after the Split-Attention conv with stride 1.
+
+    ``timm``'s dilated / stride-16 path instead uses ``AvgPool2dSame(2, stride=1)``
+    and leaves ``avd_last`` unset on ``layer4[0]``, which shifts embeddings even
+    when checkpoint keys load 100%.
+    """
+    backbone_any = cast(Any, backbone)
+    block = backbone_any.layer4[0]
+    block.downsample[0] = nn.AvgPool2d(kernel_size=1, stride=1, padding=0)
+    block.avd_last = nn.AvgPool2d(kernel_size=3, stride=1, padding=1)
+    return backbone
+
+
+class GeneralizedMeanPooling(nn.Module):
+    """GeM pooling used by FastReID SBS (learnable exponent *p*).
+
+    ``p`` defaults to 3.0 only until checkpoint load; MOT17 SBS-S50 stores the
+    trained value under ``heads.pool_layer.p`` (≈1.72). See
+    :func:`remap_fastreid_sbs_state_dict`.
+    """
+
+    def __init__(self, p: float = 3.0, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.p = nn.Parameter(torch.ones(1) * p)
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.clamp(min=self.eps).pow(self.p)
+        x = F.adaptive_avg_pool2d(x, 1)
+        return x.pow(1.0 / self.p)
+
+
+class FastReIDSBSResNeSt50(nn.Module):
+    """ResNeSt50 SBS re-ID encoder matching BoT-SORT / FastReID MOT17 checkpoints.
+
+    Inference path: patched ``timm`` ResNeSt-50 → GeM (:attr:`pool`) → BNNeck
+    (:attr:`bottleneck`). Weights for all three stages load from a BoT-SORT
+    ``.pth`` via :func:`remap_fastreid_sbs_state_dict`.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        backbone = timm.create_model(
+            "resnest50d",
+            pretrained=False,
+            num_classes=0,
+            global_pool="",
+            output_stride=16,
+        )
+        self.backbone = _patch_resnest50d_for_fastreid_last_stride(backbone)
+        self.pool = GeneralizedMeanPooling()
+        self.bottleneck = nn.BatchNorm1d(FASTREID_SBS_EMBED_DIM)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.backbone(x)
+        x = self.pool(x).flatten(1)
+        return self.bottleneck(x)
+
+
+def build_fastreid_sbs_resnest50(*, num_classes: int = 0, pretrained: bool = False) -> FastReIDSBSResNeSt50:
+    """Build the BoT-SORT FastReID SBS ResNeSt50 encoder (weights loaded separately)."""
+    del num_classes, pretrained
+    return FastReIDSBSResNeSt50()
+
+
+def remap_fastreid_sbs_state_dict(state_dict: dict) -> dict:
+    """Map BoT-SORT / FastReID SBS checkpoint keys onto :class:`FastReIDSBSResNeSt50`.
+
+    Renames FastReID ``heads.*`` keys to ``pool.*`` / ``bottleneck.*`` and passes
+    ``backbone.*`` through unchanged. Skips ``heads.weight`` (classifier). GeM
+    ``heads.pool_layer.p`` becomes ``pool.p`` and replaces the 3.0 init default.
+    """
+    mapped: dict = {}
+    for key, value in state_dict.items():
+        key = key[7:] if key.startswith("module.") else key
+        if key.startswith("backbone."):
+            mapped[key] = value
+        elif key == "heads.pool_layer.p":
+            mapped["pool.p"] = value
+        elif key.startswith("heads.bottleneck.0."):
+            mapped["bottleneck." + key[len("heads.bottleneck.0.") :]] = value
+        # Skip heads.weight (identity classifier; unused at inference).
+    return mapped

--- a/src/trackers/core/reid/architectures/osnet.py
+++ b/src/trackers/core/reid/architectures/osnet.py
@@ -1,0 +1,295 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+#
+# Adapted from KaiyangZhou/deep-person-reid
+# Copyright (c) 2018-2021 Kaiyang Zhou
+# Licensed under the MIT License
+# Source: https://github.com/KaiyangZhou/deep-person-reid/blob/master/torchreid/models/osnet.py
+# Paper: Zhou et al. Omni-Scale Feature Learning for Person Re-Identification. ICCV, 2019.
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+__all__ = ["OSNet", "build_osnet"]
+
+
+# --------------------------------------------------------------------------- #
+# Basic layers
+# --------------------------------------------------------------------------- #
+
+
+class _ConvBnRelu(nn.Module):
+    """Conv2d → BatchNorm2d → ReLU building block."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        padding: int = 0,
+        groups: int = 1,
+    ) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=padding,
+            bias=False,
+            groups=groups,
+        )
+        self.bn = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.relu(self.bn(self.conv(x)))
+
+
+class _Conv1x1(_ConvBnRelu):
+    """1x1 conv + BN + ReLU."""
+
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 1, groups: int = 1) -> None:
+        super().__init__(in_channels, out_channels, 1, stride=stride, padding=0, groups=groups)
+
+
+class _Conv1x1Linear(nn.Module):
+    """1x1 conv + BN (no non-linearity)."""
+
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 1) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(in_channels, out_channels, 1, stride=stride, padding=0, bias=False)
+        self.bn = nn.BatchNorm2d(out_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.bn(self.conv(x))
+
+
+class _LightConv3x3(nn.Module):
+    """Lightweight 3x3 conv: 1x1 linear + depthwise 3x3 + BN + ReLU."""
+
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_channels, out_channels, 1, stride=1, padding=0, bias=False)
+        self.conv2 = nn.Conv2d(out_channels, out_channels, 3, stride=1, padding=1, bias=False, groups=out_channels)
+        self.bn = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.relu(self.bn(self.conv2(self.conv1(x))))
+
+
+# --------------------------------------------------------------------------- #
+# Omni-scale building blocks
+# --------------------------------------------------------------------------- #
+
+
+class _ChannelGate(nn.Module):
+    """Channel-wise gating via squeeze-and-excitation."""
+
+    def __init__(self, in_channels: int, reduction: int = 16) -> None:
+        super().__init__()
+        self.global_avgpool = nn.AdaptiveAvgPool2d(1)
+        self.fc1 = nn.Conv2d(in_channels, in_channels // reduction, 1, bias=True)
+        self.relu = nn.ReLU(inplace=True)
+        self.fc2 = nn.Conv2d(in_channels // reduction, in_channels, 1, bias=True)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        g = self.sigmoid(self.fc2(self.relu(self.fc1(self.global_avgpool(x)))))
+        return x * g
+
+
+class OSBlock(nn.Module):
+    """Omni-scale feature learning residual block.
+
+    Aggregates features from four parallel streams with different effective
+    receptive-field depths (1, 2, 3, 4 stacked lightweight 3x3 convs) gated
+    by a shared channel-wise gate before the residual addition.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, bottleneck_reduction: int = 4) -> None:
+        super().__init__()
+        mid = out_channels // bottleneck_reduction
+        self.conv1 = _Conv1x1(in_channels, mid)
+        self.conv2a = _LightConv3x3(mid, mid)
+        self.conv2b = nn.Sequential(_LightConv3x3(mid, mid), _LightConv3x3(mid, mid))
+        self.conv2c = nn.Sequential(_LightConv3x3(mid, mid), _LightConv3x3(mid, mid), _LightConv3x3(mid, mid))
+        self.conv2d = nn.Sequential(
+            _LightConv3x3(mid, mid),
+            _LightConv3x3(mid, mid),
+            _LightConv3x3(mid, mid),
+            _LightConv3x3(mid, mid),
+        )
+        self.gate = _ChannelGate(mid)
+        self.conv3 = _Conv1x1Linear(mid, out_channels)
+        self.downsample = _Conv1x1Linear(in_channels, out_channels) if in_channels != out_channels else None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        identity = x
+        x1 = self.conv1(x)
+        x2 = (
+            self.gate(self.conv2a(x1))
+            + self.gate(self.conv2b(x1))
+            + self.gate(self.conv2c(x1))
+            + self.gate(self.conv2d(x1))
+        )
+        x3 = self.conv3(x2)
+        if self.downsample is not None:
+            identity = self.downsample(identity)
+        return F.relu(x3 + identity)
+
+
+# --------------------------------------------------------------------------- #
+# Full OSNet architecture
+# --------------------------------------------------------------------------- #
+
+
+class OSNet(nn.Module):
+    """Omni-Scale Network for instance re-identification.
+
+    Architecture from:
+        Zhou et al. *Omni-Scale Feature Learning for Person Re-Identification*. ICCV, 2019.
+        Zhou et al. *Learning Generalisable Omni-Scale Representations for Person Re-Identification*. TPAMI, 2021.
+
+    At inference (``model.eval()``) ``forward()`` returns the L2-normalizable
+    ``feature_dim``-dimensional embedding vector **before** the classifier, so
+    ``num_classes`` is only relevant when training from scratch.
+
+    Args:
+        num_classes: Number of identity classes for the classification head
+            (only used during training).
+        blocks: List of block classes for each stage.
+        layers: Number of blocks per stage.
+        channels: Channel widths ``[stem, stage1, stage2, stage3]``.
+        feature_dim: Dimensionality of the final embedding vector.
+    """
+
+    def __init__(
+        self,
+        num_classes: int,
+        blocks: list[type[nn.Module]],
+        layers: list[int],
+        channels: list[int],
+        feature_dim: int = 512,
+    ) -> None:
+        super().__init__()
+        if len(blocks) != len(layers) or len(layers) != len(channels) - 1:
+            raise ValueError("blocks, layers, and channels must have consistent lengths")
+
+        self.feature_dim = feature_dim
+        self.conv1 = _ConvBnRelu(3, channels[0], 7, stride=2, padding=3)
+        self.maxpool = nn.MaxPool2d(3, stride=2, padding=1)
+        self.conv2 = self._make_layer(blocks[0], layers[0], channels[0], channels[1], downsample=True)
+        self.conv3 = self._make_layer(blocks[1], layers[1], channels[1], channels[2], downsample=True)
+        self.conv4 = self._make_layer(blocks[2], layers[2], channels[2], channels[3], downsample=False)
+        self.conv5 = _Conv1x1(channels[3], channels[3])
+        self.global_avgpool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Sequential(
+            nn.Linear(channels[3], feature_dim),
+            nn.BatchNorm1d(feature_dim),
+            nn.ReLU(inplace=True),
+        )
+        self.classifier = nn.Linear(feature_dim, num_classes)
+        self._init_params()
+
+    @staticmethod
+    def _make_layer(
+        block: type[nn.Module],
+        num_blocks: int,
+        in_channels: int,
+        out_channels: int,
+        downsample: bool,
+    ) -> nn.Sequential:
+        layers: list[nn.Module] = [block(in_channels, out_channels)]
+        for _ in range(1, num_blocks):
+            layers.append(block(out_channels, out_channels))
+        if downsample:
+            layers.append(nn.Sequential(_Conv1x1(out_channels, out_channels), nn.AvgPool2d(2, stride=2)))
+        return nn.Sequential(*layers)
+
+    def _init_params(self) -> None:
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, (nn.BatchNorm2d, nn.BatchNorm1d)):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.Linear):
+                nn.init.normal_(m.weight, 0, 0.01)
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+
+    def _featuremaps(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(x)
+        x = self.maxpool(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+        x = self.conv4(x)
+        return self.conv5(x)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run a forward pass.
+
+        Returns the embedding vector at inference time (``model.eval()``) and
+        classifier logits during training (``model.train()``).
+        """
+        x = self._featuremaps(x)
+        v = self.global_avgpool(x).view(x.size(0), -1)
+        v = self.fc(v)
+        if not self.training:
+            return v
+        return self.classifier(v)
+
+
+# --------------------------------------------------------------------------- #
+# Factory
+# --------------------------------------------------------------------------- #
+
+_CONFIGS: dict[str, dict] = {
+    "x1_0": {"channels": [64, 256, 384, 512]},
+    "x0_75": {"channels": [48, 192, 288, 384]},
+    "x0_5": {"channels": [32, 128, 192, 256]},
+    "x0_25": {"channels": [16, 64, 96, 128]},
+}
+
+
+def build_osnet(variant: str = "x1_0", num_classes: int = 1) -> OSNet:
+    """Instantiate an OSNet architecture without loading weights.
+
+    Args:
+        variant: Width multiplier variant. One of ``"x1_0"`` (default),
+            ``"x0_75"``, ``"x0_5"``, ``"x0_25"``.
+        num_classes: Number of output classes for the classification head.
+            Only used during training; ignored at inference (``model.eval()``).
+
+    Returns:
+        An initialised :class:`OSNet` in training mode.
+
+    Raises:
+        ValueError: If *variant* is not one of the supported values.
+
+    Examples:
+        >>> model = build_osnet("x1_0")
+        >>> model.feature_dim
+        512
+    """
+    if variant not in _CONFIGS:
+        raise ValueError(f"Unknown OSNet variant '{variant}'. Choose from: {list(_CONFIGS)}")
+    cfg = _CONFIGS[variant]
+    return OSNet(
+        num_classes=num_classes,
+        blocks=[OSBlock, OSBlock, OSBlock],
+        layers=[2, 2, 2],
+        channels=cfg["channels"],
+    )

--- a/src/trackers/core/reid/distance.py
+++ b/src/trackers/core/reid/distance.py
@@ -1,0 +1,79 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Appearance similarity utilities for tracker association."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+from trackers.core.reid.feature_bank import FeatureBank
+
+
+def sanitize_embedding_matrix(embeddings: np.ndarray) -> np.ndarray:
+    """Replace non-finite rows with zeros so cosine similarity stays safe."""
+    if embeddings.size == 0:
+        return embeddings
+    cleaned = np.asarray(embeddings, dtype=np.float32)
+    if cleaned.ndim != 2:
+        raise ValueError(f"det_embeddings must be 2-D, got shape {cleaned.shape}")
+    row_finite = np.isfinite(cleaned).all(axis=1)
+    if not np.all(row_finite):
+        cleaned = cleaned.copy()
+        cleaned[~row_finite] = 0.0
+    return cleaned
+
+
+def appearance_similarity(
+    track_features: Sequence[np.ndarray | None],
+    det_embeddings: np.ndarray,
+) -> np.ndarray:
+    """Compute cosine similarity between track features and detection embeddings.
+
+    Both inputs are expected to be L2-normalised. Tracks with ``None`` features
+    receive similarity ``0.0``. Non-finite detection rows are zeroed before the
+    dot product so they cannot poison assignment. Track rows whose embedding
+    dimension does not match the detection matrix are treated as unavailable.
+
+    Args:
+        track_features: One embedding per track (``None`` = no feature yet).
+        det_embeddings: Detection embeddings, shape ``(N, D)``.
+
+    Returns:
+        Similarity matrix of shape ``(T, N)``.
+    """
+    n_tracks = len(track_features)
+    det_embeddings = sanitize_embedding_matrix(det_embeddings)
+    n_dets = det_embeddings.shape[0]
+    sim = np.zeros((n_tracks, n_dets), dtype=np.float32)
+
+    if n_tracks == 0 or n_dets == 0:
+        return sim
+
+    embed_dim = det_embeddings.shape[1]
+    track_rows: list[np.ndarray] = []
+    kept_indices: list[int] = []
+    for track_idx, feature in enumerate(track_features):
+        if feature is None:
+            continue
+        normalized = FeatureBank.normalize_embedding(feature)
+        if normalized is None or normalized.shape[0] != embed_dim:
+            continue
+        track_rows.append(normalized)
+        kept_indices.append(track_idx)
+
+    if not track_rows:
+        return sim
+
+    track_matrix = np.stack(track_rows)
+    cos_sims = (track_matrix @ det_embeddings.T).astype(np.float32)
+
+    for local_idx, track_idx in enumerate(kept_indices):
+        sim[track_idx] = cos_sims[local_idx]
+
+    return sim

--- a/src/trackers/core/reid/eval/__init__.py
+++ b/src/trackers/core/reid/eval/__init__.py
@@ -1,0 +1,46 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from trackers.core.reid.eval.datasets import ReIDSplit, ReidSplit, load_market1501, load_msmt17
+from trackers.core.reid.eval.metrics import ReIDMetrics, ReidMetrics, compute_reid_metrics
+
+__all__ = [
+    "ReIDEvaluator",
+    "ReIDMetrics",
+    "ReIDResult",
+    "ReIDSplit",
+    "ReidEvaluator",
+    "ReidMetrics",
+    "ReidResult",
+    "ReidSplit",
+    "compute_reid_metrics",
+    "load_market1501",
+    "load_msmt17",
+]
+
+
+def __getattr__(name: str) -> object:
+    if name in ("ReIDEvaluator", "ReidEvaluator"):
+        from trackers.core.reid._lazy import import_reid_symbol
+
+        value = import_reid_symbol("trackers.core.reid.eval.evaluator", "ReIDEvaluator")
+        globals()["ReIDEvaluator"] = value
+        globals()["ReidEvaluator"] = value
+        return value
+    if name in ("ReIDResult", "ReidResult"):
+        from trackers.core.reid._lazy import import_reid_symbol
+
+        value = import_reid_symbol("trackers.core.reid.eval.evaluator", "ReIDResult")
+        globals()["ReIDResult"] = value
+        globals()["ReidResult"] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/trackers/core/reid/eval/datasets.py
+++ b/src/trackers/core/reid/eval/datasets.py
@@ -1,0 +1,154 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Re-ID benchmark dataset loaders (Market-1501, MSMT17)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+# Market-1501 gallery ``0000_*`` images are distractors (pid 0). Query identities
+# remain valid when pid=0 on other datasets (e.g. MSMT17).
+MARKET1501_GALLERY_JUNK_PIDS = frozenset({-1, 0})
+
+
+@dataclass
+class ReIDSplit:
+    """Query or gallery split: image paths, person IDs, and camera IDs.
+
+    ``gallery_junk_pids`` controls which gallery person IDs are excluded from
+    ranking during retrieval evaluation (see :func:`compute_reid_metrics`).
+    """
+
+    image_paths: list[str]
+    pids: np.ndarray
+    camids: np.ndarray
+    gallery_junk_pids: frozenset[int] = frozenset({-1})
+
+    def __len__(self) -> int:
+        return len(self.image_paths)
+
+
+# Backward-compatible alias (notebooks / early API).
+ReidSplit = ReIDSplit
+
+
+# --------------------------------------------------------------------------- #
+# MSMT17
+# --------------------------------------------------------------------------- #
+
+
+def _parse_msmt17_camid(filename: str) -> int:
+    """Extract 0-indexed camid from an MSMT17 image filename.
+
+    Filename format: ``<pid>_<idx>_<camid>_<scene>_<frame>_<track>.jpg``
+    Example: ``0001_019_07_0303morning_0020_1.jpg`` → camid = 6 (0-indexed).
+    """
+    stem = Path(filename).stem
+    return int(stem.split("_")[2]) - 1
+
+
+def load_msmt17(root: str | Path) -> tuple[ReIDSplit, ReIDSplit]:
+    """Load MSMT17 query and gallery splits from *root*.
+
+    Expects ``test/``, ``list_query.txt``, and ``list_gallery.txt``. List files
+    may be 2-column (``path pid``; camid from filename) or 3-column.
+
+    Args:
+        root: Path to the MSMT17 directory.
+
+    Returns:
+        ``(query, gallery)`` :class:`ReIDSplit` pair.
+    """
+    root = Path(root)
+    if not root.exists():
+        raise FileNotFoundError(f"MSMT17 root not found: {root}")
+
+    def _parse_list(list_file: Path, image_root: Path) -> ReIDSplit:
+        if not list_file.exists():
+            raise FileNotFoundError(f"MSMT17 list file not found: {list_file}")
+        paths, pids, camids = [], [], []
+        for line in list_file.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            rel_path = parts[0]
+            pid = int(parts[1])
+            camid = int(parts[2]) if len(parts) >= 3 else _parse_msmt17_camid(Path(rel_path).name)
+            paths.append(str(image_root / rel_path))
+            pids.append(pid)
+            camids.append(camid)
+        return ReIDSplit(
+            image_paths=paths,
+            pids=np.array(pids, dtype=np.int32),
+            camids=np.array(camids, dtype=np.int32),
+            gallery_junk_pids=frozenset({-1}),
+        )
+
+    test_root = root / "test"
+    query = _parse_list(root / "list_query.txt", test_root)
+    gallery = _parse_list(root / "list_gallery.txt", test_root)
+    return query, gallery
+
+
+# --------------------------------------------------------------------------- #
+# Market-1501
+# --------------------------------------------------------------------------- #
+
+
+def _parse_market_filename(filename: str) -> tuple[int, int]:
+    """Parse ``(pid, camid)`` from a Market-1501 filename.
+
+    ``-1_*`` → junk (``pid=-1``); ``0000_*`` → distractor (``pid=0``).
+    """
+    stem = Path(filename).stem
+    parts = stem.split("_")
+    pid = int(parts[0])
+    camid = int(parts[1][1]) - 1  # "c1" → 0
+    return pid, camid
+
+
+def load_market1501(root: str | Path) -> tuple[ReIDSplit, ReIDSplit]:
+    """Load Market-1501 query and gallery splits from *root*.
+
+    Expects ``query/`` and ``bounding_box_test/``. Person and camera IDs are
+    parsed from filenames (see :func:`_parse_market_filename`).
+
+    Args:
+        root: Path to the Market-1501 directory.
+
+    Returns:
+        ``(query, gallery)`` :class:`ReIDSplit` pair.
+    """
+    root = Path(root)
+    if not root.exists():
+        raise FileNotFoundError(f"Market-1501 root not found: {root}")
+
+    def _load_dir(subdir: Path, *, gallery_junk_pids: frozenset[int]) -> ReIDSplit:
+        if not subdir.exists():
+            raise FileNotFoundError(f"Market-1501 sub-directory not found: {subdir}")
+        paths, pids, camids = [], [], []
+        for img_path in sorted(subdir.glob("*.jpg")):
+            pid, camid = _parse_market_filename(img_path.name)
+            paths.append(str(img_path))
+            pids.append(pid)
+            camids.append(camid)
+        return ReIDSplit(
+            image_paths=paths,
+            pids=np.array(pids, dtype=np.int32),
+            camids=np.array(camids, dtype=np.int32),
+            gallery_junk_pids=gallery_junk_pids,
+        )
+
+    query = _load_dir(root / "query", gallery_junk_pids=frozenset({-1}))
+    gallery = _load_dir(root / "bounding_box_test", gallery_junk_pids=MARKET1501_GALLERY_JUNK_PIDS)
+    return query, gallery

--- a/src/trackers/core/reid/eval/evaluator.py
+++ b/src/trackers/core/reid/eval/evaluator.py
@@ -1,0 +1,142 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""End-to-end re-ID evaluation pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from trackers.core.reid.eval.datasets import ReIDSplit
+from trackers.core.reid.eval.metrics import ReIDMetrics, compute_reid_metrics
+from trackers.core.reid.protocols import ReIDPathEncoder
+
+
+@dataclass
+class ReIDResult:
+    """Evaluation output: metrics, raw embeddings, and optional distance matrix."""
+
+    metrics: ReIDMetrics
+    query_embeddings: np.ndarray
+    gallery_embeddings: np.ndarray
+    distmat: np.ndarray
+
+
+# Backward-compatible alias (notebooks / early API).
+ReidResult = ReIDResult
+
+
+def _distance_matrix(q_embs: np.ndarray, g_embs: np.ndarray, metric: str) -> np.ndarray:
+    """Build a query x gallery distance matrix (``cosine`` or ``euclidean``)."""
+    if metric == "cosine":
+        qn = (q_embs / (np.linalg.norm(q_embs, axis=1, keepdims=True) + 1e-12)).astype(np.float32, copy=False)
+        gn = (g_embs / (np.linalg.norm(g_embs, axis=1, keepdims=True) + 1e-12)).astype(np.float32, copy=False)
+        distmat = qn @ gn.T
+        distmat *= -1.0
+        distmat += 1.0
+        return distmat
+    if metric == "euclidean":
+        distmat = (q_embs @ g_embs.T).astype(np.float32, copy=False)
+        distmat *= -2.0
+        distmat += (q_embs**2).sum(axis=1, keepdims=True)
+        distmat += (g_embs**2).sum(axis=1, keepdims=True).T
+        np.maximum(distmat, 0.0, out=distmat)
+        np.sqrt(distmat, out=distmat)
+        return distmat
+    raise ValueError(f"Unknown distance metric: {metric!r}. Use 'cosine' or 'euclidean'.")
+
+
+class ReIDEvaluator:
+    """Run embedding extraction and retrieval metrics for a Re-ID encoder.
+
+    Args:
+        model: Encoder implementing :class:`~trackers.core.reid.protocols.ReIDPathEncoder`
+            (for example :class:`~trackers.core.reid.model.ReIDModel`).
+        batch_size: Images per forward pass.
+    """
+
+    def __init__(self, model: ReIDPathEncoder, batch_size: int = 64) -> None:
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+        self._model = model
+        self._batch_size = batch_size
+
+    def evaluate(
+        self,
+        query: ReIDSplit,
+        gallery: ReIDSplit,
+        max_rank: int = 10,
+        verbose: bool = True,
+        distance: str = "cosine",
+        query_embeddings: np.ndarray | None = None,
+        gallery_embeddings: np.ndarray | None = None,
+        return_distmat: bool = True,
+    ) -> ReIDResult:
+        """Extract embeddings (unless provided) and compute retrieval metrics.
+
+        Args:
+            query: Query split.
+            gallery: Gallery split.
+            max_rank: Highest CMC rank to report.
+            verbose: Print progress to stdout.
+            distance: ``"cosine"`` or ``"euclidean"``.
+            query_embeddings: Optional pre-extracted raw query embeddings.
+            gallery_embeddings: Optional pre-extracted raw gallery embeddings.
+            return_distmat: Return the distance matrix (set ``False`` to save memory).
+
+        Returns:
+            :class:`ReIDResult`.
+        """
+        if query_embeddings is None or gallery_embeddings is None:
+            if verbose:
+                print(f"Extracting query embeddings  ({len(query)} images)…")
+            q_embs = self._model.extract_features_from_paths(
+                query.image_paths, batch_size=self._batch_size, normalize=False
+            )
+
+            if verbose:
+                print(f"Extracting gallery embeddings ({len(gallery)} images)…")
+            g_embs = self._model.extract_features_from_paths(
+                gallery.image_paths, batch_size=self._batch_size, normalize=False
+            )
+        else:
+            q_embs, g_embs = query_embeddings, gallery_embeddings
+
+        if verbose:
+            print(f"Computing distance matrix ({distance})…")
+        distmat = _distance_matrix(q_embs, g_embs, distance)
+
+        if verbose:
+            print("Computing metrics…")
+        metrics = compute_reid_metrics(
+            distmat=distmat,
+            q_pids=query.pids,
+            g_pids=gallery.pids,
+            q_camids=query.camids,
+            g_camids=gallery.camids,
+            max_rank=max_rank,
+            gallery_junk_pids=gallery.gallery_junk_pids,
+        )
+
+        if verbose:
+            print(f"\nResults ({distance})\n{'-' * 50}\n{metrics}\n{'-' * 50}")
+
+        if not return_distmat:
+            del distmat
+            distmat = np.empty((0, 0), dtype=np.float32)
+
+        return ReIDResult(
+            metrics=metrics,
+            query_embeddings=q_embs,
+            gallery_embeddings=g_embs,
+            distmat=distmat,
+        )
+
+
+# Backward-compatible alias (notebooks / early API).
+ReidEvaluator = ReIDEvaluator

--- a/src/trackers/core/reid/eval/metrics.py
+++ b/src/trackers/core/reid/eval/metrics.py
@@ -1,0 +1,148 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Re-ID retrieval metrics (CMC, mAP, mINP)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class ReIDMetrics:
+    """CMC / mAP / mINP scores (percentages) for one evaluation run."""
+
+    mean_average_precision: float
+    rank1: float
+    rank5: float
+    rank10: float
+    minp: float
+    num_queries: int
+
+    @property
+    def map(self) -> float:
+        """Backward-compatible alias for :attr:`mean_average_precision`."""
+        return self.mean_average_precision
+
+    def __str__(self) -> str:
+        return (
+            f"mAP: {self.mean_average_precision:.1f}%  "
+            f"Rank-1: {self.rank1:.1f}%  "
+            f"Rank-5: {self.rank5:.1f}%  "
+            f"Rank-10: {self.rank10:.1f}%  "
+            f"mINP: {self.minp:.1f}%  "
+            f"(n={self.num_queries})"
+        )
+
+
+# Backward-compatible alias (notebooks / early API).
+ReidMetrics = ReIDMetrics
+
+
+def compute_reid_metrics(
+    distmat: np.ndarray,
+    q_pids: np.ndarray,
+    g_pids: np.ndarray,
+    q_camids: np.ndarray,
+    g_camids: np.ndarray,
+    max_rank: int = 10,
+    *,
+    gallery_junk_pids: frozenset[int] = frozenset({-1}),
+) -> ReIDMetrics:
+    """Compute CMC, mAP, and mINP from a query x gallery distance matrix.
+
+    Excludes same-(pid, camid) gallery matches and gallery junk person IDs
+    (``pid in gallery_junk_pids``). Market-1501 gallery distractors use
+    ``gallery_junk_pids=frozenset({-1, 0})``; datasets where ``pid=0`` is
+    valid should keep the default ``{-1}`` only.
+
+    Args:
+        distmat: Distance matrix ``(num_queries, num_gallery)`` (lower = closer).
+        q_pids: Query person IDs.
+        g_pids: Gallery person IDs.
+        q_camids: Query camera IDs.
+        g_camids: Gallery camera IDs.
+        max_rank: Highest CMC rank to compute.
+        gallery_junk_pids: Gallery person IDs treated as junk during ranking.
+
+    Returns:
+        :class:`ReIDMetrics` with scores as percentages.
+    """
+    num_q, num_g = distmat.shape
+
+    if len(q_pids) != num_q or len(q_camids) != num_q:
+        raise ValueError("q_pids / q_camids length must match distmat rows.")
+    if len(g_pids) != num_g or len(g_camids) != num_g:
+        raise ValueError("g_pids / g_camids length must match distmat columns.")
+    if max_rank < 1:
+        raise ValueError(f"max_rank must be >= 1, got {max_rank}")
+
+    cmc_accumulator = np.zeros(max_rank, dtype=np.float64)
+    ap_list: list[float] = []
+    inp_list: list[float] = []
+
+    junk_pid_array = np.array(sorted(gallery_junk_pids), dtype=g_pids.dtype) if gallery_junk_pids else np.empty(0)
+
+    for q_idx in range(num_q):
+        q_pid = q_pids[q_idx]
+        q_camid = q_camids[q_idx]
+
+        order = np.argsort(distmat[q_idx])
+        sorted_g_pids = g_pids[order]
+        sorted_g_camids = g_camids[order]
+
+        junk = (sorted_g_pids == q_pid) & (sorted_g_camids == q_camid)
+        if junk_pid_array.size > 0:
+            junk |= np.isin(sorted_g_pids, junk_pid_array)
+        valid = ~junk
+
+        sorted_g_pids_valid = sorted_g_pids[valid]
+        matches = (sorted_g_pids_valid == q_pid).astype(np.float32)
+
+        num_rel = int(matches.sum())
+        if num_rel == 0:
+            continue
+
+        cmc_q = np.minimum(matches.cumsum(), 1.0)
+        if len(cmc_q) < max_rank:
+            if len(cmc_q) == 0:
+                continue
+            cmc_q = np.pad(cmc_q, (0, max_rank - len(cmc_q)), constant_values=cmc_q[-1])
+        else:
+            cmc_q = cmc_q[:max_rank]
+        cmc_accumulator += cmc_q
+
+        num_valid = len(matches)
+        precision_at_k = matches.cumsum() / (np.arange(num_valid) + 1)
+        ap = float((precision_at_k * matches).sum() / num_rel)
+        ap_list.append(ap)
+
+        last_true = int(np.where(matches)[0][-1]) + 1
+        inp_list.append(num_rel / last_true)
+
+    n = len(ap_list)
+    if n == 0:
+        return ReIDMetrics(
+            mean_average_precision=0.0,
+            rank1=0.0,
+            rank5=0.0,
+            rank10=0.0,
+            minp=0.0,
+            num_queries=0,
+        )
+
+    cmc = (cmc_accumulator / n) * 100.0
+
+    return ReIDMetrics(
+        mean_average_precision=float(np.mean(ap_list)) * 100.0,
+        rank1=float(cmc[0]),
+        rank5=float(cmc[min(4, max_rank - 1)]),
+        rank10=float(cmc[min(9, max_rank - 1)]),
+        minp=float(np.mean(inp_list)) * 100.0,
+        num_queries=n,
+    )

--- a/src/trackers/core/reid/extraction.py
+++ b/src/trackers/core/reid/extraction.py
@@ -1,0 +1,35 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Detection embedding extraction for tracker association."""
+
+from __future__ import annotations
+
+import numpy as np
+import supervision as sv
+
+from trackers.core.reid.protocols import ReIDEncoder
+
+
+def extract_detection_embeddings(
+    model: ReIDEncoder,
+    frame: np.ndarray,
+    boxes: np.ndarray,
+) -> np.ndarray:
+    """Extract L2-normalised appearance embeddings for detection boxes.
+
+    Args:
+        model: Re-ID encoder used to embed each crop.
+        frame: BGR video frame containing the detections.
+        boxes: Detection bounding boxes, shape ``(N, 4)`` in ``xyxy`` format.
+
+    Returns:
+        Embedding matrix of shape ``(N, D)``.  Returns ``(0, 0)`` when
+        ``boxes`` is empty.
+    """
+    if len(boxes) == 0:
+        return np.empty((0, 0), dtype=np.float32)
+    return model.extract_features(sv.Detections(xyxy=boxes), frame)

--- a/src/trackers/core/reid/feature_bank.py
+++ b/src/trackers/core/reid/feature_bank.py
@@ -1,0 +1,79 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Per-track exponential moving average feature bank."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class FeatureBank:
+    """EMA-smoothed appearance embedding for a single track.
+
+    Every ingested vector is L2-normalised. Non-finite, zero-norm, or
+    incompatible-shape inputs are ignored: the bank keeps its previous state
+    (or stays uninitialized).
+
+    Args:
+        alpha: EMA momentum in ``[0, 1]`` (``0.9`` default).
+    """
+
+    def __init__(self, alpha: float = 0.9) -> None:
+        if not 0.0 <= alpha <= 1.0:
+            raise ValueError(f"alpha must be in [0, 1], got {alpha}")
+        self._alpha = alpha
+        self._feature: np.ndarray | None = None
+
+    @property
+    def feature(self) -> np.ndarray | None:
+        """Current L2-normalised embedding, or ``None`` if never updated."""
+        return None if self._feature is None else self._feature.copy()
+
+    @property
+    def is_initialized(self) -> bool:
+        """``True`` once at least one valid embedding has been ingested."""
+        return self._feature is not None
+
+    @staticmethod
+    def normalize_embedding(embedding: np.ndarray) -> np.ndarray | None:
+        """Return an L2-normalised 1-D vector, or ``None`` when unusable."""
+        flat = np.asarray(embedding, dtype=np.float64).reshape(-1)
+        if flat.size == 0 or not np.all(np.isfinite(flat)):
+            return None
+        norm = float(np.linalg.norm(flat))
+        if norm < 1e-8:
+            return None
+        return (flat / norm).astype(np.float32)
+
+    def update(self, embedding: np.ndarray) -> bool:
+        """Blend a normalised *embedding* into the stored feature.
+
+        Returns:
+            ``True`` when the bank accepted the vector; ``False`` when the
+            input was skipped (non-finite, zero norm, incompatible shape, etc.).
+        """
+        normalized = self.normalize_embedding(embedding)
+        if normalized is None:
+            return False
+
+        if self._feature is None:
+            self._feature = normalized.copy()
+            return True
+
+        if self._feature.shape != normalized.shape:
+            return False
+
+        blended = self._alpha * self._feature + (1.0 - self._alpha) * normalized
+        blended_norm = self.normalize_embedding(blended)
+        if blended_norm is None:
+            return False
+        self._feature = blended_norm
+        return True
+
+    def reset(self) -> None:
+        """Clear the stored feature."""
+        self._feature = None

--- a/src/trackers/core/reid/model.py
+++ b/src/trackers/core/reid/model.py
@@ -1,0 +1,305 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Re-ID appearance encoder: loading, inference, and checkpoint I/O."""
+
+from __future__ import annotations
+
+import logging
+import os
+import warnings
+
+import numpy as np
+import supervision as sv
+import torch
+import torch.nn as nn
+from PIL import Image as PILImage
+from safetensors.torch import save_file
+
+from trackers.core.reid.architectures import build_architecture
+from trackers.core.reid.models.loaders import load_state_dict_for_architecture, resolve_weights
+from trackers.core.reid.models.preprocessing import ReIDPreprocessing
+from trackers.core.reid.models.registry import (
+    DEFAULT_MODEL,
+    FASTREID_MOT17_SBS50,
+    ModelCard,
+    default_preprocessing_for_architecture,
+    resolve_model_card,
+    save_model_config,
+)
+from trackers.utils.device import _best_device
+
+logger = logging.getLogger(__name__)
+
+
+def _clamp_xyxy_to_frame(box: np.ndarray, height: int, width: int) -> np.ndarray:
+    """Clip a box to frame bounds with at least 1 px width and height."""
+    x1, y1, x2, y2 = box.astype(float)
+    max_x = max(width, 1)
+    max_y = max(height, 1)
+    x1 = float(np.clip(x1, 0, max_x - 1))
+    y1 = float(np.clip(y1, 0, max_y - 1))
+    x2 = float(np.clip(x2, x1 + 1, max_x))
+    y2 = float(np.clip(y2, y1 + 1, max_y))
+    return np.array([x1, y1, x2, y2], dtype=np.float32)
+
+
+def _select_device(device: str) -> torch.device:
+    """Resolve ``"auto"`` or a device string to a :class:`torch.device`."""
+    if device == "auto":
+        return _best_device()
+    return torch.device(device)
+
+
+class ReIDModel:
+    """Appearance feature extractor for object re-identification.
+
+    Wraps a backbone and preprocessing pipeline. The default checkpoint is
+    pedestrian-trained; pass ``source``/``architecture`` for other domains.
+
+    Args:
+        backbone: Feature-extractor module (``(B, 3, H, W)`` → ``(B, D)`` in eval).
+        device: Device the backbone runs on.
+        preprocessing: Crop and embedding preprocessing.
+    """
+
+    def __init__(
+        self,
+        backbone: nn.Module,
+        device: torch.device,
+        preprocessing: ReIDPreprocessing,
+    ) -> None:
+        self._backbone = backbone
+        self._device = device
+        self._preprocessing = preprocessing
+        self._transforms = preprocessing.build_transform()
+        # Set by from_pretrained() to enable save_pretrained(); None if the
+        # model was constructed directly with a raw nn.Module architecture.
+        self._architecture: str | None = None
+        logger.info("ReIDModel preprocessing: %s", preprocessing.describe())
+
+    @property
+    def preprocessing(self) -> ReIDPreprocessing:
+        """Active preprocessing pipeline."""
+        return self._preprocessing
+
+    # ------------------------------------------------------------------ #
+    # Constructors
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        source: str | None = None,
+        *,
+        architecture: str | nn.Module | None = None,
+        preprocessing: ReIDPreprocessing | None = None,
+        device: str = "auto",
+    ) -> ReIDModel:
+        """Build a :class:`ReIDModel` from a checkpoint source.
+
+        ``source`` may be a curated alias, ``hf://`` repo or file, a local path
+        or directory with ``reid_config.json``, or ``None`` for the default
+        model. A bare ``.pth``/``.safetensors`` file requires ``architecture``.
+
+        Args:
+            source: Model source (alias, Hub URL, local path, or ``None``).
+            architecture: Backbone override; required for bare weight files.
+            preprocessing: Preprocessing override.
+            device: Compute device (``"auto"`` picks the best available).
+
+        Returns:
+            Loaded :class:`ReIDModel`.
+        """
+        resolved_device = _select_device(device)
+
+        # §2.2 step 1: no source and no architecture → use the default alias.
+        if source is None and architecture is None:
+            source = DEFAULT_MODEL
+
+        # §2.2 steps 2-3: resolve a ModelCard from an alias or config-bearing
+        # directory/repo.
+        card = None
+        if source is not None:
+            card = resolve_model_card(source)
+
+        if card is not None:
+            resolved_arch = architecture if architecture is not None else card.architecture
+            resolved_weights = card.weights
+            resolved_preprocessing = preprocessing if preprocessing is not None else card.preprocessing
+            resolved_warning = card.domain_warning
+
+        elif source is None:
+            # §2.2 step 5: architecture-only; no external weights loaded.
+            if architecture is None:
+                raise ValueError("architecture is required when source is None")
+            resolved_arch = architecture
+            resolved_weights = None
+            resolved_preprocessing = (
+                preprocessing
+                if preprocessing is not None
+                else default_preprocessing_for_architecture(architecture if isinstance(architecture, str) else None)
+            )
+            resolved_warning = None
+
+        else:
+            # §2.2 step 4: bare weights file — architecture is required.
+            if architecture is None:
+                raise ValueError(
+                    f"Cannot load {source!r}: it appears to be a bare weights "
+                    "file but no `architecture` was provided. Pass e.g. "
+                    "architecture='osnet_x1_0' to specify the model "
+                    "architecture, or point to a directory produced by "
+                    "save_pretrained() for a self-describing checkpoint."
+                )
+            resolved_arch = architecture
+            resolved_weights = source
+            resolved_preprocessing = (
+                preprocessing
+                if preprocessing is not None
+                else default_preprocessing_for_architecture(architecture if isinstance(architecture, str) else None)
+            )
+            resolved_warning = None
+
+        if resolved_warning:
+            warnings.warn(resolved_warning, UserWarning, stacklevel=2)
+
+        # Build the backbone; use the architecture's own pretrained weights
+        # (e.g. ImageNet via timm) only when no external weights will be loaded.
+        use_pretrained = resolved_weights is None
+        backbone = build_architecture(resolved_arch, pretrained=use_pretrained)
+        backbone.eval()
+
+        if resolved_weights is not None:
+            local_path = resolve_weights(resolved_weights)
+            arch_name = resolved_arch if isinstance(resolved_arch, str) else ""
+            required_fraction = 1.0 if source in (FASTREID_MOT17_SBS50, DEFAULT_MODEL) else None
+            report = load_state_dict_for_architecture(
+                backbone,
+                local_path,
+                resolved_device,
+                arch_name,
+                required_match_fraction=required_fraction,
+            )
+            logger.info("ReIDModel weights (%s): %s", resolved_weights, report.summary())
+
+        backbone.to(resolved_device)
+
+        instance = cls(backbone, resolved_device, resolved_preprocessing)
+        # Store the architecture name (string only) to enable save_pretrained.
+        instance._architecture = resolved_arch if isinstance(resolved_arch, str) else None
+        return instance
+
+    def save_pretrained(self, directory: str) -> None:
+        """Write ``weights.safetensors`` and ``reid_config.json`` to *directory*."""
+        if self._architecture is None:
+            raise ValueError(
+                "Cannot save a model whose architecture name is unknown. "
+                "Build the model via from_pretrained() with a named "
+                "architecture (e.g. 'osnet_x1_0', 'timm:resnet50') to "
+                "enable save_pretrained()."
+            )
+
+        os.makedirs(directory, exist_ok=True)
+
+        weights_path = os.path.join(directory, "weights.safetensors")
+        save_file(self._backbone.state_dict(), weights_path)
+
+        card = ModelCard(
+            architecture=self._architecture,
+            weights=None,
+            preprocessing=self._preprocessing,
+        )
+        save_model_config(card, directory)
+        logger.info("ReIDModel saved to %s", directory)
+
+    # ------------------------------------------------------------------ #
+    # Inference
+    # ------------------------------------------------------------------ #
+
+    def extract_features_from_paths(
+        self,
+        image_paths: list[str],
+        batch_size: int = 64,
+        normalize: bool = True,
+    ) -> np.ndarray:
+        """Extract embeddings from pre-cropped image paths (evaluation use).
+
+        For bbox crops from a video frame, use :meth:`extract_features`.
+
+        Args:
+            image_paths: Paths to RGB-ready crop images.
+            batch_size: Images per forward pass.
+            normalize: L2-normalise embeddings when ``True`` (default).
+
+        Returns:
+            Float32 array of shape ``(N, D)``.
+        """
+        if not image_paths:
+            return np.empty((0, 0), dtype=np.float32)
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+
+        all_embeddings: list[np.ndarray] = []
+
+        for start in range(0, len(image_paths), batch_size):
+            batch_paths = image_paths[start : start + batch_size]
+            tensors = []
+            for p in batch_paths:
+                img = PILImage.open(p).convert("RGB")
+                crop = self._preprocessing.resize_crop(np.asarray(img))
+                tensors.append(self._transforms(PILImage.fromarray(crop)))
+
+            batch = torch.stack(tensors).to(self._device)
+            with torch.inference_mode():
+                embs = self._backbone(batch)
+            if normalize:
+                embs = torch.nn.functional.normalize(embs, p=2, dim=1)
+            batch_np = embs.cpu().numpy().astype(np.float32)
+            from trackers.core.reid.distance import sanitize_embedding_matrix
+
+            all_embeddings.append(sanitize_embedding_matrix(batch_np))
+
+        return np.concatenate(all_embeddings, axis=0)
+
+    def extract_features(
+        self,
+        detections: sv.Detections,
+        frame: np.ndarray,
+    ) -> np.ndarray:
+        """Extract L2-normalised appearance embeddings for each detection.
+
+        Args:
+            detections: Detections whose ``xyxy`` boxes define the crops.
+            frame: BGR video frame the detections were produced on.
+
+        Returns:
+            Float32 array of shape ``(N, D)``, or ``(0, 0)`` when empty.
+        """
+        if len(detections) == 0:
+            return np.empty((0, 0), dtype=np.float32)
+
+        frame_h, frame_w = frame.shape[:2]
+        crops = []
+        for box in detections.xyxy:
+            safe_box = _clamp_xyxy_to_frame(box, frame_h, frame_w)
+            crop = sv.crop_image(image=frame, xyxy=safe_box.astype(int))
+            if self._preprocessing.to_rgb:
+                crop = crop[:, :, ::-1].copy()
+            crop = self._preprocessing.resize_crop(crop)
+            pil_crop = PILImage.fromarray(crop)
+            crops.append(self._transforms(pil_crop))
+
+        batch = torch.stack(crops).to(self._device)
+
+        with torch.inference_mode():
+            embeddings = self._backbone(batch)
+
+        if self._preprocessing.normalize_embeddings:
+            embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+        from trackers.core.reid.distance import sanitize_embedding_matrix
+
+        return sanitize_embedding_matrix(embeddings.cpu().numpy().astype(np.float32))

--- a/src/trackers/core/reid/models/__init__.py
+++ b/src/trackers/core/reid/models/__init__.py
@@ -1,0 +1,39 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Model loading: preprocessing, registry, and checkpoint loaders."""
+
+from trackers.core.reid.models.loaders import (
+    KeyReport,
+    load_state_dict_for_architecture,
+    load_state_dict_into,
+    resolve_weights,
+)
+from trackers.core.reid.models.preprocessing import ReIDPreprocessing
+from trackers.core.reid.models.registry import (
+    DEFAULT_MODEL,
+    FASTREID_MOT17_SBS50,
+    ModelCard,
+    default_preprocessing_for_architecture,
+    load_model_config,
+    resolve_model_card,
+    save_model_config,
+)
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "FASTREID_MOT17_SBS50",
+    "KeyReport",
+    "ModelCard",
+    "ReIDPreprocessing",
+    "default_preprocessing_for_architecture",
+    "load_model_config",
+    "load_state_dict_for_architecture",
+    "load_state_dict_into",
+    "resolve_model_card",
+    "resolve_weights",
+    "save_model_config",
+]

--- a/src/trackers/core/reid/models/loaders.py
+++ b/src/trackers/core/reid/models/loaders.py
@@ -1,0 +1,235 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Checkpoint path resolution and state-dict loading."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn as nn
+from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
+from safetensors.torch import load_file
+
+from trackers.core.reid.architectures import checkpoint_remap_for_architecture
+
+_HF_PREFIX = "hf://"
+_GD_PREFIX = "gd://"
+
+_DEFAULT_DROP_PREFIXES = ("classifier",)
+_COMMON_KEY_PREFIXES = ("module.", "model.", "encoder.")
+
+
+@dataclass
+class KeyReport:
+    """Summary of a state-dict load (matched/missing/unexpected keys)."""
+
+    matched: int
+    total: int
+    missing: list[str] = field(default_factory=list)
+    unexpected: list[str] = field(default_factory=list)
+
+    @property
+    def matched_fraction(self) -> float:
+        return self.matched / self.total if self.total else 0.0
+
+    def summary(self) -> str:
+        return (
+            f"loaded {self.matched}/{self.total} params "
+            f"({self.matched_fraction:.0%}); "
+            f"{len(self.missing)} missing, {len(self.unexpected)} unused"
+        )
+
+
+def resolve_weights(source: str) -> str:
+    """Resolve a local path, ``hf://``, or ``gd://`` URL to a local weights file."""
+    if source.startswith(_HF_PREFIX):
+        return _resolve_hf(source)
+    if source.startswith(_GD_PREFIX):
+        return _resolve_gd(source)
+
+    if not os.path.exists(source):
+        raise FileNotFoundError(f"Weights file not found: {source}")
+    return source
+
+
+def _resolve_hf(source: str) -> str:
+    rest = source[len(_HF_PREFIX) :]
+    parts = rest.split("/")
+    if len(parts) < 3:
+        raise ValueError(f"Malformed hf:// weights URL {source!r}. Expected 'hf://<org>/<name>/<filename>'.")
+
+    repo_id = "/".join(parts[:2])
+    filename = "/".join(parts[2:])
+
+    revision = None
+    if "@" in repo_id:
+        repo_id, revision = repo_id.split("@", 1)
+
+    try:
+        return hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
+    except (HfHubHTTPError, EntryNotFoundError, OSError) as exc:
+        raise RuntimeError(
+            f"Failed to download Hugging Face weights from {source!r} (repo_id={repo_id!r}, filename={filename!r})."
+        ) from exc
+
+
+def _validate_downloaded_file(path: str) -> str:
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Downloaded weights file is missing: {path}")
+    if os.path.getsize(path) < 1:
+        raise OSError(f"Downloaded weights file is empty: {path}")
+    return path
+
+
+def _resolve_gd(source: str) -> str:
+    """Download a Google Drive file once and cache under ``~/.cache/trackers/weights``."""
+    rest = source[len(_GD_PREFIX) :]
+    file_id, _, filename = rest.partition("/")
+    if not file_id:
+        raise ValueError(f"Malformed gd:// weights URL {source!r}. Expected 'gd://<file_id>/<filename>'.")
+    if not filename:
+        filename = f"{file_id}.pth"
+
+    cache_dir = os.path.join(os.path.expanduser("~"), ".cache", "trackers", "weights")
+    os.makedirs(cache_dir, exist_ok=True)
+    path = os.path.join(cache_dir, filename)
+    if os.path.exists(path):
+        return _validate_downloaded_file(path)
+
+    try:
+        import gdown
+    except ImportError as exc:
+        raise ImportError("Google Drive weights (gd://...) require gdown. Install with: pip install gdown") from exc
+
+    fd, tmp_path = tempfile.mkstemp(prefix=f"{filename}.", suffix=".part", dir=cache_dir)
+    os.close(fd)
+    try:
+        gdown.download(id=file_id, output=tmp_path, quiet=False)
+        _validate_downloaded_file(tmp_path)
+        os.replace(tmp_path, path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+    return _validate_downloaded_file(path)
+
+
+def load_state_dict_for_architecture(
+    module: nn.Module,
+    path: str,
+    device: torch.device,
+    architecture: str,
+    *,
+    warn_threshold: float = 0.5,
+    required_match_fraction: float | None = None,
+) -> KeyReport:
+    """Load *path* using the loader appropriate for *architecture*."""
+    remap = checkpoint_remap_for_architecture(architecture)
+    report = load_state_dict_into(
+        module,
+        path,
+        device,
+        remap=remap,
+        warn_threshold=warn_threshold,
+    )
+    if required_match_fraction is not None and report.matched_fraction < required_match_fraction:
+        raise ValueError(
+            f"Checkpoint {path!r} matched only {report.matched_fraction:.0%} of "
+            f"{architecture!r} parameters (required >= {required_match_fraction:.0%}). "
+            f"{report.summary()}"
+        )
+    return report
+
+
+def _strip_common_prefixes(key: str) -> str:
+    stripped = key
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _COMMON_KEY_PREFIXES:
+            if stripped.startswith(prefix):
+                stripped = stripped[len(prefix) :]
+                changed = True
+    return stripped
+
+
+def _read_state_dict(path: str, device: torch.device) -> dict:
+    """Read a raw state dict from a ``.pth`` or ``.safetensors`` file."""
+    if path.endswith(".safetensors"):
+        return load_file(path, device=str(device))
+
+    try:
+        state_dict = torch.load(path, map_location=device, weights_only=True)
+    except TypeError:
+        state_dict = torch.load(path, map_location=device, weights_only=False)
+
+    for wrapper_key in ("state_dict", "model", "encoder"):
+        if isinstance(state_dict, dict) and wrapper_key in state_dict and isinstance(state_dict[wrapper_key], dict):
+            state_dict = state_dict[wrapper_key]
+            break
+    return state_dict
+
+
+def load_state_dict_into(
+    module: nn.Module,
+    path: str,
+    device: torch.device,
+    *,
+    drop_prefixes: tuple[str, ...] = _DEFAULT_DROP_PREFIXES,
+    remap: Callable[[dict], dict] | None = None,
+    warn_threshold: float = 0.5,
+) -> KeyReport:
+    """Load *path* into *module* by name and shape (classifier keys skipped)."""
+    state_dict = _read_state_dict(path, device)
+
+    cleaned: dict
+    if remap is not None:
+        cleaned = remap(state_dict)
+    else:
+        cleaned = {}
+        for k, v in state_dict.items():
+            key = _strip_common_prefixes(k)
+            if any(key.startswith(p) for p in drop_prefixes):
+                continue
+            cleaned[key] = v
+
+    target = module.state_dict()
+    matched: dict = {}
+    unexpected: list[str] = []
+    for k, v in cleaned.items():
+        if k in target and target[k].shape == v.shape:
+            matched[k] = v
+        else:
+            unexpected.append(k)
+
+    target.update(matched)
+    module.load_state_dict(target)
+
+    missing = [k for k in target if k not in matched]
+    report = KeyReport(
+        matched=len(matched),
+        total=len(target),
+        missing=missing,
+        unexpected=unexpected,
+    )
+
+    if report.matched_fraction < warn_threshold:
+        warnings.warn(
+            f"Only {report.summary()} from {path!r}. The weights likely do not "
+            f"match this architecture — check the model/weights pairing.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    return report

--- a/src/trackers/core/reid/models/preprocessing.py
+++ b/src/trackers/core/reid/models/preprocessing.py
@@ -1,0 +1,140 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Re-ID crop and embedding preprocessing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import cv2
+import numpy as np
+from torchvision.transforms import Compose, Normalize, ToTensor
+
+# ImageNet statistics — shared by every OSNet / timm ImageNet-pretrained backbone.
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+# Standard person re-ID input geometry (height, width). OSNet and most backbones
+# train at 256x128; BoT-SORT FastReID SBS uses 384x128 (see registry overrides).
+REID_INPUT_SIZE = (256, 128)
+
+# Gray padding used by YOLO / FastReID letterbox helpers (BoT-SORT ``preprocess()``).
+FASTREID_PAD_VALUE = 114
+
+ResizeMode = Literal["stretch", "letterbox"]
+
+
+@dataclass(frozen=True)
+class ReIDPreprocessing:
+    """Crop resize/normalisation and optional L2-normalised embeddings."""
+
+    input_size: tuple[int, int] = REID_INPUT_SIZE
+    mean: tuple[float, float, float] = IMAGENET_MEAN
+    std: tuple[float, float, float] = IMAGENET_STD
+    interpolation: str = "bilinear"
+    to_rgb: bool = True
+    normalize_embeddings: bool = True
+    resize_mode: ResizeMode = "stretch"
+    pad_value: int = FASTREID_PAD_VALUE
+
+    def describe(self) -> str:
+        """Human-readable one-line summary."""
+        h, w = self.input_size
+        colour = "BGR→RGB" if self.to_rgb else "RGB (no swap)"
+        norm = "L2" if self.normalize_embeddings else "none"
+        return (
+            f"ReIDPreprocessing(resize={h}x{w} [{self.resize_mode}, {self.interpolation}], "
+            f"{colour}, mean={self.mean}, std={self.std}, embed_norm={norm})"
+        )
+
+    def resize_crop(self, crop: np.ndarray) -> np.ndarray:
+        """Resize an ``HxWxC`` crop to :attr:`input_size` using OpenCV.
+
+        ``stretch`` matches BoT-SORT ``FastReIDInterface`` inference
+        (``cv2.resize`` to ``SIZE_TEST``, aspect ratio not preserved).
+        ``letterbox`` is optional (aspect-preserving pad); BoT-SORT leaves it
+        commented out upstream, so registered FastReID defaults use stretch.
+        """
+        if crop.size == 0:
+            target_h, target_w = self.input_size
+            channels = crop.shape[2] if crop.ndim == 3 else 1
+            shape = (target_h, target_w, channels) if crop.ndim == 3 else (target_h, target_w)
+            return np.zeros(shape, dtype=crop.dtype)
+
+        target_h, target_w = self.input_size
+        interpolation = _opencv_interpolation(self.interpolation)
+
+        if self.resize_mode == "letterbox":
+            height, width = crop.shape[:2]
+            scale = min(target_h / height, target_w / width)
+            new_w = max(round(width * scale), 1)
+            new_h = max(round(height * scale), 1)
+            resized = cv2.resize(crop, (new_w, new_h), interpolation=interpolation)
+            if crop.ndim == 3:
+                padded = np.full((target_h, target_w, crop.shape[2]), self.pad_value, dtype=crop.dtype)
+            else:
+                padded = np.full((target_h, target_w), self.pad_value, dtype=crop.dtype)
+            padded[:new_h, :new_w] = resized
+            return padded
+
+        return cv2.resize(crop, (target_w, target_h), interpolation=interpolation)
+
+    def build_transform(self):
+        """Tensor normalisation for a crop already at :attr:`input_size` (RGB PIL in)."""
+        return Compose(
+            [
+                ToTensor(),
+                Normalize(mean=list(self.mean), std=list(self.std)),
+            ]
+        )
+
+    def to_dict(self) -> dict:
+        """Serialise for ``reid_config.json``."""
+        return {
+            "input_size": list(self.input_size),
+            "mean": list(self.mean),
+            "std": list(self.std),
+            "interpolation": self.interpolation,
+            "to_rgb": self.to_rgb,
+            "normalize_embeddings": self.normalize_embeddings,
+            "resize_mode": self.resize_mode,
+            "pad_value": self.pad_value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ReIDPreprocessing:
+        """Reconstruct from a ``reid_config.json`` preprocessing dict."""
+        kwargs: dict = {}
+        if "input_size" in data:
+            kwargs["input_size"] = tuple(data["input_size"])
+        if "mean" in data:
+            kwargs["mean"] = tuple(data["mean"])
+        if "std" in data:
+            kwargs["std"] = tuple(data["std"])
+        if "interpolation" in data:
+            kwargs["interpolation"] = data["interpolation"]
+        if "to_rgb" in data:
+            kwargs["to_rgb"] = data["to_rgb"]
+        if "normalize_embeddings" in data:
+            kwargs["normalize_embeddings"] = data["normalize_embeddings"]
+        if "resize_mode" in data:
+            kwargs["resize_mode"] = data["resize_mode"]
+        if "pad_value" in data:
+            kwargs["pad_value"] = data["pad_value"]
+        return cls(**kwargs)
+
+
+def _opencv_interpolation(name: str) -> int:
+    modes = {
+        "bilinear": cv2.INTER_LINEAR,
+        "bicubic": cv2.INTER_CUBIC,
+        "nearest": cv2.INTER_NEAREST,
+    }
+    if name not in modes:
+        raise ValueError(f"Unknown interpolation {name!r}. Choose from: {sorted(modes)}")
+    return modes[name]

--- a/src/trackers/core/reid/models/registry.py
+++ b/src/trackers/core/reid/models/registry.py
@@ -1,0 +1,209 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Model cards, curated aliases, and ``reid_config.json`` (de)serialization."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+
+from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
+
+from trackers.core.reid.architectures import list_architectures
+from trackers.core.reid.architectures.fastreid_sbs import FASTREID_SBS_ARCHITECTURE
+from trackers.core.reid.models.preprocessing import ReIDPreprocessing
+
+# OSNet x1.0 trained on MSMT17 with combineall (train + query + gallery).
+# Produces the strongest general-purpose pedestrian features, which is why it
+# is the library default — but because it trains on the MSMT17 test identities
+# it MUST NOT be used to benchmark MSMT17.
+_DEFAULT_OSNET_WEIGHTS = (
+    "hf://kaiyangzhou/osnet/"
+    "osnet_x1_0_msmt17_combineall_256x128_amsgrad_ep150_stp60_lr0.0015_b64_fb10"
+    "_softmax_labelsmooth_flip_jitter.pth"
+)
+
+_DOMAIN_WARNING = (
+    "The default ReIDModel weights were trained on MSMT17 pedestrian images. "
+    "Performance may degrade significantly on non-person objects (vehicles, "
+    "animals, products, etc.). Pass a domain-specific checkpoint via "
+    "`ReIDModel.from_pretrained(source, architecture=...)` for other use cases."
+)
+
+# ---------------------------------------------------------------------------
+# Public constants and types
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = "osnet_x1_0_msmt17_combineall"
+
+# Default preprocessing for registered architectures (bare `.pth` loads, no ModelCard).
+# OSNet variants use 256x128; only non-default geometries are listed explicitly.
+DEFAULT_ARCHITECTURE_PREPROCESSING = ReIDPreprocessing()
+
+_NON_DEFAULT_ARCHITECTURE_PREPROCESSING: dict[str, ReIDPreprocessing] = {
+    # BoT-SORT FastReIDInterface: cv2 stretch to 384x128 (letterbox exists but is commented out upstream).
+    FASTREID_SBS_ARCHITECTURE: ReIDPreprocessing(input_size=(384, 128), resize_mode="stretch"),
+}
+
+
+def _build_architecture_default_preprocessing() -> dict[str, ReIDPreprocessing]:
+    mapping = {name: DEFAULT_ARCHITECTURE_PREPROCESSING for name in list_architectures()}
+    mapping.update(_NON_DEFAULT_ARCHITECTURE_PREPROCESSING)
+    return mapping
+
+
+ARCHITECTURE_DEFAULT_PREPROCESSING = _build_architecture_default_preprocessing()
+
+
+def default_preprocessing_for_architecture(architecture: str | None) -> ReIDPreprocessing:
+    """Return default preprocessing for a named architecture (bare weight loads)."""
+    if architecture is None:
+        return DEFAULT_ARCHITECTURE_PREPROCESSING
+    return ARCHITECTURE_DEFAULT_PREPROCESSING.get(architecture, DEFAULT_ARCHITECTURE_PREPROCESSING)
+
+
+# BoT-SORT MOT17 SBS-S50 (ResNeSt50 + GeM + BNNeck), trained on MOT17 train-half GT crops.
+# Weights: https://github.com/niraharon/bot-sort#model-zoo
+_FASTREID_MOT17_WEIGHTS = "gd://1QZFWpoa80rqo7O-HXmlss8J8CnS7IUsN/mot17_sbs_S50.pth"
+_FASTREID_MOT17_WARNING = (
+    "The fastreid_mot17_sbs50 weights were trained on MOT17 pedestrian crops. "
+    "Use this encoder for MOT tracking benchmarks (BoT-SORT-ReID replication); "
+    "cross-domain retrieval on Market-1501 / MSMT17 is expected to underperform."
+)
+
+FASTREID_MOT17_SBS50 = "fastreid_mot17_sbs50"
+
+
+@dataclass
+class ModelCard:
+    """Architecture, weights source, preprocessing, and optional domain warning."""
+
+    architecture: str
+    weights: str | None
+    preprocessing: ReIDPreprocessing
+    domain_warning: str | None = None
+
+
+ALIASES: dict[str, ModelCard] = {
+    DEFAULT_MODEL: ModelCard(
+        architecture="osnet_x1_0",
+        weights=_DEFAULT_OSNET_WEIGHTS,
+        preprocessing=DEFAULT_ARCHITECTURE_PREPROCESSING,
+        domain_warning=_DOMAIN_WARNING,
+    ),
+    FASTREID_MOT17_SBS50: ModelCard(
+        architecture=FASTREID_SBS_ARCHITECTURE,
+        weights=_FASTREID_MOT17_WEIGHTS,
+        preprocessing=ARCHITECTURE_DEFAULT_PREPROCESSING[FASTREID_SBS_ARCHITECTURE],
+        domain_warning=_FASTREID_MOT17_WARNING,
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Resolution helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_model_card(source: str) -> ModelCard | None:
+    """Return a card for a curated alias or a directory/repo with ``reid_config.json``."""
+    if source in ALIASES:
+        return ALIASES[source]
+
+    # Local directory with a reid_config.json (save_pretrained output).
+    if os.path.isdir(source):
+        config_path = os.path.join(source, "reid_config.json")
+        if os.path.exists(config_path):
+            return load_model_config(source)
+        return None
+
+    # HF repo URL (no trailing filename) — try to fetch reid_config.json.
+    # hf://org/repo has exactly 2 non-empty parts after "hf://".
+    # hf://org/repo/file.pth has 3+ parts and is a bare weights file.
+    if source.startswith("hf://"):
+        rest = source[len("hf://") :]
+        parts = [p for p in rest.split("/") if p]
+        if len(parts) == 2:
+            try:
+                return _load_hf_repo_config(source)
+            except (HfHubHTTPError, EntryNotFoundError, OSError, ValueError) as exc:
+                raise RuntimeError(f"Failed to resolve Hugging Face repo config for {source!r}.") from exc
+
+    return None
+
+
+def load_model_config(directory_or_repo: str) -> ModelCard:
+    """Load a :class:`ModelCard` from ``reid_config.json`` (and local ``weights.safetensors`` if present)."""
+    if directory_or_repo.startswith("hf://"):
+        return _load_hf_repo_config(directory_or_repo)
+
+    config_path = os.path.join(directory_or_repo, "reid_config.json")
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(
+            f"No reid_config.json found in {directory_or_repo!r}. "
+            "Use ReIDModel.save_pretrained() to create a self-describing "
+            "model directory."
+        )
+    weights_path = os.path.join(directory_or_repo, "weights.safetensors")
+    weights_source = weights_path if os.path.exists(weights_path) else None
+    return _parse_config_file(config_path, weights_source=weights_source)
+
+
+def save_model_config(card: ModelCard, directory: str) -> None:
+    """Write ``reid_config.json`` to *directory*."""
+    if not isinstance(card.architecture, str):
+        raise ValueError(
+            "Cannot save a ModelCard whose architecture is an nn.Module. "
+            "Use a named architecture string (e.g. 'osnet_x1_0', "
+            "'timm:resnet50') to enable save_pretrained()."
+        )
+
+    config = {
+        "architecture": card.architecture,
+        "preprocessing": card.preprocessing.to_dict(),
+    }
+    config_path = os.path.join(directory, "reid_config.json")
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_hf_repo_config(hf_repo_url: str) -> ModelCard:
+    """Download and parse ``reid_config.json`` from an HF repo URL."""
+    rest = hf_repo_url[len("hf://") :]
+    parts = [p for p in rest.split("/") if p]
+    repo_id = "/".join(parts[:2])
+    revision = None
+    if "@" in repo_id:
+        repo_id, revision = repo_id.split("@", 1)
+
+    config_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="reid_config.json",
+        revision=revision,
+    )
+    weights_source = hf_repo_url.rstrip("/") + "/weights.safetensors"
+    return _parse_config_file(config_path, weights_source=weights_source)
+
+
+def _parse_config_file(config_path: str, *, weights_source: str | None) -> ModelCard:
+    """Parse a ``reid_config.json`` file into a :class:`ModelCard`."""
+    with open(config_path) as f:
+        data = json.load(f)
+
+    architecture = data["architecture"]
+    preprocessing = ReIDPreprocessing.from_dict(data.get("preprocessing", {}))
+    return ModelCard(
+        architecture=architecture,
+        weights=weights_source,
+        preprocessing=preprocessing,
+    )

--- a/src/trackers/core/reid/protocols.py
+++ b/src/trackers/core/reid/protocols.py
@@ -1,0 +1,48 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Lightweight typing protocols for optional Re-ID integration."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+import numpy as np
+import supervision as sv
+
+
+class ReIDEncoder(Protocol):
+    """Minimal encoder surface for tracker appearance association.
+
+    Any object implementing :meth:`extract_features` may be used as a
+    ``reid_model`` by trackers that support appearance matching.
+    The concrete :class:`~trackers.core.reid.model.ReIDModel` satisfies this
+    protocol but is not required for tests or custom encoders.
+    """
+
+    def extract_features(self, detections: sv.Detections, frame: np.ndarray) -> np.ndarray:
+        """Return L2-normalised embeddings for each detection box."""
+        ...
+
+
+class ReIDPathEncoder(Protocol):
+    """Minimal encoder surface for dataset / retrieval evaluation.
+
+    :class:`~trackers.core.reid.eval.evaluator.ReIDEvaluator` accepts any object
+    that can embed image paths in batches. :class:`~trackers.core.reid.model.ReIDModel`
+    implements this protocol.
+    """
+
+    def extract_features_from_paths(
+        self,
+        image_paths: Sequence[str],
+        *,
+        batch_size: int = 64,
+        normalize: bool = True,
+    ) -> np.ndarray:
+        """Embed images read from disk."""
+        ...

--- a/tests/core/reid/__init__.py
+++ b/tests/core/reid/__init__.py
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------

--- a/tests/core/reid/test_fastreid_integration.py
+++ b/tests/core/reid/test_fastreid_integration.py
@@ -1,0 +1,27 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.network
+def test_fastreid_mot17_alias_loads_with_finite_normalized_output() -> None:
+    pytest.importorskip("torch")
+    import numpy as np
+    import supervision as sv
+
+    from trackers.core.reid.model import ReIDModel
+
+    model = ReIDModel.from_pretrained("fastreid_mot17_sbs50", device="cpu")
+    frame = np.zeros((384, 128, 3), dtype=np.uint8)
+    dets = sv.Detections(xyxy=np.array([[0.0, 0.0, 128.0, 384.0]], dtype=np.float32))
+    embs = model.extract_features(dets, frame)
+    assert embs.shape == (1, 2048)
+    assert np.isfinite(embs).all()
+    np.testing.assert_allclose(np.linalg.norm(embs, axis=1), 1.0, atol=1e-4)
+    assert model.preprocessing.input_size == (384, 128)

--- a/tests/core/reid/test_reid.py
+++ b/tests/core/reid/test_reid.py
@@ -1,0 +1,627 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Minimal test suite for the re-ID package.
+
+Tests are grouped by the module they exercise:
+  - preprocessing / registry / loaders / model / round-trip (RFC 0002)
+  - feature bank + appearance distance
+  - eval metrics + dataset loaders
+
+torch/timm-dependent tests are guarded with pytest.importorskip.
+No network downloads are performed (see test_fastreid_integration.py).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from trackers.core.reid.models.loaders import resolve_weights
+from trackers.core.reid.models.preprocessing import ReIDPreprocessing
+from trackers.core.reid.models.registry import (
+    DEFAULT_MODEL,
+    FASTREID_MOT17_SBS50,
+    default_preprocessing_for_architecture,
+    resolve_model_card,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Preprocessing
+# ---------------------------------------------------------------------------
+
+
+class TestReIDPreprocessing:
+    def test_build_transform_callable(self) -> None:
+        pytest.importorskip("torch")
+        pytest.importorskip("torchvision")
+        t = ReIDPreprocessing().build_transform()
+        from PIL import Image
+
+        img = Image.new("RGB", (128, 256))  # PIL (width, height) = (W, H)
+        out = t(img)
+        assert out.shape == (3, 256, 128)
+
+    def test_stretch_resize_matches_target_size(self) -> None:
+        pytest.importorskip("cv2")
+        crop = np.zeros((100, 50, 3), dtype=np.uint8)
+        out = ReIDPreprocessing(input_size=(384, 128), resize_mode="stretch").resize_crop(crop)
+        assert out.shape == (384, 128, 3)
+
+    def test_letterbox_preserves_aspect_and_pads(self) -> None:
+        pytest.importorskip("cv2")
+        crop = np.full((200, 100, 3), 255, dtype=np.uint8)
+        out = ReIDPreprocessing(input_size=(384, 128), resize_mode="letterbox").resize_crop(crop)
+        assert out.shape == (384, 128, 3)
+        assert out[0, 0, 0] == 255
+        assert out[-1, 0, 0] == 114
+
+    def test_fastreid_default_uses_stretch(self) -> None:
+        from trackers.core.reid.architectures.fastreid_sbs import FASTREID_SBS_ARCHITECTURE
+
+        fastreid = default_preprocessing_for_architecture(FASTREID_SBS_ARCHITECTURE)
+        assert fastreid.input_size == (384, 128)
+        assert fastreid.resize_mode == "stretch"
+
+    def test_unknown_interpolation_raises(self) -> None:
+        pytest.importorskip("cv2")
+        p = ReIDPreprocessing(interpolation="lanczos")
+        crop = np.zeros((32, 16, 3), dtype=np.uint8)
+        with pytest.raises(ValueError, match="lanczos"):
+            p.resize_crop(crop)
+
+    def test_to_dict_from_dict_roundtrip(self) -> None:
+        p = ReIDPreprocessing(input_size=(128, 64), interpolation="bicubic", to_rgb=False)
+        d = p.to_dict()
+        assert d["interpolation"] == "bicubic"
+        assert d["input_size"] == [128, 64]
+        assert d["to_rgb"] is False
+        p2 = ReIDPreprocessing.from_dict(d)
+        assert p2 == p
+
+
+# ---------------------------------------------------------------------------
+# 2. Registry / resolution
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_resolve_default_alias(self) -> None:
+        card = resolve_model_card(DEFAULT_MODEL)
+        assert card is not None
+        assert card.architecture == "osnet_x1_0"
+        assert card.weights is not None
+        assert card.domain_warning is not None
+
+    def test_resolve_fastreid_mot17_alias(self) -> None:
+        from trackers.core.reid.architectures.fastreid_sbs import FASTREID_SBS_ARCHITECTURE
+
+        card = resolve_model_card(FASTREID_MOT17_SBS50)
+        assert card is not None
+        assert card.architecture == FASTREID_SBS_ARCHITECTURE
+        assert card.weights is not None
+        assert card.preprocessing.input_size == (384, 128)
+        assert card.domain_warning is not None
+
+    def test_default_preprocessing_for_architecture(self) -> None:
+        from trackers.core.reid.architectures.fastreid_sbs import FASTREID_SBS_ARCHITECTURE
+
+        osnet = default_preprocessing_for_architecture("osnet_x1_0")
+        assert osnet.input_size == (256, 128)
+        fastreid = default_preprocessing_for_architecture(FASTREID_SBS_ARCHITECTURE)
+        assert fastreid.input_size == (384, 128)
+        assert default_preprocessing_for_architecture("timm:resnet50").input_size == (256, 128)
+
+    def test_local_dir_with_config(self, tmp_path) -> None:
+        import json
+
+        config = {
+            "architecture": "osnet_x1_0",
+            "preprocessing": ReIDPreprocessing().to_dict(),
+        }
+        (tmp_path / "reid_config.json").write_text(json.dumps(config))
+        card = resolve_model_card(str(tmp_path))
+        assert card is not None
+        assert card.architecture == "osnet_x1_0"
+
+    def test_bare_path_without_architecture_raises(self) -> None:
+        """from_pretrained on a bare weights file without architecture → ValueError."""
+        pytest.importorskip("torch")
+        from trackers.core.reid.model import ReIDModel
+
+        with tempfile.NamedTemporaryFile(suffix=".pth", delete=False) as f:
+            tmp_path = f.name
+        try:
+            # Write a minimal torch save so the file exists
+            import torch
+
+            torch.save({}, tmp_path)
+            with pytest.raises(ValueError, match="architecture"):
+                ReIDModel.from_pretrained(tmp_path)
+        finally:
+            os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 3. Loaders
+# ---------------------------------------------------------------------------
+
+
+class TestLoaders:
+    def test_missing_local_path_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            resolve_weights("/nonexistent/path/to/weights.pth")
+
+    def test_malformed_hf_url_raises(self) -> None:
+        from trackers.core.reid.models.loaders import _resolve_hf
+
+        with pytest.raises(ValueError, match="hf://"):
+            _resolve_hf("hf://only_one_part")
+
+    def test_load_state_dict_full_match(self) -> None:
+        pytest.importorskip("torch")
+        import torch
+        import torch.nn as nn
+
+        from trackers.core.reid.models.loaders import load_state_dict_into
+
+        model = nn.Linear(4, 2)
+        with tempfile.NamedTemporaryFile(suffix=".pth", delete=False) as f:
+            tmp_path = f.name
+        try:
+            torch.save(model.state_dict(), tmp_path)
+            report = load_state_dict_into(model, tmp_path, torch.device("cpu"))
+            assert report.matched == report.total
+            assert report.matched_fraction == 1.0
+        finally:
+            os.unlink(tmp_path)
+
+    def test_load_state_dict_mismatch_warns(self) -> None:
+        pytest.importorskip("torch")
+        import torch
+        import torch.nn as nn
+
+        from trackers.core.reid.models.loaders import load_state_dict_into
+
+        source = nn.Linear(4, 2)
+        target = nn.Linear(8, 4)
+        with tempfile.NamedTemporaryFile(suffix=".pth", delete=False) as f:
+            tmp_path = f.name
+        try:
+            torch.save(source.state_dict(), tmp_path)
+            with pytest.warns(UserWarning, match="weights likely do not match"):
+                load_state_dict_into(target, tmp_path, torch.device("cpu"))
+        finally:
+            os.unlink(tmp_path)
+
+    def test_generic_loader_preserves_backbone_prefix(self) -> None:
+        pytest.importorskip("torch")
+        import torch
+        import torch.nn as nn
+
+        from trackers.core.reid.models.loaders import load_state_dict_into
+
+        class _BackboneModel(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.backbone = nn.Linear(4, 2)
+
+        model = _BackboneModel()
+        wrapped = {
+            "backbone.weight": model.backbone.weight.detach().clone(),
+            "backbone.bias": model.backbone.bias.detach().clone(),
+        }
+        with tempfile.NamedTemporaryFile(suffix=".pth", delete=False) as f:
+            tmp_path = f.name
+        try:
+            torch.save(wrapped, tmp_path)
+            report = load_state_dict_into(model, tmp_path, torch.device("cpu"))
+            assert report.matched == report.total
+            assert report.matched_fraction == 1.0
+        finally:
+            os.unlink(tmp_path)
+
+    def test_remap_fastreid_sbs_keys(self) -> None:
+        pytest.importorskip("torch")
+        import torch
+
+        from trackers.core.reid.architectures.fastreid_sbs import (
+            remap_fastreid_sbs_state_dict,
+        )
+
+        raw = {
+            "backbone.conv1.0.weight": torch.zeros(1),
+            "heads.pool_layer.p": torch.tensor([1.5]),
+            "heads.bottleneck.0.weight": torch.zeros(2048),
+            "heads.weight": torch.zeros(487, 2048),
+        }
+        mapped = remap_fastreid_sbs_state_dict(raw)
+        assert "backbone.conv1.0.weight" in mapped
+        assert "pool.p" in mapped
+        assert "bottleneck.weight" in mapped
+        assert "heads.weight" not in mapped
+
+    def test_load_fastreid_sbs_from_synthetic_checkpoint(self) -> None:
+        pytest.importorskip("torch")
+        import torch
+
+        from trackers.core.reid.architectures import build_architecture
+        from trackers.core.reid.architectures.fastreid_sbs import FASTREID_SBS_ARCHITECTURE
+        from trackers.core.reid.models.loaders import load_state_dict_for_architecture
+
+        model = build_architecture(FASTREID_SBS_ARCHITECTURE)
+        source = model.state_dict()
+        wrapped: dict = {}
+        for key, value in source.items():
+            if key.startswith("backbone."):
+                wrapped[key] = value
+            elif key == "pool.p":
+                wrapped["heads.pool_layer.p"] = value
+            elif key.startswith("bottleneck."):
+                wrapped[f"heads.bottleneck.0.{key[len('bottleneck.') :]}"] = value
+
+        with tempfile.NamedTemporaryFile(suffix=".pth", delete=False) as f:
+            tmp_path = f.name
+        try:
+            torch.save(wrapped, tmp_path)
+            report = load_state_dict_for_architecture(model, tmp_path, torch.device("cpu"), FASTREID_SBS_ARCHITECTURE)
+            assert report.matched == report.total
+            assert report.matched_fraction == 1.0
+        finally:
+            os.unlink(tmp_path)
+
+    def test_fastreid_sbs_loads_gem_p_from_checkpoint(self) -> None:
+        """GeM ``p`` must come from ``heads.pool_layer.p``, not the 3.0 constructor default."""
+        pytest.importorskip("torch")
+        import torch
+
+        from trackers.core.reid.architectures import build_architecture
+        from trackers.core.reid.architectures.fastreid_sbs import (
+            FASTREID_SBS_ARCHITECTURE,
+            FastReIDSBSResNeSt50,
+        )
+        from trackers.core.reid.models.loaders import load_state_dict_for_architecture
+
+        mot17_gem_p = 1.7194522619247437  # heads.pool_layer.p in mot17_sbs_S50.pth
+
+        model = cast(FastReIDSBSResNeSt50, build_architecture(FASTREID_SBS_ARCHITECTURE))
+        assert model.pool.p.item() == pytest.approx(3.0)
+
+        wrapped: dict = {"heads.pool_layer.p": torch.tensor([mot17_gem_p])}
+        for key, value in model.state_dict().items():
+            if key.startswith("backbone."):
+                wrapped[key] = value
+            elif key.startswith("bottleneck."):
+                wrapped[f"heads.bottleneck.0.{key[len('bottleneck.') :]}"] = value
+
+        with tempfile.NamedTemporaryFile(suffix=".pth", delete=False) as f:
+            tmp_path = f.name
+        try:
+            torch.save(wrapped, tmp_path)
+            report = load_state_dict_for_architecture(model, tmp_path, torch.device("cpu"), FASTREID_SBS_ARCHITECTURE)
+            assert report.matched == report.total
+            assert model.pool.p.item() == pytest.approx(mot17_gem_p)
+            assert model.pool.p.item() != pytest.approx(3.0)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_fastreid_sbs_last_stride_patch(self) -> None:
+        """``layer4[0]`` must match FastReID LAST_STRIDE=1 (not raw timm output_stride=16)."""
+        pytest.importorskip("torch")
+        pytest.importorskip("timm")
+        import torch.nn as nn
+
+        from trackers.core.reid.architectures import build_architecture
+        from trackers.core.reid.architectures.fastreid_sbs import (
+            FASTREID_SBS_ARCHITECTURE,
+            FastReIDSBSResNeSt50,
+        )
+
+        model = cast(FastReIDSBSResNeSt50, build_architecture(FASTREID_SBS_ARCHITECTURE))
+        block = cast(Any, cast(Any, model.backbone).layer4[0])
+        assert isinstance(block.downsample[0], nn.AvgPool2d)
+        assert block.downsample[0].kernel_size == (1, 1) or block.downsample[0].kernel_size == 1
+        assert block.downsample[0].stride == (1, 1) or block.downsample[0].stride == 1
+        assert isinstance(block.avd_last, nn.AvgPool2d)
+        assert block.avd_last.kernel_size == (3, 3) or block.avd_last.kernel_size == 3
+        assert block.avd_last.stride == (1, 1) or block.avd_last.stride == 1
+
+    def test_fastreid_sbs_forward_shape(self) -> None:
+        pytest.importorskip("torch")
+        import torch
+
+        from trackers.core.reid.architectures import build_architecture
+        from trackers.core.reid.architectures.fastreid_sbs import FASTREID_SBS_ARCHITECTURE
+
+        model = build_architecture(FASTREID_SBS_ARCHITECTURE)
+        model.eval()
+        with torch.inference_mode():
+            out = model(torch.randn(2, 3, 384, 128))
+        assert out.shape == (2, 2048)
+
+
+# ---------------------------------------------------------------------------
+# 4. Model smoke (torch required)
+# ---------------------------------------------------------------------------
+
+
+class TestModelSmoke:
+    def test_extract_features_tiny_module(self) -> None:
+        pytest.importorskip("torch")
+        import numpy as np
+        import supervision as sv
+        import torch
+        import torch.nn as nn
+
+        from trackers.core.reid.model import ReIDModel
+        from trackers.core.reid.models.preprocessing import ReIDPreprocessing
+
+        class _TinyEncoder(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.flatten(1)[:, :16]
+
+        device = torch.device("cpu")
+        preprocessing = ReIDPreprocessing()
+        model = ReIDModel(_TinyEncoder(), device, preprocessing)
+
+        frame = np.zeros((128, 128, 3), dtype=np.uint8)
+        dets = sv.Detections(xyxy=np.array([[0, 0, 64, 64]], dtype=np.float32))
+        embs = model.extract_features(dets, frame)
+        assert embs.shape[0] == 1
+        assert embs.dtype == np.float32
+        # Verify L2 normalization (default normalize_embeddings=True)
+        norms = np.linalg.norm(embs, axis=1)
+        np.testing.assert_allclose(norms, np.ones_like(norms), atol=1e-5)
+
+    def test_extract_features_clamps_out_of_frame_boxes(self) -> None:
+        pytest.importorskip("torch")
+        import numpy as np
+        import supervision as sv
+        import torch
+        import torch.nn as nn
+
+        from trackers.core.reid.model import ReIDModel
+        from trackers.core.reid.models.preprocessing import ReIDPreprocessing
+
+        class _TinyEncoder(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.flatten(1)[:, :16]
+
+        device = torch.device("cpu")
+        model = ReIDModel(_TinyEncoder(), device, ReIDPreprocessing())
+        frame = np.zeros((128, 128, 3), dtype=np.uint8)
+        dets = sv.Detections(xyxy=np.array([[-40.0, -40.0, 10.0, 10.0]], dtype=np.float32))
+        embs = model.extract_features(dets, frame)
+        assert embs.shape[0] == 1
+
+    def test_empty_detections_returns_empty(self) -> None:
+        pytest.importorskip("torch")
+        import numpy as np
+        import supervision as sv
+        import torch
+        import torch.nn as nn
+
+        from trackers.core.reid.model import ReIDModel
+        from trackers.core.reid.models.preprocessing import ReIDPreprocessing
+
+        class _TinyEncoder(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.flatten(1)[:, :16]
+
+        device = torch.device("cpu")
+        model = ReIDModel(_TinyEncoder(), device, ReIDPreprocessing())
+        frame = np.zeros((128, 128, 3), dtype=np.uint8)
+        embs = model.extract_features(sv.Detections.empty(), frame)
+        assert embs.shape == (0, 0)
+
+    def test_from_pretrained_architecture_only(self) -> None:
+        """from_pretrained(architecture=...) builds an OSNet model with no downloads."""
+        pytest.importorskip("torch")
+        import numpy as np
+        import supervision as sv
+
+        from trackers.core.reid.model import ReIDModel
+
+        # osnet_x0_25 is a clean-room architecture with no external weights, so
+        # this builds entirely offline (random init).
+        model = ReIDModel.from_pretrained(architecture="osnet_x0_25", device="cpu")
+        frame = np.zeros((256, 128, 3), dtype=np.uint8)
+        dets = sv.Detections(xyxy=np.array([[0, 0, 128, 256]], dtype=np.float32))
+        embs = model.extract_features(dets, frame)
+        assert embs.ndim == 2
+        assert embs.shape[0] == 1
+        norms = np.linalg.norm(embs, axis=1)
+        np.testing.assert_allclose(norms, np.ones_like(norms), atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 5. Round-trip: save_pretrained → from_pretrained (torch required)
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_save_and_reload_produces_identical_embeddings(self, tmp_path) -> None:
+        pytest.importorskip("torch")
+        pytest.importorskip("safetensors")
+        import numpy as np
+        import supervision as sv
+
+        from trackers.core.reid.model import ReIDModel
+
+        # osnet_x0_25 builds offline; its random init is fixed for this process,
+        # so the saved weights reload to byte-identical parameters.
+        model_a = ReIDModel.from_pretrained(architecture="osnet_x0_25", device="cpu")
+        save_dir = str(tmp_path / "saved_model")
+        model_a.save_pretrained(save_dir)
+
+        assert os.path.exists(os.path.join(save_dir, "weights.safetensors"))
+        assert os.path.exists(os.path.join(save_dir, "reid_config.json"))
+
+        model_b = ReIDModel.from_pretrained(save_dir, device="cpu")
+        assert model_b.preprocessing == model_a.preprocessing
+
+        frame = np.zeros((256, 128, 3), dtype=np.uint8)
+        dets = sv.Detections(xyxy=np.array([[0, 0, 128, 256]], dtype=np.float32))
+        embs_a = model_a.extract_features(dets, frame)
+        embs_b = model_b.extract_features(dets, frame)
+        np.testing.assert_allclose(embs_a, embs_b, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 6. Feature bank + appearance distance
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureBank:
+    def test_first_update_normalizes(self) -> None:
+        from trackers.core.reid.feature_bank import FeatureBank
+
+        bank = FeatureBank(alpha=0.9)
+        assert bank.update(np.array([3.0, 4.0], dtype=np.float32))
+        feature = bank.feature
+        assert feature is not None
+        np.testing.assert_allclose(np.linalg.norm(feature), 1.0, atol=1e-6)
+
+    def test_zero_and_non_finite_embeddings_are_skipped(self) -> None:
+        from trackers.core.reid.feature_bank import FeatureBank
+
+        bank = FeatureBank()
+        assert bank.update(np.zeros(8, dtype=np.float32)) is False
+        assert bank.update(np.array([1.0, np.nan], dtype=np.float32)) is False
+        assert not bank.is_initialized
+
+    def test_shape_change_is_rejected(self) -> None:
+        from trackers.core.reid.feature_bank import FeatureBank
+
+        bank = FeatureBank()
+        bank.update(np.array([1.0, 0.0], dtype=np.float32))
+        before = bank.feature
+        assert before is not None
+        assert bank.update(np.array([1.0, 0.0, 0.0], dtype=np.float32)) is False
+        after = bank.feature
+        assert after is not None
+        np.testing.assert_allclose(before, after)
+
+
+class TestAppearanceSimilarity:
+    def test_non_finite_detection_rows_are_sanitized(self) -> None:
+        from trackers.core.reid.distance import appearance_similarity
+
+        sim = appearance_similarity(
+            [np.array([1.0, 0.0], dtype=np.float32)],
+            np.array([[1.0, 0.0], [np.nan, 1.0]], dtype=np.float32),
+        )
+        assert np.isfinite(sim).all()
+        assert sim[0, 0] == pytest.approx(1.0)
+        assert sim[0, 1] == pytest.approx(0.0)
+
+    def test_skips_incompatible_track_dimensions(self) -> None:
+        from trackers.core.reid.distance import appearance_similarity
+
+        sim = appearance_similarity(
+            [np.array([1.0, 0.0, 0.0], dtype=np.float32)],
+            np.array([[1.0, 0.0]], dtype=np.float32),
+        )
+        assert sim.shape == (1, 1)
+        assert sim[0, 0] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# 7. Eval metrics + dataset loaders
+# ---------------------------------------------------------------------------
+
+
+class TestComputeReidMetrics:
+    def test_market1501_pid_zero_is_junk_in_gallery(self) -> None:
+        from trackers.core.reid.eval.datasets import MARKET1501_GALLERY_JUNK_PIDS
+        from trackers.core.reid.eval.metrics import compute_reid_metrics
+
+        metrics = compute_reid_metrics(
+            np.array([[0.1, 0.2, 0.3]], dtype=np.float32),
+            q_pids=np.array([1]),
+            g_pids=np.array([0, 1, 2]),
+            q_camids=np.array([0]),
+            g_camids=np.array([0, 1, 0]),
+            max_rank=3,
+            gallery_junk_pids=MARKET1501_GALLERY_JUNK_PIDS,
+        )
+        assert metrics.rank1 == pytest.approx(100.0)
+
+    def test_cmc_pads_when_valid_gallery_shorter_than_max_rank(self) -> None:
+        from trackers.core.reid.eval.metrics import compute_reid_metrics
+
+        metrics = compute_reid_metrics(
+            np.array([[0.2, 0.1]], dtype=np.float32),
+            q_pids=np.array([3]),
+            g_pids=np.array([3, 8]),
+            q_camids=np.array([0]),
+            g_camids=np.array([1, 0]),
+            max_rank=5,
+        )
+        assert metrics.rank1 == pytest.approx(0.0)
+        assert metrics.rank5 == pytest.approx(100.0)
+
+    def test_reid_metrics_map_alias(self) -> None:
+        from trackers.core.reid.eval.metrics import ReIDMetrics
+
+        metrics = ReIDMetrics(
+            mean_average_precision=42.0,
+            rank1=1.0,
+            rank5=2.0,
+            rank10=3.0,
+            minp=4.0,
+            num_queries=1,
+        )
+        assert metrics.map == pytest.approx(42.0)
+
+
+class TestMarket1501Loader:
+    def test_load_market1501_from_temp_tree(self, tmp_path) -> None:
+        from trackers.core.reid.eval.datasets import (
+            MARKET1501_GALLERY_JUNK_PIDS,
+            load_market1501,
+        )
+
+        query_dir = tmp_path / "query"
+        gallery_dir = tmp_path / "bounding_box_test"
+        query_dir.mkdir()
+        gallery_dir.mkdir()
+        (query_dir / "0001_c1s1_001051_00.jpg").write_bytes(b"jpeg")
+        (gallery_dir / "0000_c1s1_000151_01.jpg").write_bytes(b"jpeg")
+        (gallery_dir / "0002_c2s1_000851_01.jpg").write_bytes(b"jpeg")
+
+        query, gallery = load_market1501(tmp_path)
+        assert len(query) == 1
+        assert query.pids.tolist() == [1]
+        assert gallery.pids.tolist() == [0, 2]
+        assert gallery.gallery_junk_pids == MARKET1501_GALLERY_JUNK_PIDS
+
+
+class TestMSMT17Loader:
+    def test_load_msmt17_from_temp_lists(self, tmp_path) -> None:
+        from pathlib import Path
+
+        from trackers.core.reid.eval.datasets import load_msmt17
+
+        root = Path(tmp_path)
+        test_root = root / "test"
+        test_root.mkdir()
+        rel = "0001/0001_019_07_0303morning_0020_1.jpg"
+        image_path = test_root / rel
+        image_path.parent.mkdir(parents=True)
+        image_path.write_bytes(b"jpeg")
+        (root / "list_query.txt").write_text(f"{rel} 42\n")
+        (root / "list_gallery.txt").write_text(f"{rel} 42 6\n")
+
+        query, gallery = load_msmt17(root)
+        assert query.pids.tolist() == [42]
+        assert query.camids.tolist() == [6]
+        assert gallery.pids.tolist() == [42]
+        assert gallery.gallery_junk_pids == frozenset({-1})

--- a/tests/core/test_import_isolation.py
+++ b/tests/core/test_import_isolation.py
@@ -1,0 +1,56 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# ReID-only heavy deps. PIL is intentionally excluded: supervision (base dep) imports it.
+_REID_HEAVY_MODULES = ("torch", "torchvision", "timm", "huggingface_hub", "safetensors", "gdown")
+
+
+def _block_modules_stmt() -> str:
+    return "; ".join(f"sys.modules[{name!r}] = None" for name in _REID_HEAVY_MODULES)
+
+
+def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+        env=os.environ.copy(),
+    )
+
+
+def test_base_package_import_without_reid_extra() -> None:
+    """Fresh process: base `import trackers` works with ReID heavy modules blocked."""
+    code = f"import sys; {_block_modules_stmt()}; import trackers; assert trackers.BoTSORTTracker; print('ok')"
+    result = _run_isolated(code)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_reid_model_lazy_access_gives_install_hint() -> None:
+    """Fresh process: accessing ReIDModel without deps shows trackers[reid] hint."""
+    code = (
+        "import sys\n"
+        f"{_block_modules_stmt()}\n"
+        "import trackers\n"
+        "try:\n"
+        "    _ = trackers.ReIDModel\n"
+        "except ImportError as exc:\n"
+        "    assert 'trackers[reid]' in str(exc)\n"
+        "    print('ok')\n"
+        "else:\n"
+        "    raise SystemExit('expected ImportError')\n"
+    )
+    result = _run_isolated(code)
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -159,12 +159,25 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "bitsandbytes"
 version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "torch", marker = "sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/eb/477d6b5602f469c7305fd43eec71d890c39909f615c1d7138f6e7d226eff/bitsandbytes-0.47.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:2f805b76891a596025e9e13318b675d08481b9ee650d65e5d2f9d844084c6521", size = 30004641, upload-time = "2025-08-11T18:51:20.524Z" },
@@ -241,7 +254,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "pycparser", marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
@@ -279,7 +292,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "pycparser", marker = "(python_full_version >= '3.14' and implementation_name != 'PyPy') or (implementation_name != 'PyPy' and sys_platform != 'darwin')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -531,8 +544,8 @@ name = "cryptography"
 version = "48.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 's390x' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' and platform_machine != 's390x' and sys_platform != 'darwin'" },
+    { name = "cffi", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
 wheels = [
@@ -593,7 +606,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/fe/7351d7e586a8b4c9f89731bfe4cf0148223e8f9903ff09571f78b3fb0682/cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08b395f79cb89ce0cd8effff07c4a1e20101b873c256a1aeb286e8fd7bd0f556", size = 5744254, upload-time = "2026-03-11T00:12:29.798Z" },
@@ -628,34 +641,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -736,7 +749,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -828,6 +841,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821, upload-time = "2024-10-26T00:50:33.425Z" },
+]
+
+[[package]]
+name = "gdown"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "filelock" },
+    { name = "requests", extra = ["socks"] },
+    { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/b5/a45f62f20664031bf74a6aeb6f8d8cd5910e411bf90d756bd6b09bdc6c35/gdown-6.1.0.tar.gz", hash = "sha256:361c6e04c6ca335df50b9d71f40bcfe9ab70fb26a1b0e890a427267781389553", size = 269670, upload-time = "2026-05-30T11:56:21.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/56/a99f0f159cce5b26d267317d436afee184f45fc7911938757d7cbbd2d10c/gdown-6.1.0-py3-none-any.whl", hash = "sha256:38a36a94275b8272f684db469bbd73b4d1f64cbbc1751bcb993a1b2be8f013c8", size = 19216, upload-time = "2026-05-30T11:56:20.016Z" },
 ]
 
 [[package]]
@@ -1138,7 +1167,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "(python_full_version < '3.12' and platform_machine != 's390x') or (python_full_version < '3.11' and platform_machine == 's390x')" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1219,7 +1248,7 @@ name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools", marker = "platform_machine != 's390x'" },
+    { name = "more-itertools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
 wheels = [
@@ -1231,7 +1260,7 @@ name = "jaraco-context"
 version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12' and platform_machine != 's390x'" },
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload-time = "2024-08-20T03:39:27.358Z" }
 wheels = [
@@ -1243,7 +1272,7 @@ name = "jaraco-functools"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools", marker = "platform_machine != 's390x'" },
+    { name = "more-itertools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz", hash = "sha256:70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d", size = 19159, upload-time = "2024-09-27T19:47:09.122Z" }
 wheels = [
@@ -1282,13 +1311,13 @@ name = "keyring"
 version = "25.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12' and platform_machine != 's390x'" },
-    { name = "jaraco-classes", marker = "platform_machine != 's390x'" },
-    { name = "jaraco-context", marker = "platform_machine != 's390x'" },
-    { name = "jaraco-functools", marker = "platform_machine != 's390x'" },
-    { name = "jeepney", marker = "platform_machine != 's390x' and sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "platform_machine != 's390x' and sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "platform_machine != 's390x' and sys_platform == 'linux'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750, upload-time = "2024-12-25T15:26:45.782Z" }
 wheels = [
@@ -1993,7 +2022,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2032,7 +2061,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2044,7 +2073,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2074,9 +2103,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2088,7 +2117,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2786,6 +2815,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3265,6 +3303,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
+]
+
 [[package]]
 name = "requests-file"
 version = "3.0.1"
@@ -3502,8 +3545,8 @@ name = "secretstorage"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "platform_machine != 's390x' and sys_platform != 'darwin'" },
-    { name = "jeepney", marker = "platform_machine != 's390x' and sys_platform != 'darwin'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
 wheels = [
@@ -3759,6 +3802,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
@@ -3863,7 +3915,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
 wheels = [
@@ -3897,7 +3949,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/32/38498d2a1a5d70f33f6c3909bbad48557c9a54b0e33a9307ff06b6d416ba/tifffile-2026.1.28.tar.gz", hash = "sha256:537ae6466a8bb555c336108bb1878d8319d52c9c738041d3349454dea6956e1c", size = 374675, upload-time = "2026-01-29T05:17:24.992Z" }
 wheels = [
@@ -4131,6 +4183,15 @@ dependencies = [
 detection = [
     { name = "inference-models" },
 ]
+reid = [
+    { name = "gdown" },
+    { name = "huggingface-hub" },
+    { name = "pillow" },
+    { name = "safetensors" },
+    { name = "timm" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
 tune = [
     { name = "optuna" },
 ]
@@ -4164,17 +4225,24 @@ mypy-types = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gdown", marker = "extra == 'reid'", specifier = ">=5.0.0" },
+    { name = "huggingface-hub", marker = "extra == 'reid'", specifier = ">=0.20.0" },
     { name = "inference-models", marker = "extra == 'detection'", specifier = ">=0.19.0" },
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "opencv-python", specifier = ">=4.8.0" },
     { name = "optuna", marker = "extra == 'tune'", specifier = ">=3.0.0" },
+    { name = "pillow", marker = "extra == 'reid'", specifier = ">=10.0.0" },
     { name = "pydeprecate", specifier = ">=0.7.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "safetensors", marker = "extra == 'reid'", specifier = ">=0.4.0" },
     { name = "scipy", specifier = ">=1.13.1" },
     { name = "supervision", specifier = ">=0.26.1" },
+    { name = "timm", marker = "extra == 'reid'", specifier = ">=1.0.0" },
+    { name = "torch", marker = "extra == 'reid'", specifier = ">=2.0.0" },
+    { name = "torchvision", marker = "extra == 'reid'", specifier = ">=0.15.0" },
 ]
-provides-extras = ["detection", "tune"]
+provides-extras = ["detection", "tune", "reid"]
 
 [package.metadata.requires-dev]
 build = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lays down the classic ReID foundation without tracker association wiring:

- Optional `trackers[reid]` extra (torch/timm/HF/safetensors/Pillow/gdown)
- `ReIDModel.from_pretrained` / `save_pretrained` with OSNet, FastReID SBS, and `timm:` backbones
- Curated aliases (`osnet_x1_0_msmt17_combineall`, `fastreid_mot17_sbs50`)
- `FeatureBank`, appearance distance, extraction helpers, typing protocols
- Market-1501 / MSMT17 loaders + CMC/mAP evaluator
- Lazy `from trackers import ReIDModel` so base imports stay torch-free
- API docs, install notes, and `notebooks/eval_reid.ipynb`
- CI: `--extra reid` + import-isolation smoke tests

## Out of scope (follow-up PR)

BoT-SORT appearance association, `--tracker.reid.*` CLI, tracker docs/demos.

Stacked follow-up: `cursor/reid-botsort-941e` → this branch.

## Test plan

- [x] `pytest tests/core/reid/test_reid.py tests/core/test_import_isolation.py -m "not network"`
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f62c7-a84f-7afb-9043-52922f8b941e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f62c7-a84f-7afb-9043-52922f8b941e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

