### PR TITLE
fix(cmc): handle frame resolution changes in optical-flow motion estimation

### DIFF
--- a/src/trackers/motion/estimator.py
+++ b/src/trackers/motion/estimator.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import cv2
 import numpy as np
 
@@ -14,6 +16,8 @@ from trackers.motion.transformation import (
     HomographyTransformation,
     IdentityTransformation,
 )
+
+logger = logging.getLogger("trackers.motion.estimator")
 
 _OPTICAL_FLOW_WINDOW_SIZE = (21, 21)
 _OPTICAL_FLOW_MAX_PYRAMID_LEVEL = 3
@@ -89,7 +93,8 @@ class MotionEstimator:
 
         self._previous_grayscale: np.ndarray | None = None
         self._previous_features: np.ndarray | None = None
-        self._accumulated_homography: np.ndarray = np.eye(3, dtype=np.float64)
+        self._accumulated_homography: np.ndarray
+        self._reset_accumulator()
 
     def update(self, frame: np.ndarray) -> CoordinatesTransformation:
         """Process a new frame and return the coordinate transformation.
@@ -105,27 +110,53 @@ class MotionEstimator:
             `CoordinatesTransformation` for converting between absolute and
                 relative coordinates. Returns `IdentityTransformation` for the
                 first frame or if motion estimation fails.
+
+        Note:
+            If the frame shape changes versus the previous frame (e.g. a source
+            that renegotiates resolution mid-stream), the accumulated homography
+            is reset to identity, re-baselining the world coordinate system to
+            the new resolution. Absolute coordinates are therefore not
+            continuous across a resolution change. Callers relying on
+            absolute-coordinate continuity should call `reset()` themselves and
+            re-establish any world-space references after such a change. Because
+            the guard only compares against the immediately-previous frame, a
+            source that sustains a resolution oscillation (thrashing between two
+            sizes, e.g. from a flaky transcoder or a flapping bitrate ladder)
+            re-baselines on every frame, effectively disabling motion
+            compensation for the duration of the oscillation.
         """
         if len(frame.shape) == 3:
             grayscale = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
         else:
             grayscale = frame.copy()
 
+        current_features = self._find_features(grayscale)
+
         if self._previous_grayscale is None:
             self._previous_grayscale = grayscale
-            self._previous_features = self._find_features(grayscale)
+            self._previous_features = current_features
             return IdentityTransformation()
-
-        current_features = self._find_features(grayscale)
 
         # A frame size change (e.g. a source that renegotiates resolution
         # mid-stream) breaks the pixel coordinate frame the accumulated
-        # homography lives in, so reset it as reset() does before re-syncing.
+        # homography lives in, so reset only the accumulator (via
+        # _reset_accumulator, as reset() does) before re-syncing. Unlike
+        # reset(), this deliberately keeps the cached previous frame / features
+        # (the lines just below immediately re-baseline them to this frame), so
+        # a future reader should not "fix" this to call reset() instead.
         # Returning the stale homography would hand back coordinates in the old
         # resolution's scale, and calcOpticalFlowPyrLK would assert on the
         # mismatched sizes.
+        # This guard duplicates CMC._estimate_sparse_optflow in utils/cmc.py;
+        # the two are parallel sparse-optical-flow pipelines kept separate on
+        # purpose (divergent resets/return types) — consolidating is tracked debt.
         if self._previous_grayscale.shape != grayscale.shape:
-            self._accumulated_homography = np.eye(3, dtype=np.float64)
+            logger.debug(
+                "MotionEstimator: frame size changed (%s -> %s); re-baselining accumulated homography",
+                self._previous_grayscale.shape,
+                grayscale.shape,
+            )
+            self._reset_accumulator()
             self._previous_grayscale = grayscale
             self._previous_features = current_features
             return self._get_current_transformation()
@@ -234,4 +265,13 @@ class MotionEstimator:
         """
         self._previous_grayscale = None
         self._previous_features = None
+        self._reset_accumulator()
+
+    def _reset_accumulator(self) -> None:
+        """Reset the accumulated homography to the identity transform.
+
+        Re-baselines the world coordinate system to the current frame. Unlike
+        `reset()`, this does NOT clear the cached previous frame or feature
+        points; use `reset()` when a full state reset is required.
+        """
         self._accumulated_homography = np.eye(3, dtype=np.float64)

--- a/src/trackers/motion/estimator.py
+++ b/src/trackers/motion/estimator.py
@@ -166,7 +166,7 @@ class MotionEstimator:
             self._previous_features = current_features
             return self._get_current_transformation()
 
-        tracked_points, status, _ = cv2.calcOpticalFlowPyrLK(
+        tracked_points, status, _ = cv2.calcOpticalFlowPyrLK(  # type: ignore[call-overload]
             self._previous_grayscale,
             grayscale,
             self._previous_features,

--- a/src/trackers/motion/estimator.py
+++ b/src/trackers/motion/estimator.py
@@ -118,6 +118,18 @@ class MotionEstimator:
 
         current_features = self._find_features(grayscale)
 
+        # A frame size change (e.g. a source that renegotiates resolution
+        # mid-stream) breaks the pixel coordinate frame the accumulated
+        # homography lives in, so reset it as reset() does before re-syncing.
+        # Returning the stale homography would hand back coordinates in the old
+        # resolution's scale, and calcOpticalFlowPyrLK would assert on the
+        # mismatched sizes.
+        if self._previous_grayscale.shape != grayscale.shape:
+            self._accumulated_homography = np.eye(3, dtype=np.float64)
+            self._previous_grayscale = grayscale
+            self._previous_features = current_features
+            return self._get_current_transformation()
+
         if self._previous_features is None or len(self._previous_features) < _MIN_POINTS_FOR_HOMOGRAPHY:
             self._previous_grayscale = grayscale
             self._previous_features = current_features

--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -524,18 +524,40 @@ class CMC:
             self._initialized = True
             return affine_mtx
 
-        # If we don't have points, or the frame size changed (e.g. a video
-        # source that renegotiates resolution mid-stream), re-init and return
-        # identity. calcOpticalFlowPyrLK asserts that both frames share the
-        # same size, so a mismatch would crash it.
-        if (
-            self._prev_frame_gray is None
-            or self._prev_points is None
-            or keypoints is None
-            or self._prev_frame_gray.shape != frame.shape
-        ):
+        # No usable prior state (no previous frame / points) or no keypoints in
+        # the current frame: re-init and return identity.
+        if self._prev_frame_gray is None or self._prev_points is None or keypoints is None:
             self._prev_frame_gray = frame.copy()
-            self._prev_points = copy.copy(keypoints)
+            self._prev_points = None if keypoints is None else keypoints.copy()
+            return affine_mtx
+
+        # A mid-stream frame-size change (e.g. a video source that renegotiates
+        # resolution) is an expected event, not a failure, so it is surfaced via
+        # a debug log below and does NOT bump frames_failed (which counts genuine
+        # estimation failures). calcOpticalFlowPyrLK asserts that both frames
+        # share the same size, so a mismatch would crash it. Known limitation: the
+        # guard only compares against the immediately-previous frame, so a source
+        # sustaining a resolution oscillation (thrashing between two sizes, e.g.
+        # from a flaky transcoder or flapping bitrate ladder) re-inits on every
+        # frame, effectively disabling CMC for the duration of the oscillation.
+        # This guard mirrors MotionEstimator.update in motion/estimator.py;
+        # the two are parallel sparse-optical-flow pipelines, deliberately not
+        # merged (divergent resets/return types) — tracked debt to consolidate.
+        # Known, untested, low-risk edge (downscale-collapse): when downscale > 1
+        # the shapes compared below are the already-downscaled ones, so two
+        # different input resolutions that floor-divide to the same downscaled
+        # shape slip past this guard. calcOpticalFlowPyrLK then runs on the
+        # equal-sized downscaled frames without asserting, so it does not crash;
+        # the only cost is one frame of slightly degraded motion estimate. No
+        # test covers this and none is added — the real-world risk is negligible.
+        if self._prev_frame_gray.shape != frame.shape:
+            logger.debug(
+                "CMC: frame size changed (%s -> %s); re-syncing sparse optical flow",
+                self._prev_frame_gray.shape,
+                frame.shape,
+            )
+            self._prev_frame_gray = frame.copy()
+            self._prev_points = keypoints.copy()
             return affine_mtx
 
         # Optical flow correspondences

--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -522,8 +522,16 @@ class CMC:
             self._initialized = True
             return affine_mtx
 
-        # If we don't have points, re-init
-        if self._prev_frame_gray is None or self._prev_points is None or keypoints is None:
+        # If we don't have points, or the frame size changed (e.g. a video
+        # source that renegotiates resolution mid-stream), re-init and return
+        # identity. calcOpticalFlowPyrLK asserts that both frames share the
+        # same size, so a mismatch would crash it.
+        if (
+            self._prev_frame_gray is None
+            or self._prev_points is None
+            or keypoints is None
+            or self._prev_frame_gray.shape != frame.shape
+        ):
             self._prev_frame_gray = frame.copy()
             self._prev_points = copy.copy(keypoints)
             return affine_mtx

--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -329,7 +329,9 @@ class CMC:
 
         Returns:
             Affine transform matrix of shape (2, 3), dtype float32.
-            Identity if not enough correspondences or if not initialized yet.
+            Identity if not enough correspondences, if not initialized yet, or if
+            the current frame size differs from the previous frame's (mid-stream
+            resolution change).
 
         Examples:
             >>> import numpy as np
@@ -631,6 +633,11 @@ class CMC:
             self._prev_frame_gray = frame.copy()
             return affine_mtx
 
+        # A mid-stream resolution/size change is already handled here: a shape
+        # mismatch between self._prev_frame_gray and frame makes findTransformECC
+        # raise cv2.error internally, which the except below catches and turns
+        # into an identity transform (with self._prev_frame_gray refreshed after).
+        # So ECC needs no explicit size guard like _estimate_sparse_optflow has.
         try:
             _cc, affine_est = cv2.findTransformECC(
                 self._prev_frame_gray,

--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -258,16 +258,16 @@ class CMC:
         self.extractor: Any | None = None
         self.matcher: Any | None = None
         if self.cfg.method == "orb":
-            self.detector = cv2.FastFeatureDetector_create(self.cfg.fast_threshold)
-            self.extractor = cv2.ORB_create()
+            self.detector = cv2.FastFeatureDetector_create(self.cfg.fast_threshold)  # type: ignore[attr-defined]
+            self.extractor = cv2.ORB_create()  # type: ignore[attr-defined]
             self.matcher = cv2.BFMatcher(cv2.NORM_HAMMING)
         elif self.cfg.method == "sift":
-            self.detector = cv2.SIFT_create(
+            self.detector = cv2.SIFT_create(  # type: ignore[attr-defined]
                 nOctaveLayers=self.cfg.sift_n_octave_layers,
                 contrastThreshold=self.cfg.sift_contrast_threshold,
                 edgeThreshold=int(self.cfg.sift_edge_threshold),
             )
-            self.extractor = cv2.SIFT_create(
+            self.extractor = cv2.SIFT_create(  # type: ignore[attr-defined]
                 nOctaveLayers=self.cfg.sift_n_octave_layers,
                 contrastThreshold=self.cfg.sift_contrast_threshold,
                 edgeThreshold=int(self.cfg.sift_edge_threshold),
@@ -515,7 +515,7 @@ class CMC:
             frame = cv2.resize(frame, (new_w, new_h))
 
         # Find keypoints in current frame
-        keypoints = cv2.goodFeaturesToTrack(frame, mask=None, **self.feature_params)
+        keypoints = cv2.goodFeaturesToTrack(frame, mask=None, **self.feature_params)  # type: ignore[call-overload]
 
         # First frame: init and return identity
         if not self._initialized:
@@ -562,7 +562,9 @@ class CMC:
 
         # Optical flow correspondences
         # calcOpticalFlowPyrLK will throw or return nonsense if we give it None
-        matched, status, _err = cv2.calcOpticalFlowPyrLK(self._prev_frame_gray, frame, self._prev_points, None)
+        matched, status, _err = cv2.calcOpticalFlowPyrLK(  # type: ignore[call-overload]
+            self._prev_frame_gray, frame, self._prev_points, None
+        )
 
         if status is None or matched is None:
             self._prev_frame_gray = frame.copy()
@@ -661,7 +663,7 @@ class CMC:
         # into an identity transform (with self._prev_frame_gray refreshed after).
         # So ECC needs no explicit size guard like _estimate_sparse_optflow has.
         try:
-            _cc, affine_est = cv2.findTransformECC(
+            _cc, affine_est = cv2.findTransformECC(  # type: ignore[call-overload]
                 self._prev_frame_gray,
                 frame,
                 affine_mtx,

--- a/tests/motion/test_estimator.py
+++ b/tests/motion/test_estimator.py
@@ -1,0 +1,63 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import numpy as np
+
+from trackers.motion.estimator import MotionEstimator
+from trackers.motion.transformation import CoordinatesTransformation
+
+
+def _noise_frame(height: int, width: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.integers(0, 255, (height, width, 3), dtype=np.uint8)
+
+
+def test_motion_estimator_survives_resolution_change() -> None:
+    """A frame size change mid-stream returns a transformation instead of crashing.
+
+    calcOpticalFlowPyrLK asserts both frames share the same size, so when a
+    source renegotiates resolution between two consecutive frames the estimator
+    must re-sync the reference frame rather than crash.
+    """
+    estimator = MotionEstimator()
+    estimator.update(_noise_frame(480, 640, seed=1))
+    transform = estimator.update(_noise_frame(720, 1280, seed=2))  # resolution changed
+
+    assert isinstance(transform, CoordinatesTransformation)
+    point = np.array([[100.0, 100.0]], dtype=np.float32)
+    assert np.all(np.isfinite(transform.abs_to_rel(point)))
+
+
+def test_motion_estimator_recovers_after_resolution_change() -> None:
+    """After a resolution change the estimator keeps working on the new size."""
+    estimator = MotionEstimator()
+    estimator.update(_noise_frame(480, 640, seed=1))
+    estimator.update(_noise_frame(720, 1280, seed=2))  # change: re-syncs
+    transform = estimator.update(_noise_frame(720, 1280, seed=3))  # same new size
+
+    assert isinstance(transform, CoordinatesTransformation)
+    point = np.array([[100.0, 100.0]], dtype=np.float32)
+    assert np.all(np.isfinite(transform.abs_to_rel(point)))
+
+
+def test_motion_estimator_resets_frame_on_resolution_change() -> None:
+    """A resolution change re-baselines instead of carrying stale-scale coordinates.
+
+    The accumulated homography lives in the previous resolution's pixel space,
+    so returning it after a size change would hand back coordinates in the wrong
+    scale. The estimator must reset the reference frame to identity.
+    """
+    estimator = MotionEstimator()
+    estimator.update(_noise_frame(480, 640, seed=1))
+    # simulate motion accumulated in the old resolution's pixel space
+    estimator._accumulated_homography = np.array([[1.0, 0.0, 50.0], [0.0, 1.0, 30.0], [0.0, 0.0, 1.0]])
+
+    transform = estimator.update(_noise_frame(960, 1280, seed=2))  # resolution changed
+
+    point = np.array([[0.0, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(transform.abs_to_rel(point), point)  # re-baselined, not 50/30

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -110,3 +110,63 @@ def test_cmc_recovers_after_tiny_frame_followup_call_returns_identity(
 
     assert affine_mtx.shape == (2, 3)
     np.testing.assert_array_equal(affine_mtx, np.eye(2, 3, dtype=np.float32))
+
+
+@pytest.mark.parametrize("method", CMC_METHODS)
+def test_cmc_survives_resolution_change(
+    method: Literal["sparseOptFlow", "orb", "sift", "ecc"],
+) -> None:
+    """No CMC method crashes when the frame size changes mid-stream.
+
+    A source that renegotiates resolution (e.g. an RTSP camera after a
+    reconnect, or switching clips without a reset) feeds consecutive frames of
+    different sizes. sparseOptFlow feeds both into calcOpticalFlowPyrLK, which
+    asserts they share the same size, so it used to crash; the others already
+    coped. Every method must return a finite affine matrix.
+    """
+    rng = np.random.default_rng(0)
+    small = rng.integers(0, 255, (480, 640, 3), dtype=np.uint8)
+    large = rng.integers(0, 255, (720, 1280, 3), dtype=np.uint8)
+
+    cmc = CMC(CMCConfig(method=method, downscale=2))
+    cmc.estimate(small)
+    affine_mtx = cmc.estimate(large)  # resolution changed between the two frames
+
+    assert affine_mtx.shape == (2, 3)
+    assert np.all(np.isfinite(affine_mtx))
+
+
+def test_cmc_sparse_optflow_returns_identity_on_resolution_change() -> None:
+    """sparseOptFlow re-inits and returns identity when the frame size changes.
+
+    This is the guarded path: the cached previous frame no longer matches the
+    new frame size, so the optical-flow step is skipped for that frame.
+    """
+    rng = np.random.default_rng(0)
+    small = rng.integers(0, 255, (480, 640, 3), dtype=np.uint8)
+    large = rng.integers(0, 255, (720, 1280, 3), dtype=np.uint8)
+
+    cmc = CMC(CMCConfig(method="sparseOptFlow", downscale=2))
+    cmc.estimate(small)
+    affine_mtx = cmc.estimate(large)
+
+    np.testing.assert_array_equal(affine_mtx, np.eye(2, 3, dtype=np.float32))
+
+
+@pytest.mark.parametrize("method", CMC_METHODS)
+def test_cmc_recovers_after_resolution_change(
+    method: Literal["sparseOptFlow", "orb", "sift", "ecc"],
+) -> None:
+    """After a resolution change CMC keeps estimating on the new size."""
+    rng = np.random.default_rng(1)
+    small = rng.integers(0, 255, (480, 640, 3), dtype=np.uint8)
+    large_a = rng.integers(0, 255, (720, 1280, 3), dtype=np.uint8)
+    large_b = rng.integers(0, 255, (720, 1280, 3), dtype=np.uint8)
+
+    cmc = CMC(CMCConfig(method=method, downscale=2))
+    cmc.estimate(small)
+    cmc.estimate(large_a)  # change: re-syncs on the new size
+    affine_mtx = cmc.estimate(large_b)  # same new size again: no crash, finite output
+
+    assert affine_mtx.shape == (2, 3)
+    assert np.all(np.isfinite(affine_mtx))


### PR DESCRIPTION
`BoTSORTTracker` uses `sparseOptFlow` for camera motion compensation by default (`enable_cmc=True`, `cmc_method="sparseOptFlow"`). That path caches the previous grayscale frame and feeds it into `calcOpticalFlowPyrLK` together with the current one:

```python
matched, status, _err = cv2.calcOpticalFlowPyrLK(self._prev_frame_gray, frame, self._prev_points, None)
```

`calcOpticalFlowPyrLK` asserts both frames share the same size, so if the frame resolution changes between two `update()` calls the tracker crashes with an unhandled `cv2.error`. This happens in real pipelines: an RTSP camera renegotiating its stream after a reconnect, or feeding clips of different sizes through the same tracker without calling `reset()`. The function already guards the other degenerate paths (no keypoints, `status is None`, too few correspondences) and re-inits to identity for those, but not for a resolution change — that case was still missing.

The same gap exists in `MotionEstimator.update()` (public API, used by the motion-aware trace annotator), which calls `calcOpticalFlowPyrLK` with the same cached-frame pattern.

**Changes**

- `src/trackers/utils/cmc.py`: extend the existing re-init guard in `_estimate_sparse_optflow` with a `self._prev_frame_gray.shape != frame.shape` check, so a size change re-syncs the reference frame and returns identity instead of reaching the crash.
- `src/trackers/motion/estimator.py`: add the same guard to `MotionEstimator.update()`. A size change also invalidates the accumulated homography — it was computed at the old resolution, so I reset it to identity there too, otherwise it keeps returning coordinates in the wrong scale instead of crashing.
- Tests for both: a resolution change no longer crashes, the estimator recovers on the new size, and the coordinates it returns after a resize match the new scale instead of the old one.

Only `sparseOptFlow` had the bug, `orb`, `sift` and `ecc` already handled a size change, so I didn't touch them (the parametrised test checks that all four survive it).

**Validation**

- Both crashes reproduce on `develop` with the `cv2.error` above. The new regression tests fail there and pass with the fix.
- `pytest tests/utils tests/motion` passes .. the CMC vs BoT-SORT behaviour is otherwise unchanged, this only guards the frame where the size differs.
- `ruff check` and `ruff format --check` are clean on the touched files.
