### PR TITLE
[McByte part 8] Complete McByte with mask-conditioned association

### DIFF
--- a/src/trackers/core/mcbyte/mask_association.py
+++ b/src/trackers/core/mcbyte/mask_association.py
@@ -1,0 +1,471 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from trackers.core.mcbyte.masks.base import MaskOutput
+
+MINIMUM_MASK_AVERAGE_CONFIDENCE = 0.6
+MINIMUM_MASK_COVERAGE = 0.9
+MINIMUM_MASK_FILL_RATIO = 0.05
+
+
+@dataclass(frozen=True)
+class MaskConditionedAssociation:
+    """Association problem prepared for the remaining Hungarian assignment.
+
+    Attributes:
+        conditioned_similarity: Similarity matrix restricted to the remaining
+            tracklet and detection indices. Qualifying mask evidence is added to
+            selected entries without clamping, so values may exceed ``1.0``.
+        locked_matches: Clear threshold-valid matches expressed as
+            ``(tracklet_index, detection_index)`` pairs in the original matrix.
+        remaining_track_indices: Original tracklet indices represented by the
+            rows of ``conditioned_similarity``.
+        remaining_detection_indices: Original detection indices represented by
+            the columns of ``conditioned_similarity``.
+    """
+
+    conditioned_similarity: np.ndarray
+    locked_matches: list[tuple[int, int]]
+    remaining_track_indices: list[int]
+    remaining_detection_indices: list[int]
+
+
+def _validate_threshold(name: str, value: float) -> None:
+    """Validate that a threshold is a fraction in the inclusive range [0, 1]."""
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must be between 0 and 1.")
+
+
+def _validate_inputs(
+    similarity: np.ndarray,
+    raw_iou_similarity: np.ndarray,
+    tracklet_ids: list[int],
+    detection_boxes: np.ndarray,
+) -> None:
+    """Validate matrix dimensions and their associated metadata."""
+    if similarity.ndim != 2:
+        raise ValueError(f"similarity must be a two-dimensional matrix. Got shape {similarity.shape}.")
+
+    if raw_iou_similarity.shape != similarity.shape:
+        raise ValueError(
+            "raw_iou_similarity must have the same shape as similarity. "
+            f"Got {raw_iou_similarity.shape} and {similarity.shape}."
+        )
+
+    num_tracklets, num_detections = similarity.shape
+
+    if len(tracklet_ids) != num_tracklets:
+        raise ValueError(
+            "Number of tracklet IDs must match the number of similarity rows. "
+            f"Got {len(tracklet_ids)} IDs and {num_tracklets} rows."
+        )
+
+    if detection_boxes.shape != (num_detections, 4):
+        raise ValueError(f"detection_boxes must have shape (num_detections, 4). Got {detection_boxes.shape}.")
+
+
+def _get_clear_matches(
+    similarity: np.ndarray,
+    minimum_similarity: float,
+) -> list[tuple[int, int]]:
+    """Return threshold-valid pairs that are unique in both row and column.
+
+    Eligibility is determined from the untouched similarity matrix. A pair is
+    clear when it is the only threshold-valid candidate for both its tracklet
+    row and its detection column.
+    """
+    eligible = similarity >= minimum_similarity
+    row_candidate_counts = eligible.sum(axis=1)
+    column_candidate_counts = eligible.sum(axis=0)
+
+    # A matrix entry is True only if:
+    # the pair is eligible
+    # AND its row has exactly one eligible candidate
+    # AND its column has exactly one eligible candidate.
+    # None indexing: transform into a vector so that it can be broadcasted and
+    # performed logical AND with a matrix.
+    clear_rows, clear_columns = np.where(
+        eligible & (row_candidate_counts[:, None] == 1) & (column_candidate_counts[None, :] == 1)
+    )
+
+    return list(
+        zip(
+            clear_rows.tolist(),
+            clear_columns.tolist(),
+        )
+    )
+
+
+def _get_remaining_indices(
+    num_tracklets: int,
+    num_detections: int,
+    locked_matches: list[tuple[int, int]],
+) -> tuple[list[int], list[int]]:
+    """Return original matrix indices not consumed by locked matches."""
+    locked_track_indices = {track_index for track_index, _ in locked_matches}
+    locked_detection_indices = {detection_index for _, detection_index in locked_matches}
+
+    remaining_track_indices = [index for index in range(num_tracklets) if index not in locked_track_indices]
+    remaining_detection_indices = [index for index in range(num_detections) if index not in locked_detection_indices]
+
+    return remaining_track_indices, remaining_detection_indices
+
+
+def _get_ambiguous_candidate_matrix(
+    similarity: np.ndarray,
+    minimum_similarity: float,
+) -> np.ndarray:
+    """Return eligible pairs belonging to an ambiguous row or column.
+
+    Ambiguity is always computed from the untouched base similarity matrix.
+    A pair is ambiguous when its tracklet has multiple eligible detections or
+    its detection has multiple eligible tracklets.
+    """
+    eligible = similarity >= minimum_similarity
+    ambiguous_rows = eligible.sum(axis=1) > 1
+    ambiguous_columns = eligible.sum(axis=0) > 1
+
+    # Every eligible cell whose row or column is ambiguous
+    return eligible & (ambiguous_rows[:, None] | ambiguous_columns[None, :])
+
+
+def _get_isolated_candidate_matrix(
+    raw_iou_similarity: np.ndarray,
+    minimum_similarity: float,
+) -> np.ndarray:
+    """Return isolated positive-IoU pairs below the normal threshold.
+
+    A pair is isolated when it is the only positive-IoU edge in both its row
+    and its column. Isolation is based exclusively on raw IoU geometry, not on
+    score-fused similarity.
+    """
+    positive_iou = raw_iou_similarity > 0.0
+    isolated_rows = positive_iou.sum(axis=1) == 1
+    isolated_columns = positive_iou.sum(axis=0) == 1
+
+    below_threshold = raw_iou_similarity < minimum_similarity
+
+    # A pair survives only if:
+    # raw IoU is greater than zero
+    # AND raw IoU is below the normal threshold
+    # AND its row has exactly one positive-IoU edge
+    # AND its column has exactly one positive-IoU edge.
+    return positive_iou & below_threshold & isolated_rows[:, None] & isolated_columns[None, :]
+
+
+def _get_mask_metrics(
+    mask: np.ndarray,
+    detection_xyxy: np.ndarray,
+) -> tuple[float, float] | None:
+    """Return mask coverage and mask fill ratio for one detection box.
+
+    Mask coverage is the fraction of the full visible mask contained inside the
+    detection box. Mask fill ratio is the fraction of detection-box pixels
+    occupied by the mask.
+
+    Returns:
+        ``(mask_coverage, mask_fill_ratio)`` or ``None`` when the mask is not
+        visible or the clipped detection box has no positive area.
+    """
+    if mask.ndim != 2:
+        raise ValueError(f"Each mask must have shape (H, W). Got shape {mask.shape}.")
+
+    mask_bool = mask.astype(bool, copy=False)
+    visible_mask_area = int(mask_bool.sum())
+    if visible_mask_area == 0:
+        return None
+
+    height, width = mask_bool.shape
+    x1, y1, x2, y2 = detection_xyxy
+
+    left = int(np.floor(np.clip(x1, 0, width)))
+    top = int(np.floor(np.clip(y1, 0, height)))
+    right = int(np.ceil(np.clip(x2, 0, width)))
+    bottom = int(np.ceil(np.clip(y2, 0, height)))
+
+    if right <= left or bottom <= top:
+        return None
+
+    mask_pixels_inside_box = int(mask_bool[top:bottom, left:right].sum())
+    detection_area = (right - left) * (bottom - top)
+
+    mask_coverage = mask_pixels_inside_box / visible_mask_area
+    mask_fill_ratio = mask_pixels_inside_box / detection_area
+
+    return mask_coverage, mask_fill_ratio
+
+
+def _apply_mask_similarity_boosts(
+    conditioned_similarity: np.ndarray,
+    candidate_matrix: np.ndarray,
+    remaining_track_indices: list[int],
+    remaining_detection_indices: list[int],
+    tracklet_ids: list[int],
+    detection_boxes: np.ndarray,
+    mask_output: MaskOutput | None,
+    minimum_mask_average_confidence: float,
+    minimum_mask_coverage: float,
+    minimum_mask_fill_ratio: float,
+) -> None:
+    """Apply mask evidence to qualifying association-score entries.
+
+    The function examines only pairs marked as ``True`` in ``candidate_matrix``.
+    These pairs have already been selected by the caller as either ambiguous
+    threshold-valid associations or optional isolated low-IoU associations.
+
+    ``conditioned_similarity`` and ``candidate_matrix`` use local indices from
+    the reduced association problem after clear matches have been removed.
+    ``remaining_track_indices`` and ``remaining_detection_indices`` map these
+    local row and column indices back to the corresponding indices in the
+    original full association problem.
+
+    For every candidate pair, the function:
+
+        1. resolves the stable tracklet ID associated with the original row;
+        2. finds the corresponding local mask index in ``mask_output``;
+        3. verifies that the mask index and average mask confidence are valid;
+        4. computes mask coverage and mask fill ratio for the original
+           detection box;
+        5. adds the mask fill ratio to the local association score when all
+           configured mask thresholds are satisfied.
+
+    The score matrix is modified in place. Mask bonuses are intentionally not
+    clamped, so conditioned association scores may exceed ``1.0``.
+
+    Args:
+        conditioned_similarity: Writable reduced association-score matrix with
+            shape ``(R, C)``, where ``R`` and ``C`` are the numbers of remaining
+            tracklets and detections after clear matches have been removed.
+            Qualifying mask fill ratios are added directly to this array.
+        candidate_matrix: Boolean matrix with the same shape as
+            ``conditioned_similarity``. A ``True`` entry identifies a reduced
+            tracklet-detection pair that is eligible for mask-based
+            conditioning.
+        remaining_track_indices: Mapping from each local row of the reduced
+            matrices to its original tracklet-row index in ``tracklet_ids`` and
+            the full association matrix.
+        remaining_detection_indices: Mapping from each local column of the
+            reduced matrices to its original detection-column index in
+            ``detection_boxes`` and the full association matrix.
+        tracklet_ids: Stable tracker IDs ordered according to the rows of the
+            original full association matrix. A tracklet without a corresponding
+            mask is skipped.
+        detection_boxes: Detection boxes in ``xyxy`` format, ordered according
+            to the columns of the original full association matrix. Expected
+            shape is ``(num_detections, 4)``.
+        mask_output: Current propagated mask output. Its
+            ``tracklet_mask_dict`` maps stable tracklet IDs to local mask-array
+            indices, while ``mask_avg_prob_dict`` stores average mask confidence
+            keyed by stable tracklet ID. If the output, masks, or confidence
+            mapping is unavailable, no scores are modified.
+        minimum_mask_average_confidence: Minimum average propagated-mask
+            confidence required before mask evidence may be used.
+        minimum_mask_coverage: Minimum fraction of the complete visible mask
+            that must lie inside the detection box.
+        minimum_mask_fill_ratio: Minimum fraction of the detection-box area that
+            must be occupied by the mask.
+
+    Returns:
+        None. ``conditioned_similarity`` is updated in place.
+    """
+    if mask_output is None or mask_output.masks is None or mask_output.mask_avg_prob_dict is None:
+        return
+
+    # Local indices in the reduced matrix.
+    candidate_rows, candidate_columns = np.where(candidate_matrix)
+
+    for local_track_index, local_detection_index in zip(
+        candidate_rows,
+        candidate_columns,
+    ):
+        original_track_index = remaining_track_indices[local_track_index]
+        original_detection_index = remaining_detection_indices[local_detection_index]
+
+        # Resolve stable tracklet ID
+        tracklet_id = tracklet_ids[original_track_index]
+        mask_index = mask_output.tracklet_mask_dict.get(tracklet_id)
+        if mask_index is None:
+            continue
+
+        if not 0 <= mask_index < mask_output.masks.shape[0]:
+            continue
+
+        average_confidence = mask_output.mask_avg_prob_dict.get(tracklet_id)
+        if average_confidence is None or average_confidence < minimum_mask_average_confidence:
+            continue
+
+        metrics = _get_mask_metrics(
+            mask=mask_output.masks[mask_index],
+            detection_xyxy=detection_boxes[original_detection_index],
+        )
+        if metrics is None:
+            continue
+
+        mask_coverage, mask_fill_ratio = metrics
+
+        if mask_fill_ratio < minimum_mask_fill_ratio:
+            continue
+
+        if mask_coverage < minimum_mask_coverage:
+            continue
+
+        conditioned_similarity[
+            local_track_index,
+            local_detection_index,
+        ] += mask_fill_ratio
+
+
+def condition_similarity_with_masks(
+    *,
+    similarity: np.ndarray,
+    raw_iou_similarity: np.ndarray,
+    tracklet_ids: list[int],
+    detection_boxes: np.ndarray,
+    mask_output: MaskOutput | None,
+    minimum_similarity: float,
+    minimum_mask_average_confidence: float = MINIMUM_MASK_AVERAGE_CONFIDENCE,
+    minimum_mask_coverage: float = MINIMUM_MASK_COVERAGE,
+    minimum_mask_fill_ratio: float = MINIMUM_MASK_FILL_RATIO,
+    enable_isolated_mask_matching: bool = False,
+) -> MaskConditionedAssociation:
+    """Prepare a similarity matrix for mask-conditioned assignment.
+
+    The function preserves clear threshold-valid IoU decisions by locking pairs
+    that are unique in both their row and column. It then removes their rows and
+    columns from the remaining assignment problem.
+
+    For the remaining pairs, mask evidence may increase association scores when
+    a pair is ambiguous in the original similarity matrix. When
+    ``enable_isolated_mask_matching`` is enabled, mask evidence may also rescue
+    an isolated positive-similarity-IoU pair that lies below the normal association
+    threshold.
+
+    Ambiguity and isolation are computed before any mask updates. Qualifying
+    mask-fill ratios are added without clamping, so conditioned scores may
+    exceed ``1.0``.
+
+    Args:
+        similarity: Base stage-specific association similarity matrix with shape
+            ``(num_tracklets, num_detections)``. This may be raw IoU or
+            score-fused IoU depending on the association stage.
+        raw_iou_similarity: Raw IoU matrix with the same shape. It is used only
+            to identify optional isolated geometric pairs.
+        tracklet_ids: Stable tracker IDs corresponding to similarity rows.
+            Tracklets without a usable stable ID may use a negative value; such
+            IDs will not resolve to a mask.
+        detection_boxes: Detection boxes in ``xyxy`` format with shape
+            ``(num_detections, 4)``.
+        mask_output: Current propagated masks and tracklet mappings.
+        minimum_similarity: Normal minimum similarity required by the current
+            association stage.
+        minimum_mask_average_confidence: Minimum average propagated-mask
+            confidence required to use mask evidence.
+        minimum_mask_coverage: Minimum fraction of the visible mask that must
+            lie inside the detection box (mc).
+        minimum_mask_fill_ratio: Minimum fraction of the detection box that must
+            be occupied by the mask (mf).
+        enable_isolated_mask_matching: Whether mask evidence may also condition
+            isolated positive-IoU pairs below ``minimum_similarity``.
+
+    Returns:
+        Prepared reduced association problem, locked clear matches, and the
+        original indices represented by the reduced matrix.
+    """
+    _validate_threshold("minimum_similarity", minimum_similarity)
+    _validate_threshold(
+        "minimum_mask_average_confidence",
+        minimum_mask_average_confidence,
+    )
+    _validate_threshold("minimum_mask_coverage", minimum_mask_coverage)
+    _validate_threshold(
+        "minimum_mask_fill_ratio",
+        minimum_mask_fill_ratio,
+    )
+    _validate_inputs(
+        similarity=similarity,
+        raw_iou_similarity=raw_iou_similarity,
+        tracklet_ids=tracklet_ids,
+        detection_boxes=detection_boxes,
+    )
+
+    # All ambiguity and locking decisions are based on an untouched snapshot of the
+    # initial matrix.
+    base_similarity = similarity.copy()
+
+    locked_matches = _get_clear_matches(
+        similarity=base_similarity,
+        minimum_similarity=minimum_similarity,
+    )
+
+    remaining_track_indices, remaining_detection_indices = _get_remaining_indices(
+        num_tracklets=base_similarity.shape[0],
+        num_detections=base_similarity.shape[1],
+        locked_matches=locked_matches,
+    )
+
+    # copy(): independent working copy that will be modified.
+    # Not a meaningful memory concern.
+    reduced_similarity = base_similarity[
+        np.ix_(
+            remaining_track_indices,
+            remaining_detection_indices,
+        )
+    ].copy()
+
+    # Ambiguity is a property of the original association situation before any
+    # modifications, hence computed from base_similarity.
+    ambiguous_candidates = _get_ambiguous_candidate_matrix(
+        similarity=base_similarity,
+        minimum_similarity=minimum_similarity,
+    )
+
+    candidate_matrix = ambiguous_candidates[
+        np.ix_(
+            remaining_track_indices,
+            remaining_detection_indices,
+        )
+    ]
+
+    if enable_isolated_mask_matching:
+        isolated_candidates = _get_isolated_candidate_matrix(
+            raw_iou_similarity=raw_iou_similarity,
+            minimum_similarity=minimum_similarity,
+        )
+        candidate_matrix = (
+            candidate_matrix
+            | isolated_candidates[
+                np.ix_(
+                    remaining_track_indices,
+                    remaining_detection_indices,
+                )
+            ]
+        )
+
+    _apply_mask_similarity_boosts(
+        conditioned_similarity=reduced_similarity,
+        candidate_matrix=candidate_matrix,
+        remaining_track_indices=remaining_track_indices,
+        remaining_detection_indices=remaining_detection_indices,
+        tracklet_ids=tracklet_ids,
+        detection_boxes=detection_boxes,
+        mask_output=mask_output,
+        minimum_mask_average_confidence=minimum_mask_average_confidence,
+        minimum_mask_coverage=minimum_mask_coverage,
+        minimum_mask_fill_ratio=minimum_mask_fill_ratio,
+    )
+
+    return MaskConditionedAssociation(
+        conditioned_similarity=reduced_similarity,
+        locked_matches=locked_matches,
+        remaining_track_indices=remaining_track_indices,
+        remaining_detection_indices=remaining_detection_indices,
+    )

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -4,6 +4,8 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from dataclasses import dataclass
+from pathlib import Path
 from typing import cast
 
 import numpy as np
@@ -12,12 +14,19 @@ from deprecate import deprecated  # type: ignore[import-untyped]
 from scipy.optimize import linear_sum_assignment
 
 from trackers.core.base import BaseTracker
-from trackers.core.mcbyte.mask_manager import MaskManager
-from trackers.core.mcbyte.masks.base import MaskOutput, TrackletSnapshot
-from trackers.core.mcbyte.masks.dummy import (
-    DummyBoxMaskGenerator,
-    DummyIdentityMaskPropagator,
+from trackers.core.mcbyte.mask_association import (
+    MINIMUM_MASK_AVERAGE_CONFIDENCE,
+    MINIMUM_MASK_COVERAGE,
+    MINIMUM_MASK_FILL_RATIO,
+    condition_similarity_with_masks,
 )
+from trackers.core.mcbyte.mask_manager import (
+    MASK_CREATION_BBOX_OVERLAP_THRESHOLD,
+    MaskManager,
+)
+from trackers.core.mcbyte.masks.base import MaskOutput, TrackletSnapshot
+from trackers.core.mcbyte.masks.cutie import CutieMaskPropagator
+from trackers.core.mcbyte.masks.sam import SAMBoxMaskGenerator
 from trackers.core.mcbyte.tracklet import McByteTracklet
 from trackers.core.mcbyte.utils import _fuse_score, get_alive_tracklets
 from trackers.utils.cmc import CMC, CMCConfig, CMCMethod
@@ -29,44 +38,155 @@ from trackers.utils.state_representations import (
 )
 
 
-class McByteTracker(BaseTracker):
-    """McByte-style multi-object tracker.
+@dataclass(frozen=True)
+class McByteMaskConfig:
+    """Configuration for McByte's SAM and Cutie mask pipeline.
 
-    This tracker builds on ByteTrack-style two-stage IoU association with
-    Kalman-filter-based tracklets, optional camera motion compensation, and optional
-    McByte mask-manager support.
-
-    When a mask manager is configured, the tracker follows the original McByte
-    timing: masks for frame ``t`` are prepared before association on frame ``t``,
-    using tracker outputs from frame ``t-1``. Tracklets that are temporarily lost
-    but still alive keep their masks; masks are removed only when tracklets are
-    terminated by tracker pruning.
+    The configuration is used only when ``McByteTracker`` automatically creates
+    its default real ``MaskManager``. It is ignored when a custom manager is
+    supplied directly.
 
     Args:
-        lost_track_buffer: Time buffer, in frames at 30 FPS, for keeping lost
-            tracks alive before deletion. This value is scaled by ``frame_rate``.
-        frame_rate: Video frame rate used to scale ``lost_track_buffer``.
-        track_activation_threshold: Minimum confidence required to spawn a new
-            track.
-        minimum_consecutive_frames: Number of successful updates required before
-            assigning a stable track ID.
-        minimum_iou_threshold_first_assoc: Minimum similarity threshold for the
-            first association stage.
-        minimum_iou_threshold_second_assoc: Minimum similarity threshold for the
-            second association stage.
-        minimum_iou_threshold_unconfirmed_assoc: Minimum similarity threshold for
-            matching unconfirmed tracks.
-        high_conf_det_threshold: Confidence threshold used to split detections
-            into high- and low-confidence groups.
-        enable_cmc: Whether to enable camera motion compensation.
+        device: Device shared by SAM and Cutie, for example ``"cuda"``,
+            ``"cuda:0"``, or ``"cpu"``.
+        sam_checkpoint_path: Optional SAM checkpoint path. When omitted, the
+            default checkpoint for ``sam_model_type`` is used and downloaded
+            automatically when necessary.
+        sam_model_type: SAM model variant used for box-prompted mask generation.
+        cutie_weights_path: Optional Cutie checkpoint path. When omitted, the
+            default checkpoint for ``cutie_model_type`` is used and downloaded
+            automatically when necessary.
+        cutie_model_type: Cutie model variant used for temporal propagation.
+        cutie_config_path: Optional Cutie Hydra configuration directory. When
+            omitted, it is inferred from the installed Cutie package.
+        cutie_config_name: Hydra configuration name loaded by Cutie.
+        cutie_use_amp: Whether Cutie may use automatic mixed precision. AMP is
+            activated only when Cutie runs on a CUDA device.
+        mask_creation_bbox_overlap_threshold: Bounding-box overlap fraction at
+            or above which mask creation is delayed by ``MaskManager``.
+    """
+
+    device: str = "cuda"
+
+    sam_checkpoint_path: str | Path | None = None
+    sam_model_type: str = "vit_b"
+
+    cutie_weights_path: str | Path | None = None
+    cutie_model_type: str = "base-mega"
+    cutie_config_path: str | Path | None = None
+    cutie_config_name: str = "eval_config"
+    cutie_use_amp: bool = True
+
+    mask_creation_bbox_overlap_threshold: float = MASK_CREATION_BBOX_OVERLAP_THRESHOLD
+
+
+def _build_default_mask_manager(
+    config: McByteMaskConfig,
+) -> MaskManager:
+    """Create McByte's standard SAM + Cutie mask-management pipeline."""
+    mask_generator = SAMBoxMaskGenerator(
+        checkpoint_path=config.sam_checkpoint_path,
+        model_type=config.sam_model_type,
+        device=config.device,
+    )
+
+    mask_propagator = CutieMaskPropagator(
+        weights_path=config.cutie_weights_path,
+        model_type=config.cutie_model_type,
+        config_path=config.cutie_config_path,
+        config_name=config.cutie_config_name,
+        device=config.device,
+        use_amp=config.cutie_use_amp,
+    )
+
+    return MaskManager(
+        mask_generator=mask_generator,
+        mask_propagator=mask_propagator,
+        mask_creation_bbox_overlap_threshold=(config.mask_creation_bbox_overlap_threshold),
+    )
+
+
+class McByteTracker(BaseTracker):
+    """McByte multi-object tracker with optional mask-conditioned association.
+
+    McByte extends a ByteTrack-style multi-stage tracking pipeline with
+    clear-match locking, reduced assignment, optional camera motion
+    compensation, and optional propagated-mask evidence.
+
+    The tracker can operate in two configurations:
+
+    - without a ``MaskManager``, association uses the McByte clear-match locking
+      and reduced-assignment procedure with IoU-based similarities;
+    - with a ``MaskManager`` (full McByte), masks are additionally used to condition
+      ambiguous associations and, when enabled, isolated positive-IoU associations
+      below the normal stage threshold.
+
+    When ``enable_mask_manager=True``, the default mask pipeline initializes
+    masks from detection boxes using SAM and propagates them temporally using
+    Cutie. A custom ``MaskManager`` may instead be supplied directly, for
+    example to inject alternative mask components or lightweight test doubles.
+
+    Mask processing follows the original McByte timing. At frame ``t``, masks
+    are updated before association using the frame, visible tracklets, newly
+    created tracklets, and removed-tracklet events stored after processing frame
+    ``t - 1``. Temporarily lost but still active tracklets retain their masks.
+    Masks are removed only after the corresponding tracklets are terminated
+    during tracker pruning.
+
+    Input frames are expected in RGB channel order. A frame is required when
+    mask management is enabled and is also needed for camera motion
+    compensation. When no frame is supplied, those frame-dependent operations
+    are skipped.
+
+    Args:
+        lost_track_buffer: Time buffer, expressed as a number of frames at
+            30 FPS, for retaining unmatched tracks before deletion. The value
+            is scaled according to ``frame_rate``.
+        frame_rate: Sequence frame rate used to scale ``lost_track_buffer``.
+        track_activation_threshold: Minimum detection confidence required to
+            create a new tracklet.
+        minimum_consecutive_frames: Number of successful tracklet updates
+            required before assigning a confirmed non-negative tracker ID.
+        minimum_iou_threshold_first_assoc: Minimum association similarity for
+            matching high-confidence detections to confirmed and lost tracks.
+        minimum_iou_threshold_second_assoc: Minimum association similarity for
+            matching low-confidence detections to remaining tracked tracks.
+        minimum_iou_threshold_unconfirmed_assoc: Minimum association similarity
+            for matching unconfirmed tracks to remaining high-confidence
+            detections.
+        high_conf_det_threshold: Confidence threshold separating high- and
+            low-confidence detections. Detections with confidence at or below
+            0.1 are discarded.
+        enable_cmc: Whether to apply camera motion compensation before
+            association.
         cmc_method: Camera motion compensation method.
-        cmc_downscale: Downscale factor used by camera motion compensation.
-        instant_first_frame_activation: Whether tracks spawned on the first frame
-            receive confirmed IDs immediately.
-        state_estimator_class: State estimator class used by McByte tracklets.
-        iou: IoU implementation used for association.
-        enable_mask_manager: Whether to create the default dummy mask manager.
-        mask_manager: Optional custom mask manager instance.
+        cmc_downscale: Image downscale factor used during camera motion
+            estimation.
+        instant_first_frame_activation: Whether tracklets created on the first
+            frame receive confirmed tracker IDs immediately.
+        state_estimator_class: State estimator class used by newly created
+            ``McByteTracklet`` instances.
+        iou: IoU implementation used to compute association similarities. When
+            omitted, the default ``IoU`` implementation is used.
+        enable_mask_manager: Whether to construct McByte's default SAM and
+            Cutie mask pipeline. It is disabled by default to avoid loading
+            optional heavyweight models when mask-conditioned tracking is not
+            requested.
+        mask_manager: Optional custom ``MaskManager``. When supplied, it is used
+            directly regardless of ``enable_mask_manager``, and automatic
+            SAM/Cutie construction is skipped.
+        mask_config: Configuration for automatic construction of the default
+            SAM/Cutie pipeline. It requires ``enable_mask_manager=True`` and
+            cannot be combined with a custom ``mask_manager``.
+        minimum_mask_average_confidence: Minimum average confidence of a
+            propagated mask before it may influence association.
+        minimum_mask_coverage: Minimum fraction of the visible tracklet mask
+            that must lie inside a candidate detection box.
+        minimum_mask_fill_ratio: Minimum fraction of a candidate detection-box
+            area that must be occupied by the tracklet mask.
+        enable_isolated_mask_matching: Whether mask evidence may rescue an
+            isolated candidate with positive IoU whose association similarity
+            is below the normal stage threshold.
     """
 
     tracker_id = "mcbyte"
@@ -77,7 +197,7 @@ class McByteTracker(BaseTracker):
         frame_rate: float = 30.0,
         track_activation_threshold: float = 0.7,
         minimum_consecutive_frames: int = 2,
-        minimum_iou_threshold_first_assoc: float = 0.2,
+        minimum_iou_threshold_first_assoc: float = 0.1,
         minimum_iou_threshold_second_assoc: float = 0.5,
         minimum_iou_threshold_unconfirmed_assoc: float = 0.3,
         high_conf_det_threshold: float = 0.6,
@@ -89,6 +209,11 @@ class McByteTracker(BaseTracker):
         iou: BaseIoU | None = None,
         enable_mask_manager: bool = False,
         mask_manager: MaskManager | None = None,
+        mask_config: McByteMaskConfig | None = None,
+        minimum_mask_average_confidence: float = MINIMUM_MASK_AVERAGE_CONFIDENCE,
+        minimum_mask_coverage: float = MINIMUM_MASK_COVERAGE,
+        minimum_mask_fill_ratio: float = MINIMUM_MASK_FILL_RATIO,
+        enable_isolated_mask_matching: bool = False,
     ) -> None:
         # Calculate maximum frames without update based on lost_track_buffer and
         # frame_rate. This scales the buffer based on the frame rate to ensure
@@ -101,6 +226,10 @@ class McByteTracker(BaseTracker):
         self.track_activation_threshold = track_activation_threshold
         self.high_conf_det_threshold = high_conf_det_threshold
         self.instant_first_frame_activation = instant_first_frame_activation
+        self.minimum_mask_average_confidence = minimum_mask_average_confidence
+        self.minimum_mask_coverage = minimum_mask_coverage
+        self.minimum_mask_fill_ratio = minimum_mask_fill_ratio
+        self.enable_isolated_mask_matching = enable_isolated_mask_matching
         self.tracks: list[McByteTracklet] = []
         self.state_estimator_class = state_estimator_class
         self.iou = iou if iou is not None else IoU()
@@ -109,12 +238,20 @@ class McByteTracker(BaseTracker):
         self.enable_cmc = enable_cmc
         self.cmc = CMC(CMCConfig(method=cmc_method, downscale=cmc_downscale)) if enable_cmc else None
 
-        self.mask_manager = mask_manager
-        if self.mask_manager is None and enable_mask_manager:
-            self.mask_manager = MaskManager(
-                mask_generator=DummyBoxMaskGenerator(),
-                mask_propagator=DummyIdentityMaskPropagator(),
+        self.mask_manager: MaskManager | None
+
+        if mask_manager is not None and mask_config is not None:
+            raise ValueError("mask_config cannot be used together with a custom mask_manager.")
+        if mask_config is not None and not enable_mask_manager:
+            raise ValueError("mask_config requires enable_mask_manager=True when no custom mask_manager is supplied.")
+        if mask_manager is not None:
+            self.mask_manager = mask_manager
+        elif enable_mask_manager:
+            self.mask_manager = _build_default_mask_manager(
+                mask_config if mask_config is not None else McByteMaskConfig()
             )
+        else:
+            self.mask_manager = None
 
         self._previous_frame: np.ndarray | None = None
         self._previous_tracklets: list[TrackletSnapshot] = []
@@ -223,10 +360,21 @@ class McByteTracker(BaseTracker):
         # Lost tracks are included here (following the original ByteTrack), and
         # IoU is fused with detection scores.
         strack_pool = confirmed_tracks + lost_tracks
-        iou_matrix = self._get_iou_matrix(strack_pool, high_boxes)
-        iou_matrix = _fuse_score(self.iou.normalize_for_fusion(iou_matrix), high_scores)
-        matched, unmatched_pool, unmatched_high = self._get_associated_indices(
-            iou_matrix, self.minimum_iou_threshold_first_assoc
+        raw_iou_similarity = self._get_iou_matrix(
+            strack_pool,
+            high_boxes,
+        )
+        association_similarity = _fuse_score(
+            self.iou.normalize_for_fusion(raw_iou_similarity.copy()),
+            high_scores,
+        )
+
+        matched, unmatched_pool, unmatched_high = self._get_mask_conditioned_associated_indices(
+            similarity_matrix=association_similarity,
+            raw_iou_similarity=raw_iou_similarity,
+            tracklets=strack_pool,
+            detection_boxes=high_boxes,
+            min_similarity_thresh=self.minimum_iou_threshold_first_assoc,
         )
 
         for row, col in matched:
@@ -241,8 +389,20 @@ class McByteTracker(BaseTracker):
         # only (excluding lost tracks, following the original ByteTrack).
         # No score fusing in second association.
         remaining_tracked = [strack_pool[i] for i in unmatched_pool if strack_pool[i].time_since_update == 1]
-        iou_matrix = self._get_iou_matrix(remaining_tracked, low_boxes)
-        matched, _, unmatched_low = self._get_associated_indices(iou_matrix, self.minimum_iou_threshold_second_assoc)
+        raw_iou_similarity = self._get_iou_matrix(
+            remaining_tracked,
+            low_boxes,
+        )
+
+        # There is no score fusion in stage 2, so the assignment matrix
+        # and raw-IoU matrix are the same.
+        matched, _, unmatched_low = self._get_mask_conditioned_associated_indices(
+            similarity_matrix=raw_iou_similarity,
+            raw_iou_similarity=raw_iou_similarity,
+            tracklets=remaining_tracked,
+            detection_boxes=low_boxes,
+            min_similarity_thresh=self.minimum_iou_threshold_second_assoc,
+        )
 
         for row, col in matched:
             track = remaining_tracked[row]
@@ -267,10 +427,21 @@ class McByteTracker(BaseTracker):
             uh_boxes = high_boxes[unmatched_high_list]
             uh_scores = high_scores[unmatched_high_list]
 
-            iou_matrix = self._get_iou_matrix(unconfirmed_tracks, uh_boxes)
-            iou_matrix = _fuse_score(self.iou.normalize_for_fusion(iou_matrix), uh_scores)
-            matched_uc, unmatched_uc_indices, remaining_uh = self._get_associated_indices(
-                iou_matrix, self.minimum_iou_threshold_unconfirmed_assoc
+            raw_iou_similarity = self._get_iou_matrix(
+                unconfirmed_tracks,
+                uh_boxes,
+            )
+            association_similarity = _fuse_score(
+                self.iou.normalize_for_fusion(raw_iou_similarity.copy()),
+                uh_scores,
+            )
+
+            matched_uc, unmatched_uc_indices, remaining_uh = self._get_mask_conditioned_associated_indices(
+                similarity_matrix=association_similarity,
+                raw_iou_similarity=raw_iou_similarity,
+                tracklets=unconfirmed_tracks,
+                detection_boxes=uh_boxes,
+                min_similarity_thresh=self.minimum_iou_threshold_unconfirmed_assoc,
             )
 
             for row, col in matched_uc:
@@ -416,6 +587,96 @@ class McByteTracker(BaseTracker):
         else:
             tracklet_boxes = np.array([tracklet.get_state_bbox() for tracklet in tracklets])
         return self.iou.compute(tracklet_boxes, detections)
+
+    def _get_mask_conditioned_associated_indices(
+        self,
+        similarity_matrix: np.ndarray,
+        raw_iou_similarity: np.ndarray,
+        tracklets: list[McByteTracklet],
+        detection_boxes: np.ndarray,
+        min_similarity_thresh: float,
+    ) -> tuple[list[tuple[int, int]], list[int], list[int]]:
+        """Associate tracklets and detections using McByte mask conditioning.
+
+        Clear threshold-valid pairs are locked before assignment when they are the
+        only eligible candidate in both their row and column. The remaining
+        association problem is conditioned with propagated-mask evidence for
+        ambiguous pairs and, optionally, isolated positive-IoU pairs below the
+        normal threshold.
+
+        Hungarian assignment is applied only to the remaining reduced matrix.
+        Reduced row and column indices are then mapped back to the original
+        ``tracklets`` and ``detection_boxes`` index spaces and combined with the
+        locked matches.
+
+        When no propagated mask output is available, mask-based score updates are
+        skipped. Clear-match locking and assignment of the remaining problem still
+        follow the McByte association pipeline.
+
+        Args:
+            similarity_matrix: Stage-specific association similarity matrix with
+                shape ``(num_tracklets, num_detections)``. This is score-fused IoU
+                for the first and unconfirmed association stages, and raw IoU for
+                the second association stage.
+            raw_iou_similarity: Unfused IoU similarity matrix with the same shape.
+                It is used to determine optional isolated geometric candidates.
+            tracklets: Tracklets corresponding, in order, to the rows of both
+                similarity matrices.
+            detection_boxes: Detection boxes in ``xyxy`` format corresponding, in
+                order, to the columns of both similarity matrices.
+            min_similarity_thresh: Minimum stage-specific similarity required for
+                a valid association.
+
+        Returns:
+            A tuple containing:
+
+            - matched original ``(tracklet_index, detection_index)`` pairs;
+            - sorted original indices of unmatched tracklets;
+            - sorted original indices of unmatched detections.
+        """
+        conditioned_association = condition_similarity_with_masks(
+            similarity=similarity_matrix,
+            raw_iou_similarity=raw_iou_similarity,
+            tracklet_ids=[int(tracklet.tracker_id) for tracklet in tracklets],
+            detection_boxes=detection_boxes,
+            mask_output=self._last_mask_output,
+            minimum_similarity=min_similarity_thresh,
+            minimum_mask_average_confidence=self.minimum_mask_average_confidence,
+            minimum_mask_coverage=self.minimum_mask_coverage,
+            minimum_mask_fill_ratio=self.minimum_mask_fill_ratio,
+            enable_isolated_mask_matching=self.enable_isolated_mask_matching,
+        )
+
+        (
+            reduced_matches,
+            reduced_unmatched_track_indices,
+            reduced_unmatched_detection_indices,
+        ) = self._get_associated_indices(
+            similarity_matrix=conditioned_association.conditioned_similarity,
+            min_similarity_thresh=min_similarity_thresh,
+        )
+
+        remapped_matches = [
+            (
+                conditioned_association.remaining_track_indices[reduced_track_index],
+                conditioned_association.remaining_detection_indices[reduced_detection_index],
+            )
+            for reduced_track_index, reduced_detection_index in reduced_matches
+        ]
+
+        matched = sorted(conditioned_association.locked_matches + remapped_matches)
+
+        unmatched_tracks = sorted(
+            conditioned_association.remaining_track_indices[reduced_track_index]
+            for reduced_track_index in reduced_unmatched_track_indices
+        )
+
+        unmatched_detections = sorted(
+            conditioned_association.remaining_detection_indices[reduced_detection_index]
+            for reduced_detection_index in reduced_unmatched_detection_indices
+        )
+
+        return matched, unmatched_tracks, unmatched_detections
 
     def _get_associated_indices(
         self,

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -25,8 +25,6 @@ from trackers.core.mcbyte.mask_manager import (
     MaskManager,
 )
 from trackers.core.mcbyte.masks.base import MaskOutput, TrackletSnapshot
-from trackers.core.mcbyte.masks.cutie import CutieMaskPropagator
-from trackers.core.mcbyte.masks.sam import SAMBoxMaskGenerator
 from trackers.core.mcbyte.tracklet import McByteTracklet
 from trackers.core.mcbyte.utils import _fuse_score, get_alive_tracklets
 from trackers.utils.cmc import CMC, CMCConfig, CMCMethod
@@ -84,6 +82,10 @@ def _build_default_mask_manager(
     config: McByteMaskConfig,
 ) -> MaskManager:
     """Create McByte's standard SAM + Cutie mask-management pipeline."""
+
+    from trackers.core.mcbyte.masks.cutie import CutieMaskPropagator
+    from trackers.core.mcbyte.masks.sam import SAMBoxMaskGenerator
+
     mask_generator = SAMBoxMaskGenerator(
         checkpoint_path=config.sam_checkpoint_path,
         model_type=config.sam_model_type,
@@ -149,6 +151,10 @@ class McByteTracker(BaseTracker):
             required before assigning a confirmed non-negative tracker ID.
         minimum_iou_threshold_first_assoc: Minimum association similarity for
             matching high-confidence detections to confirmed and lost tracks.
+            The default of ``0.1`` is intentionally lower than in BoT-SORT and
+            other trackers, allowing mask-conditioned association to evaluate
+            a broader set of plausible candidates before resolving ambiguities
+            and optional isolations.
         minimum_iou_threshold_second_assoc: Minimum association similarity for
             matching low-confidence detections to remaining tracked tracks.
         minimum_iou_threshold_unconfirmed_assoc: Minimum association similarity

--- a/src/trackers/scripts/run_mcbyte_benchmarks_example.py
+++ b/src/trackers/scripts/run_mcbyte_benchmarks_example.py
@@ -1,0 +1,640 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Run McByte on complete benchmark test sets and save MOTChallenge-format results.
+
+Supported datasets
+------------------
+
+- MOT17
+- DanceTrack
+- SportsMOT
+- SoccerNet-tracking
+
+Expected directory layout
+-------------------------
+
+NOTE: detection_root and image_root in the DATASETS dictionary below must be set
+in accordance with your files on a disk or server. See the instructions below for
+more details.
+
+This example script assumes the following dataset organization.
+
+Detection files
+^^^^^^^^^^^^^^^
+
+MOT17, DanceTrack and SportsMOT:
+
+One detection file per sequence, stored in separate dataset directories, e.g.
+
+    detections/MOT17/test/MOT17-01.txt
+    detections/dancetrack/test/dancetrack0003.txt
+    detections/sportsmot/test/v_-9kabh1K8UA_c008.txt
+
+SoccerNet-tracking:
+
+One detection file per sequence, following the original SoccerNet naming
+convention, e.g.
+
+    detections/SoccerNet_tracking_2022_test_set_dets/
+        SNMOT-116__det.txt
+
+Frame directories
+^^^^^^^^^^^^^^^^^
+
+For all datasets, the image root contains one directory per sequence, each
+containing an ``img1`` subdirectory with the sequence frames, e.g.
+
+    datasets/dancetrack/test/
+        dancetrack0003/img1/
+        dancetrack0009/img1/
+        ...
+
+Detection file formats
+----------------------
+
+MOT17, DanceTrack and SportsMOT detections are expected in XYXY format:
+
+    frame,x1,y1,x2,y2,confidence
+
+Example:
+
+    215,1433.7001,480.6000,1479.6001,579.1500,0.02
+
+SoccerNet-tracking detections are expected in MOT format
+(as in the original ground truths):
+
+    frame,id,left,top,width,height,confidence,...
+
+Example:
+
+    170,-1,1392,472,37,106,1,-1,-1,-1
+
+The input identity column is ignored because tracker identities are produced by
+McByte.
+
+Each sequence is processed independently using a fresh McByte tracker. If a
+sequence fails, the error is recorded and benchmark execution continues with
+the remaining sequences.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal, TextIO
+
+import cv2
+import numpy as np
+import supervision as sv
+import torch
+
+from trackers.core.mcbyte.tracker import McByteMaskConfig, McByteTracker
+from trackers.utils.cmc import CMCMethod
+
+DetectionFileFormat = Literal["xyxy", "mot"]
+DEFAULT_OUTPUT_ROOT = Path("outputs/mcbyte_benchmarks")
+
+MOT17_EXISTING = ("01", "03", "06", "07", "08", "12", "14")
+MOT17_MISSING = ("02", "04", "05", "09", "10", "11", "13")
+MOT17_SUFFIXES = ("FRCNN", "SDP", "DPM")
+
+SUPPORTED_CMC_METHODS = ("orb", "sift", "sparseOptFlow", "ecc")
+
+
+@dataclass(frozen=True)
+class DetectionRecord:
+    """One detection parsed from an input file."""
+
+    xyxy: np.ndarray
+    confidence: float
+
+
+@dataclass(frozen=True)
+class DatasetConfig:
+    """Dataset-specific paths and parsing behavior.
+
+    Each dataset defines where detections and frames are located,
+    how detections should be parsed,
+    and any dataset-specific conventions.
+    """
+
+    name: str
+    detection_root: Path
+    image_root: Path
+    detection_format: DetectionFileFormat
+    frame_rate: float = 30.0
+    mot17_layout: bool = False
+    soccernet_filename: bool = False
+    confidence_override: float | None = None
+
+
+DATASETS: dict[str, DatasetConfig] = {
+    "mot17": DatasetConfig(
+        name="mot17",
+        detection_root=Path(""),
+        image_root=Path(""),
+        detection_format="xyxy",
+        mot17_layout=True,
+    ),
+    "dancetrack": DatasetConfig(
+        name="dancetrack",
+        detection_root=Path(""),
+        image_root=Path(""),
+        detection_format="xyxy",
+    ),
+    "sportsmot": DatasetConfig(
+        name="sportsmot",
+        detection_root=Path(""),
+        image_root=Path(""),
+        detection_format="xyxy",
+    ),
+    "soccernet": DatasetConfig(
+        name="soccernet",
+        detection_root=Path(""),
+        image_root=Path(""),
+        detection_format="mot",
+        soccernet_filename=True,
+        # Preserves the old SoccerNet runner. Set to None to read column 7.
+        confidence_override=1.0,
+    ),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset",
+        choices=sorted(DATASETS),
+        action="append",
+        default=None,
+        help="Dataset to run; repeat as needed. Omit to run all datasets.",
+    )
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument(
+        "--enable-isolated-mask-matching",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=DEFAULT_OUTPUT_ROOT,
+    )
+    parser.add_argument("--skip-existing", action="store_true")
+    parser.add_argument("--disable-cmc", action="store_true")
+    parser.add_argument(
+        "--cmc-method",
+        type=str,
+        default="sparseOptFlow",
+        choices=SUPPORTED_CMC_METHODS,
+        help="Camera-motion compensation method.",
+    )
+    parser.add_argument("--cmc-downscale", type=int, default=2)
+    parser.add_argument("--keep-partial-results", action="store_true")
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    """Validate global runtime arguments."""
+    if args.cmc_downscale <= 0:
+        raise ValueError("cmc-downscale must be positive.")
+    if args.device.startswith("cuda") and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested, but CUDA PyTorch is unavailable.")
+
+
+def configure_logging(run_root: Path) -> logging.Logger:
+    """Log to both the terminal and the run directory."""
+    logger = logging.getLogger("mcbyte_benchmarks")
+    logger.setLevel(logging.INFO)
+    logger.handlers.clear()
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+
+    console = logging.StreamHandler()
+    console.setFormatter(formatter)
+    logger.addHandler(console)
+
+    file_handler = logging.FileHandler(run_root / "run.log", encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    return logger
+
+
+def sequence_name(detection_file: Path, config: DatasetConfig) -> str:
+    """Resolve a sequence name from a detection filename."""
+    if config.soccernet_filename:
+        return detection_file.name.split("__", maxsplit=1)[0]
+    return detection_file.stem
+
+
+def image_directory(sequence: str, config: DatasetConfig) -> Path:
+    """Resolve the sequence frame directory."""
+    directory_name = f"{sequence}-FRCNN" if config.mot17_layout else sequence
+    return config.image_root / directory_name / "img1"
+
+
+def read_detection_file(
+    detection_file: Path,
+    config: DatasetConfig,
+) -> dict[int, list[DetectionRecord]]:
+    """Read detections grouped by frame.
+
+    XYXY format: frame,x1,y1,x2,y2,confidence
+    MOT format:  frame,id,left,top,width,height,confidence,...
+    """
+    grouped: dict[int, list[DetectionRecord]] = defaultdict(list)
+
+    with detection_file.open("r", encoding="utf-8") as file:
+        for line_number, raw_line in enumerate(file, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            values = line.split(",")
+
+            try:
+                if config.detection_format == "xyxy":
+                    if len(values) < 6:
+                        raise ValueError("expected at least 6 columns")
+                    frame_number = int(float(values[0]))
+                    x1, y1, x2, y2 = map(float, values[1:5])
+                    confidence = float(values[5])
+                else:
+                    if len(values) < 7:
+                        raise ValueError("expected at least 7 columns")
+                    frame_number = int(float(values[0]))
+                    left, top, width, height = map(float, values[2:6])
+                    x1, y1 = left, top
+                    x2, y2 = left + width, top + height
+                    confidence = (
+                        config.confidence_override if config.confidence_override is not None else float(values[6])
+                    )
+            except ValueError as exc:
+                raise ValueError(f"Invalid line {line_number} in {detection_file}: {line}") from exc
+
+            if frame_number <= 0:
+                raise ValueError(f"Non-positive frame number on line {line_number}.")
+            if x2 <= x1 or y2 <= y1:
+                continue
+
+            grouped[frame_number].append(
+                DetectionRecord(
+                    xyxy=np.array([x1, y1, x2, y2], dtype=np.float32),
+                    confidence=float(confidence),
+                )
+            )
+
+    return dict(grouped)
+
+
+def build_detections(records: list[DetectionRecord]) -> sv.Detections:
+    """Create Supervision detections from parsed records."""
+    if not records:
+        return sv.Detections.empty()
+    return sv.Detections(
+        xyxy=np.stack([record.xyxy for record in records]).astype(np.float32),
+        confidence=np.asarray(
+            [record.confidence for record in records],
+            dtype=np.float32,
+        ),
+    )
+
+
+def find_frame_path(image_dir: Path, frame_number: int) -> Path:
+    """Find a frame using common MOT naming schemes."""
+    for pattern in (
+        "{:06d}.jpg",
+        "{:08d}.jpg",
+        "{:06d}.png",
+        "{:08d}.png",
+    ):
+        path = image_dir / pattern.format(frame_number)
+        if path.is_file():
+            return path
+    raise FileNotFoundError(f"Could not find frame {frame_number} in {image_dir}.")
+
+
+def load_rgb_frame(frame_path: Path) -> np.ndarray:
+    """Load one frame and convert OpenCV BGR channels to RGB."""
+    frame_bgr = cv2.imread(str(frame_path))
+    if frame_bgr is None:
+        raise RuntimeError(f"cv2.imread failed for {frame_path}.")
+    return cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+
+
+def create_tracker(
+    *,
+    device: str,
+    frame_rate: float,
+    enable_isolated_mask_matching: bool,
+    enable_cmc: bool,
+    cmc_method: CMCMethod,
+    cmc_downscale: int,
+) -> McByteTracker:
+    """Create a fresh full McByte tracker for one sequence."""
+    return McByteTracker(
+        frame_rate=frame_rate,
+        enable_cmc=enable_cmc,
+        cmc_method=cmc_method,
+        cmc_downscale=cmc_downscale,
+        enable_mask_manager=True,
+        mask_config=McByteMaskConfig(device=device),
+        enable_isolated_mask_matching=enable_isolated_mask_matching,
+    )
+
+
+def write_mot_results(
+    output: TextIO,
+    frame_number: int,
+    tracked: sv.Detections,
+) -> None:
+    """Write valid tracked detections in MOTChallenge format."""
+    if tracked.tracker_id is None:
+        return
+
+    for xyxy, tracker_id_value in zip(tracked.xyxy, tracked.tracker_id):
+        tracker_id = int(tracker_id_value)
+        if tracker_id < 0:
+            continue
+        left, top, right, bottom = map(float, xyxy)
+        output.write(
+            f"{frame_number},{tracker_id},{left:.2f},{top:.2f},{right - left:.2f},{bottom - top:.2f},-1,-1,-1,-1\n"
+        )
+
+
+def cleanup_tracker(
+    tracker: McByteTracker | None,
+    logger: logging.Logger,
+    sequence: str,
+) -> None:
+    """Reset state, collect Python objects, and release cached CUDA memory."""
+    if tracker is not None:
+        try:
+            tracker.reset()
+        except Exception:
+            logger.exception("Tracker reset failed after %s.", sequence)
+    del tracker
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def run_sequence(
+    *,
+    sequence: str,
+    detection_file: Path,
+    image_dir: Path,
+    output_file: Path,
+    config: DatasetConfig,
+    device: str,
+    enable_isolated_mask_matching: bool,
+    enable_cmc: bool,
+    cmc_method: CMCMethod,
+    cmc_downscale: int,
+    keep_partial_results: bool,
+    logger: logging.Logger,
+) -> int:
+    """Run one benchmark sequence.
+
+    A fresh tracker is created for the sequence.
+    Results are first written to a temporary `.partial` file,
+    which is replaced by the final MOT result only after successful completion.
+    """
+    detections_by_frame = read_detection_file(detection_file, config)
+    if not detections_by_frame:
+        raise ValueError(f"No detections found in {detection_file}.")
+
+    last_frame = max(detections_by_frame)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    partial_file = output_file.with_suffix(".txt.partial")
+    partial_file.unlink(missing_ok=True)
+    tracker: McByteTracker | None = None
+
+    try:
+        tracker = create_tracker(
+            device=device,
+            frame_rate=config.frame_rate,
+            enable_isolated_mask_matching=enable_isolated_mask_matching,
+            enable_cmc=enable_cmc,
+            cmc_method=cmc_method,
+            cmc_downscale=cmc_downscale,
+        )
+
+        with partial_file.open("w", encoding="utf-8") as output:
+            for frame_number in range(1, last_frame + 1):
+                frame_rgb = load_rgb_frame(find_frame_path(image_dir, frame_number))
+                detections = build_detections(detections_by_frame.get(frame_number, []))
+                tracked = tracker.update(detections=detections, frame=frame_rgb)
+                write_mot_results(output, frame_number, tracked)
+
+                if frame_number == 1 or frame_number % 250 == 0:
+                    logger.info(
+                        "%s | frame %d/%d",
+                        sequence,
+                        frame_number,
+                        last_frame,
+                    )
+
+        partial_file.replace(output_file)
+        return last_frame
+    except Exception:
+        if not keep_partial_results:
+            partial_file.unlink(missing_ok=True)
+        raise
+    finally:
+        cleanup_tracker(tracker, logger, sequence)
+
+
+def record_failure(
+    failure_file: TextIO,
+    dataset: str,
+    sequence: str,
+    reason: str,
+) -> None:
+    """Record one failure and flush it immediately."""
+    failure_file.write(f"{dataset}\t{sequence}\t{reason}\n")
+    failure_file.flush()
+
+
+def run_dataset(
+    *,
+    config: DatasetConfig,
+    output_dir: Path,
+    device: str,
+    enable_isolated_mask_matching: bool,
+    enable_cmc: bool,
+    cmc_method: CMCMethod,
+    cmc_downscale: int,
+    skip_existing: bool,
+    keep_partial_results: bool,
+    failure_file: TextIO,
+    logger: logging.Logger,
+) -> tuple[int, int, int]:
+    """Run every sequence in one dataset.
+
+    Each detection file is matched with its corresponding image directory,
+    processed using a fresh McByte tracker, and written as one MOTChallenge
+    result file. Missing or failed sequences are recorded while processing
+    continues with the remaining sequences.
+    """
+    if not config.detection_root.is_dir():
+        raise NotADirectoryError(config.detection_root)
+    if not config.image_root.is_dir():
+        raise NotADirectoryError(config.image_root)
+
+    detection_files = sorted(config.detection_root.glob("*.txt"))
+    if not detection_files:
+        raise FileNotFoundError(f"No detections in {config.detection_root}.")
+
+    completed = skipped = failed = 0
+    for index, detection_file in enumerate(detection_files, start=1):
+        seq = sequence_name(detection_file, config)
+        final_output = output_dir / f"{seq}.txt"
+        frames = image_directory(seq, config)
+
+        if skip_existing and final_output.is_file():
+            logger.info("[%s %d/%d] Skip %s", config.name, index, len(detection_files), seq)
+            skipped += 1
+            continue
+
+        logger.info("[%s %d/%d] Process %s", config.name, index, len(detection_files), seq)
+        try:
+            last_frame = run_sequence(
+                sequence=seq,
+                detection_file=detection_file,
+                image_dir=frames,
+                output_file=final_output,
+                config=config,
+                device=device,
+                enable_isolated_mask_matching=enable_isolated_mask_matching,
+                enable_cmc=enable_cmc,
+                cmc_method=cmc_method,
+                cmc_downscale=cmc_downscale,
+                keep_partial_results=keep_partial_results,
+                logger=logger,
+            )
+        except torch.cuda.OutOfMemoryError as exc:
+            failed += 1
+            logger.exception("CUDA OOM: %s/%s", config.name, seq)
+            record_failure(failure_file, config.name, seq, f"CUDA OOM: {exc}")
+        except Exception as exc:
+            failed += 1
+            logger.exception("Failed: %s/%s", config.name, seq)
+            record_failure(
+                failure_file,
+                config.name,
+                seq,
+                f"{type(exc).__name__}: {exc}",
+            )
+        else:
+            completed += 1
+            logger.info("Completed %s/%s (%d frames)", config.name, seq, last_frame)
+
+    return completed, skipped, failed
+
+
+def prepare_mot17_submission(
+    raw_dir: Path,
+    submission_dir: Path,
+    logger: logging.Logger,
+) -> None:
+    """Create MOT17 submission files.
+
+    The MOT17 evaluation server expects one result file per detector
+    (FRCNN, SDP and DPM). Since McByte is detector-agnostic here,
+    the same tracking result is duplicated for all three detector names.
+    """
+    submission_dir.mkdir(parents=True, exist_ok=True)
+
+    for number in MOT17_EXISTING:
+        source = raw_dir / f"MOT17-{number}.txt"
+        if not source.is_file():
+            logger.warning("Missing MOT17 source result: %s", source)
+            continue
+        content = source.read_bytes()
+        for suffix in MOT17_SUFFIXES:
+            (submission_dir / f"MOT17-{number}-{suffix}.txt").write_bytes(content)
+
+    for number in MOT17_MISSING:
+        for suffix in MOT17_SUFFIXES:
+            (submission_dir / f"MOT17-{number}-{suffix}.txt").touch(exist_ok=True)
+
+
+def main() -> None:
+    """Run all selected datasets and summarize sequence failures."""
+    args = parse_args()
+    validate_args(args)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    isolation = "isolation" if args.enable_isolated_mask_matching else "no_isolation"
+    run_root = args.output_root / f"{timestamp}__{isolation}"
+    run_root.mkdir(parents=True, exist_ok=False)
+    logger = configure_logging(run_root)
+
+    selected = args.dataset if args.dataset is not None else list(DATASETS)
+    logger.info("Run root: %s", run_root)
+    logger.info("Datasets: %s", selected)
+    logger.info("Device: %s", args.device)
+    logger.info("Isolation: %s", args.enable_isolated_mask_matching)
+
+    total_completed = total_skipped = total_failed = 0
+    failure_path = run_root / "failed_sequences.txt"
+
+    with failure_path.open("w", encoding="utf-8") as failure_file:
+        for name in selected:
+            config = DATASETS[name]
+            raw_dir = run_root / name / "raw"
+            try:
+                completed, skipped, failed = run_dataset(
+                    config=config,
+                    output_dir=raw_dir,
+                    device=args.device,
+                    enable_isolated_mask_matching=args.enable_isolated_mask_matching,
+                    enable_cmc=not args.disable_cmc,
+                    cmc_method=args.cmc_method,
+                    cmc_downscale=args.cmc_downscale,
+                    skip_existing=args.skip_existing,
+                    keep_partial_results=args.keep_partial_results,
+                    failure_file=failure_file,
+                    logger=logger,
+                )
+            except Exception as exc:
+                logger.exception("Dataset setup failed: %s", name)
+                record_failure(
+                    failure_file,
+                    name,
+                    "<dataset setup>",
+                    f"{type(exc).__name__}: {exc}",
+                )
+                total_failed += 1
+                continue
+
+            total_completed += completed
+            total_skipped += skipped
+            total_failed += failed
+
+            if name == "mot17":
+                prepare_mot17_submission(
+                    raw_dir,
+                    run_root / "mot17" / "submission",
+                    logger,
+                )
+
+    logger.info(
+        "Finished: completed=%d skipped=%d failed=%d",
+        total_completed,
+        total_skipped,
+        total_failed,
+    )
+    logger.info("Failure report: %s", failure_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trackers/scripts/run_mcbyte_benchmarks_example.py
+++ b/src/trackers/scripts/run_mcbyte_benchmarks_example.py
@@ -452,17 +452,6 @@ def run_sequence(
         cleanup_tracker(tracker, logger, sequence)
 
 
-def record_failure(
-    failure_file: TextIO,
-    dataset: str,
-    sequence: str,
-    reason: str,
-) -> None:
-    """Record one failure and flush it immediately."""
-    failure_file.write(f"{dataset}\t{sequence}\t{reason}\n")
-    failure_file.flush()
-
-
 def run_dataset(
     *,
     config: DatasetConfig,
@@ -474,7 +463,6 @@ def run_dataset(
     cmc_downscale: int,
     skip_existing: bool,
     keep_partial_results: bool,
-    failure_file: TextIO,
     logger: logging.Logger,
 ) -> tuple[int, int, int]:
     """Run every sequence in one dataset.
@@ -520,19 +508,12 @@ def run_dataset(
                 keep_partial_results=keep_partial_results,
                 logger=logger,
             )
-        except torch.cuda.OutOfMemoryError as exc:
+        except torch.cuda.OutOfMemoryError:
             failed += 1
-            logger.exception("CUDA OOM: %s/%s", config.name, seq)
-            record_failure(failure_file, config.name, seq, f"CUDA OOM: {exc}")
-        except Exception as exc:
+            logger.exception("CUDA OOM while processing %s/%s", config.name, seq)
+        except Exception:
             failed += 1
-            logger.exception("Failed: %s/%s", config.name, seq)
-            record_failure(
-                failure_file,
-                config.name,
-                seq,
-                f"{type(exc).__name__}: {exc}",
-            )
+            logger.exception("Failed while processing %s/%s", config.name, seq)
         else:
             completed += 1
             logger.info("Completed %s/%s (%d frames)", config.name, seq, last_frame)
@@ -585,47 +566,38 @@ def main() -> None:
     logger.info("Isolation: %s", args.enable_isolated_mask_matching)
 
     total_completed = total_skipped = total_failed = 0
-    failure_path = run_root / "failed_sequences.txt"
 
-    with failure_path.open("w", encoding="utf-8") as failure_file:
-        for name in selected:
-            config = DATASETS[name]
-            raw_dir = run_root / name / "raw"
-            try:
-                completed, skipped, failed = run_dataset(
-                    config=config,
-                    output_dir=raw_dir,
-                    device=args.device,
-                    enable_isolated_mask_matching=args.enable_isolated_mask_matching,
-                    enable_cmc=not args.disable_cmc,
-                    cmc_method=args.cmc_method,
-                    cmc_downscale=args.cmc_downscale,
-                    skip_existing=args.skip_existing,
-                    keep_partial_results=args.keep_partial_results,
-                    failure_file=failure_file,
-                    logger=logger,
-                )
-            except Exception as exc:
-                logger.exception("Dataset setup failed: %s", name)
-                record_failure(
-                    failure_file,
-                    name,
-                    "<dataset setup>",
-                    f"{type(exc).__name__}: {exc}",
-                )
-                total_failed += 1
-                continue
+    for name in selected:
+        config = DATASETS[name]
+        raw_dir = run_root / name / "raw"
+        try:
+            completed, skipped, failed = run_dataset(
+                config=config,
+                output_dir=raw_dir,
+                device=args.device,
+                enable_isolated_mask_matching=args.enable_isolated_mask_matching,
+                enable_cmc=not args.disable_cmc,
+                cmc_method=args.cmc_method,
+                cmc_downscale=args.cmc_downscale,
+                skip_existing=args.skip_existing,
+                keep_partial_results=args.keep_partial_results,
+                logger=logger,
+            )
+        except Exception:
+            logger.exception("Dataset setup failed: %s", name)
+            total_failed += 1
+            continue
 
-            total_completed += completed
-            total_skipped += skipped
-            total_failed += failed
+        total_completed += completed
+        total_skipped += skipped
+        total_failed += failed
 
-            if name == "mot17":
-                prepare_mot17_submission(
-                    raw_dir,
-                    run_root / "mot17" / "submission",
-                    logger,
-                )
+        if name == "mot17":
+            prepare_mot17_submission(
+                raw_dir,
+                run_root / "mot17" / "submission",
+                logger,
+            )
 
     logger.info(
         "Finished: completed=%d skipped=%d failed=%d",
@@ -633,7 +605,6 @@ def main() -> None:
         total_skipped,
         total_failed,
     )
-    logger.info("Failure report: %s", failure_path)
 
 
 if __name__ == "__main__":

--- a/tests/core/test_mcbyte_mask_association.py
+++ b/tests/core/test_mcbyte_mask_association.py
@@ -1,0 +1,701 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import numpy as np
+
+from trackers.core.mcbyte.mask_association import (
+    _get_mask_metrics,
+    condition_similarity_with_masks,
+)
+from trackers.core.mcbyte.masks.base import MaskOutput
+
+
+def _mask_output(
+    masks: np.ndarray,
+    tracklet_mask_dict: dict[int, int],
+    confidences: dict[int, float],
+) -> MaskOutput:
+    return MaskOutput(
+        masks=masks,
+        tracklet_mask_dict=tracklet_mask_dict,
+        mask_avg_prob_dict=confidences,
+    )
+
+
+def _full_mask(
+    height: int = 10,
+    width: int = 10,
+) -> np.ndarray:
+    return np.ones((height, width), dtype=bool)
+
+
+def test_mask_metrics_compute_coverage_and_fill_ratio() -> None:
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[2:6, 2:6] = True
+
+    metrics = _get_mask_metrics(
+        mask=mask,
+        detection_xyxy=np.array([2, 2, 6, 6], dtype=np.float32),
+    )
+
+    assert metrics is not None
+    mask_coverage, mask_fill_ratio = metrics
+    assert np.isclose(mask_coverage, 1.0)
+    assert np.isclose(mask_fill_ratio, 1.0)
+
+
+def test_clear_match_is_locked_and_removed_from_remaining_problem() -> None:
+    similarity = np.array(
+        [
+            [0.8, 0.1],
+            [0.1, 0.7],
+        ],
+        dtype=np.float32,
+    )
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10, 20],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=None,
+        minimum_similarity=0.5,
+    )
+
+    assert result.locked_matches == [(0, 0), (1, 1)]
+    assert result.remaining_track_indices == []
+    assert result.remaining_detection_indices == []
+    assert result.conditioned_similarity.shape == (0, 0)
+
+
+def test_ambiguous_row_receives_mask_fill_bonus() -> None:
+    similarity = np.array(
+        [
+            [0.7, 0.6],
+        ],
+        dtype=np.float32,
+    )
+    masks = np.zeros((1, 10, 10), dtype=bool)
+    masks[0, 0:5, 0:5] = True
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=masks,
+            tracklet_mask_dict={10: 0},
+            confidences={10: 0.9},
+        ),
+        minimum_similarity=0.5,
+    )
+
+    np.testing.assert_allclose(
+        result.conditioned_similarity,
+        np.array([[1.7, 0.6]], dtype=np.float32),
+    )
+
+
+def test_ambiguous_column_pair_receives_mask_fill_bonus() -> None:
+    similarity = np.array(
+        [
+            [0.7],
+            [0.6],
+        ],
+        dtype=np.float32,
+    )
+
+    masks = np.zeros((2, 10, 10), dtype=bool)
+    masks[0, 0:5, 0:5] = True
+    masks[1, 5:10, 5:10] = True
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10, 20],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=masks,
+            tracklet_mask_dict={
+                10: 0,
+                20: 1,
+            },
+            confidences={
+                10: 0.9,
+                20: 0.9,
+            },
+        ),
+        minimum_similarity=0.5,
+    )
+
+    np.testing.assert_allclose(
+        result.conditioned_similarity,
+        np.array(
+            [
+                [1.7],
+                [0.6],
+            ],
+            dtype=np.float32,
+        ),
+    )
+
+
+def test_ambiguity_is_computed_from_original_similarity_matrix() -> None:
+    # Row 0 is ambiguous, column 1 is ambiguous, (1, 1) is also considered ambiguous
+    # because its column has two eligible tracklets.
+    similarity = np.array(
+        [
+            [0.7, 0.6],
+            [0.1, 0.8],
+        ],
+        dtype=np.float32,
+    )
+
+    masks = np.zeros((2, 10, 10), dtype=bool)
+    masks[0, 0:5, 0:5] = True
+    masks[1, 5:10, 5:10] = True
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10, 20],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=masks,
+            tracklet_mask_dict={
+                10: 0,
+                20: 1,
+            },
+            confidences={
+                10: 0.9,
+                20: 0.9,
+            },
+        ),
+        minimum_similarity=0.5,
+    )
+
+    assert result.locked_matches == []
+
+    # Ensure that both mask bonuses are decided from the untouched original matrix,
+    # rather than progressively recalculating ambiguity after one score is modified
+    np.testing.assert_allclose(
+        result.conditioned_similarity,
+        np.array(
+            [
+                [1.7, 0.6],
+                [0.1, 1.8],
+            ],
+            dtype=np.float32,
+        ),
+    )
+
+
+def test_locked_matches_and_ambiguous_subproblem_preserve_original_indices() -> None:
+    similarity = np.array(
+        [
+            [0.9, 0.1, 0.0],
+            [0.1, 0.7, 0.6],
+            [0.0, 0.6, 0.7],
+        ],
+        dtype=np.float32,
+    )
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10, 20, 30],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+                [10, 10, 15, 15],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=None,
+        minimum_similarity=0.5,
+    )
+
+    assert result.locked_matches == [(0, 0)]
+    assert result.remaining_track_indices == [1, 2]
+    assert result.remaining_detection_indices == [1, 2]
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        np.array(
+            [
+                [0.7, 0.6],
+                [0.6, 0.7],
+            ],
+            dtype=np.float32,
+        ),
+    )
+
+
+def test_multiple_ambiguous_pairs_receive_independent_mask_bonuses() -> None:
+    similarity = np.array(
+        [
+            [0.7, 0.6],
+            [0.6, 0.7],
+        ],
+        dtype=np.float32,
+    )
+
+    masks = np.zeros((2, 10, 10), dtype=bool)
+    masks[0, 0:5, 0:5] = True
+    masks[1, 5:10, 5:10] = True
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10, 20],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=masks,
+            tracklet_mask_dict={
+                10: 0,
+                20: 1,
+            },
+            confidences={
+                10: 0.9,
+                20: 0.9,
+            },
+        ),
+        minimum_similarity=0.5,
+    )
+
+    np.testing.assert_allclose(
+        result.conditioned_similarity,
+        np.array(
+            [
+                [1.7, 0.6],
+                [0.6, 1.7],
+            ],
+            dtype=np.float32,
+        ),
+    )
+
+
+def test_mask_bonus_is_not_clamped_to_one() -> None:
+    similarity = np.array([[0.8, 0.7]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 10, 10],
+                [0, 0, 5, 5],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=np.stack([_full_mask()]),
+            tracklet_mask_dict={10: 0},
+            confidences={10: 0.9},
+        ),
+        minimum_similarity=0.5,
+    )
+
+    assert np.isclose(result.conditioned_similarity[0, 0], 1.8)
+
+
+def test_missing_mask_output_keeps_ambiguous_scores_unchanged() -> None:
+    similarity = np.array([[0.7, 0.6]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=None,
+        minimum_similarity=0.5,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_missing_tracklet_mask_keeps_scores_unchanged() -> None:
+    similarity = np.array([[0.7, 0.6]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=np.stack([_full_mask()]),
+            tracklet_mask_dict={99: 0},
+            confidences={99: 0.9},
+        ),
+        minimum_similarity=0.5,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_invalid_mask_index_keeps_scores_unchanged() -> None:
+    similarity = np.array([[0.7, 0.6]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=np.stack([_full_mask()]),
+            # valid mask index in this case would be 0
+            tracklet_mask_dict={
+                10: 5,
+            },
+            confidences={
+                10: 0.9,
+            },
+        ),
+        minimum_similarity=0.5,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_missing_mask_confidence_keeps_scores_unchanged() -> None:
+    similarity = np.array([[0.7, 0.6]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 10, 10],
+                [0, 0, 5, 5],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=np.stack([_full_mask()]),
+            tracklet_mask_dict={
+                10: 0,
+            },
+            confidences={},
+        ),
+        minimum_similarity=0.5,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_low_mask_confidence_keeps_scores_unchanged() -> None:
+    similarity = np.array([[0.7, 0.6]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 10, 10],
+                [0, 0, 5, 5],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=np.stack([_full_mask()]),
+            tracklet_mask_dict={10: 0},
+            confidences={10: 0.5},
+        ),
+        minimum_similarity=0.5,
+        minimum_mask_average_confidence=0.6,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_low_mask_coverage_keeps_entry_unchanged() -> None:
+    similarity = np.array([[0.7, 0.6]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=np.stack([_full_mask()]),
+            tracklet_mask_dict={10: 0},
+            confidences={10: 0.9},
+        ),
+        minimum_similarity=0.5,
+        minimum_mask_coverage=0.9,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_low_mask_fill_ratio_keeps_entry_unchanged() -> None:
+    similarity = np.array([[0.7, 0.6]], dtype=np.float32)
+    mask = np.zeros((20, 20), dtype=bool)
+    mask[0:2, 0:2] = True
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 20, 20],
+                [0, 0, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=np.stack([mask]),
+            tracklet_mask_dict={10: 0},
+            confidences={10: 0.9},
+        ),
+        minimum_similarity=0.5,
+        minimum_mask_coverage=0.9,
+        minimum_mask_fill_ratio=0.05,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_empty_mask_keeps_scores_unchanged() -> None:
+    similarity = np.array([[0.7, 0.6]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=np.zeros((1, 10, 10), dtype=bool),
+            tracklet_mask_dict={10: 0},
+            confidences={10: 0.9},
+        ),
+        minimum_similarity=0.5,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_isolated_below_threshold_pair_is_unchanged_when_disabled() -> None:
+    similarity = np.array([[0.2]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array([[0, 0, 10, 10]], dtype=np.float32),
+        mask_output=_mask_output(
+            masks=np.stack([_full_mask()]),
+            tracklet_mask_dict={10: 0},
+            confidences={10: 0.9},
+        ),
+        minimum_similarity=0.5,
+        enable_isolated_mask_matching=False,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_isolated_below_threshold_pair_is_boosted_when_enabled() -> None:
+    similarity = np.array([[0.2]], dtype=np.float32)
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array([[0, 0, 10, 10]], dtype=np.float32),
+        mask_output=_mask_output(
+            masks=np.stack([_full_mask()]),
+            tracklet_mask_dict={10: 0},
+            confidences={10: 0.9},
+        ),
+        minimum_similarity=0.5,
+        enable_isolated_mask_matching=True,
+    )
+
+    assert np.isclose(result.conditioned_similarity[0, 0], 1.2)
+
+
+def test_below_threshold_pair_is_not_rescued_when_not_isolated() -> None:
+    similarity = np.array(
+        [
+            [0.2, 0.1],
+        ],
+        dtype=np.float32,
+    )
+
+    result = condition_similarity_with_masks(
+        similarity=similarity,
+        raw_iou_similarity=similarity,
+        tracklet_ids=[10],
+        detection_boxes=np.array(
+            [
+                [0, 0, 10, 10],
+                [0, 0, 10, 10],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=_mask_output(
+            masks=np.stack([_full_mask()]),
+            tracklet_mask_dict={10: 0},
+            confidences={10: 0.9},
+        ),
+        minimum_similarity=0.5,
+        enable_isolated_mask_matching=True,
+    )
+
+    np.testing.assert_array_equal(
+        result.conditioned_similarity,
+        similarity,
+    )
+
+
+def test_empty_association_problem_is_supported() -> None:
+    result = condition_similarity_with_masks(
+        similarity=np.empty((0, 0), dtype=np.float32),
+        raw_iou_similarity=np.empty((0, 0), dtype=np.float32),
+        tracklet_ids=[],
+        detection_boxes=np.empty((0, 4), dtype=np.float32),
+        mask_output=None,
+        minimum_similarity=0.5,
+    )
+
+    assert result.locked_matches == []
+    assert result.remaining_track_indices == []
+    assert result.remaining_detection_indices == []
+    assert result.conditioned_similarity.shape == (0, 0)
+
+
+def test_empty_tracklet_dimension_is_supported() -> None:
+    result = condition_similarity_with_masks(
+        similarity=np.empty((0, 3), dtype=np.float32),
+        raw_iou_similarity=np.empty((0, 3), dtype=np.float32),
+        tracklet_ids=[],
+        detection_boxes=np.array(
+            [
+                [0, 0, 5, 5],
+                [5, 5, 10, 10],
+                [10, 10, 15, 15],
+            ],
+            dtype=np.float32,
+        ),
+        mask_output=None,
+        minimum_similarity=0.5,
+    )
+
+    assert result.locked_matches == []
+    assert result.remaining_track_indices == []
+    assert result.remaining_detection_indices == [0, 1, 2]
+    assert result.conditioned_similarity.shape == (0, 3)
+
+
+def test_empty_detection_dimension_is_supported() -> None:
+    result = condition_similarity_with_masks(
+        similarity=np.empty((2, 0), dtype=np.float32),
+        raw_iou_similarity=np.empty((2, 0), dtype=np.float32),
+        tracklet_ids=[10, 20],
+        detection_boxes=np.empty((0, 4), dtype=np.float32),
+        mask_output=None,
+        minimum_similarity=0.5,
+    )
+
+    assert result.locked_matches == []
+    assert result.remaining_track_indices == [0, 1]
+    assert result.remaining_detection_indices == []
+    assert result.conditioned_similarity.shape == (2, 0)

--- a/tests/core/test_mcbyte_mask_association.py
+++ b/tests/core/test_mcbyte_mask_association.py
@@ -15,18 +15,6 @@ from trackers.core.mcbyte.mask_association import (
 from trackers.core.mcbyte.masks.base import MaskOutput
 
 
-def _mask_output(
-    masks: np.ndarray,
-    tracklet_mask_dict: dict[int, int],
-    confidences: dict[int, float],
-) -> MaskOutput:
-    return MaskOutput(
-        masks=masks,
-        tracklet_mask_dict=tracklet_mask_dict,
-        mask_avg_prob_dict=confidences,
-    )
-
-
 def _full_mask(
     height: int = 10,
     width: int = 10,
@@ -100,10 +88,10 @@ def test_ambiguous_row_receives_mask_fill_bonus() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=masks,
             tracklet_mask_dict={10: 0},
-            confidences={10: 0.9},
+            mask_avg_prob_dict={10: 0.9},
         ),
         minimum_similarity=0.5,
     )
@@ -137,13 +125,13 @@ def test_ambiguous_column_pair_receives_mask_fill_bonus() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=masks,
             tracklet_mask_dict={
                 10: 0,
                 20: 1,
             },
-            confidences={
+            mask_avg_prob_dict={
                 10: 0.9,
                 20: 0.9,
             },
@@ -189,13 +177,13 @@ def test_ambiguity_is_computed_from_original_similarity_matrix() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=masks,
             tracklet_mask_dict={
                 10: 0,
                 20: 1,
             },
-            confidences={
+            mask_avg_prob_dict={
                 10: 0.9,
                 20: 0.9,
             },
@@ -285,13 +273,13 @@ def test_multiple_ambiguous_pairs_receive_independent_mask_bonuses() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=masks,
             tracklet_mask_dict={
                 10: 0,
                 20: 1,
             },
-            confidences={
+            mask_avg_prob_dict={
                 10: 0.9,
                 20: 0.9,
             },
@@ -325,10 +313,10 @@ def test_mask_bonus_is_not_clamped_to_one() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([_full_mask()]),
             tracklet_mask_dict={10: 0},
-            confidences={10: 0.9},
+            mask_avg_prob_dict={10: 0.9},
         ),
         minimum_similarity=0.5,
     )
@@ -374,10 +362,10 @@ def test_missing_tracklet_mask_keeps_scores_unchanged() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([_full_mask()]),
             tracklet_mask_dict={99: 0},
-            confidences={99: 0.9},
+            mask_avg_prob_dict={99: 0.9},
         ),
         minimum_similarity=0.5,
     )
@@ -402,13 +390,13 @@ def test_invalid_mask_index_keeps_scores_unchanged() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([_full_mask()]),
             # valid mask index in this case would be 0
             tracklet_mask_dict={
                 10: 5,
             },
-            confidences={
+            mask_avg_prob_dict={
                 10: 0.9,
             },
         ),
@@ -435,12 +423,12 @@ def test_missing_mask_confidence_keeps_scores_unchanged() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([_full_mask()]),
             tracklet_mask_dict={
                 10: 0,
             },
-            confidences={},
+            mask_avg_prob_dict={},
         ),
         minimum_similarity=0.5,
     )
@@ -465,10 +453,10 @@ def test_low_mask_confidence_keeps_scores_unchanged() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([_full_mask()]),
             tracklet_mask_dict={10: 0},
-            confidences={10: 0.5},
+            mask_avg_prob_dict={10: 0.5},
         ),
         minimum_similarity=0.5,
         minimum_mask_average_confidence=0.6,
@@ -494,10 +482,10 @@ def test_low_mask_coverage_keeps_entry_unchanged() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([_full_mask()]),
             tracklet_mask_dict={10: 0},
-            confidences={10: 0.9},
+            mask_avg_prob_dict={10: 0.9},
         ),
         minimum_similarity=0.5,
         minimum_mask_coverage=0.9,
@@ -525,10 +513,10 @@ def test_low_mask_fill_ratio_keeps_entry_unchanged() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([mask]),
             tracklet_mask_dict={10: 0},
-            confidences={10: 0.9},
+            mask_avg_prob_dict={10: 0.9},
         ),
         minimum_similarity=0.5,
         minimum_mask_coverage=0.9,
@@ -555,10 +543,10 @@ def test_empty_mask_keeps_scores_unchanged() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.zeros((1, 10, 10), dtype=bool),
             tracklet_mask_dict={10: 0},
-            confidences={10: 0.9},
+            mask_avg_prob_dict={10: 0.9},
         ),
         minimum_similarity=0.5,
     )
@@ -577,10 +565,10 @@ def test_isolated_below_threshold_pair_is_unchanged_when_disabled() -> None:
         raw_iou_similarity=similarity,
         tracklet_ids=[10],
         detection_boxes=np.array([[0, 0, 10, 10]], dtype=np.float32),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([_full_mask()]),
             tracklet_mask_dict={10: 0},
-            confidences={10: 0.9},
+            mask_avg_prob_dict={10: 0.9},
         ),
         minimum_similarity=0.5,
         enable_isolated_mask_matching=False,
@@ -600,10 +588,10 @@ def test_isolated_below_threshold_pair_is_boosted_when_enabled() -> None:
         raw_iou_similarity=similarity,
         tracklet_ids=[10],
         detection_boxes=np.array([[0, 0, 10, 10]], dtype=np.float32),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([_full_mask()]),
             tracklet_mask_dict={10: 0},
-            confidences={10: 0.9},
+            mask_avg_prob_dict={10: 0.9},
         ),
         minimum_similarity=0.5,
         enable_isolated_mask_matching=True,
@@ -631,10 +619,10 @@ def test_below_threshold_pair_is_not_rescued_when_not_isolated() -> None:
             ],
             dtype=np.float32,
         ),
-        mask_output=_mask_output(
+        mask_output=MaskOutput(
             masks=np.stack([_full_mask()]),
             tracklet_mask_dict={10: 0},
-            confidences={10: 0.9},
+            mask_avg_prob_dict={10: 0.9},
         ),
         minimum_similarity=0.5,
         enable_isolated_mask_matching=True,

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -371,14 +371,8 @@ def test_mcbyte_mask_conditioned_association_changes_ambiguous_assignment() -> N
         min_similarity_thresh=0.5,
     )
 
-    assert matches_without_masks == [
-        (0, 1),
-        (1, 0),
-    ]
-    assert matches_with_masks == [
-        (0, 0),
-        (1, 1),
-    ]
+    assert matches_without_masks == [(0, 1), (1, 0)]
+    assert matches_with_masks == [(0, 0), (1, 1)]
     assert unmatched_tracks == []
     assert unmatched_detections == []
 

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -7,10 +7,19 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 import supervision as sv
+from pytest import MonkeyPatch
 
+import trackers.core.mcbyte.tracker as mcbyte_tracker_module
+from trackers.core.mcbyte.mask_manager import MaskManager
 from trackers.core.mcbyte.masks.base import MaskOutput, TrackletSnapshot
-from trackers.core.mcbyte.tracker import McByteTracker
+from trackers.core.mcbyte.masks.dummy import (
+    DummyBoxMaskGenerator,
+    DummyIdentityMaskPropagator,
+)
+from trackers.core.mcbyte.tracker import McByteMaskConfig, McByteTracker
+from trackers.core.mcbyte.tracklet import McByteTracklet
 
 
 class SpyMaskManager:
@@ -47,9 +56,29 @@ def _detection(xyxy: tuple[float, float, float, float], conf: float = 0.9) -> sv
     )
 
 
+def _tracklet_with_id(
+    tracker_id: int,
+    xyxy: tuple[float, float, float, float],
+) -> McByteTracklet:
+    """Create a McByte tracklet with a stable tracker ID for association tests."""
+    tracklet = McByteTracklet(
+        initial_bbox=np.array(xyxy, dtype=np.float32),
+    )
+    tracklet.tracker_id = tracker_id
+    return tracklet
+
+
 def _make_frame(h: int = 480, w: int = 640, seed: int = 42) -> np.ndarray:
     rng = np.random.default_rng(seed)
     return rng.integers(0, 255, (h, w, 3), dtype=np.uint8)
+
+
+def _dummy_mask_manager() -> MaskManager:
+    """Create a lightweight mask manager for tracker unit tests."""
+    return MaskManager(
+        mask_generator=DummyBoxMaskGenerator(),
+        mask_propagator=DummyIdentityMaskPropagator(),
+    )
 
 
 def test_mcbyte_instantiates_and_updates_with_frame_and_sparse_opt_flow_cmc_returns_ids() -> None:
@@ -73,7 +102,7 @@ def test_mcbyte_instantiates_and_updates_with_frame_and_sparse_opt_flow_cmc_retu
 def test_mcbyte_reset_clears_mask_state() -> None:
     tracker = McByteTracker(
         enable_cmc=False,
-        enable_mask_manager=True,
+        mask_manager=_dummy_mask_manager(),
         minimum_consecutive_frames=1,
     )
 
@@ -147,8 +176,7 @@ def test_mcbyte_passes_new_tracklets_to_mask_manager_on_next_frame() -> None:
 def test_mcbyte_mask_lifecycle_keeps_missing_tracklet_until_explicit_removal() -> None:
     tracker = McByteTracker(
         enable_cmc=False,
-        enable_mask_manager=True,
-        mask_manager=None,
+        mask_manager=_dummy_mask_manager(),
         minimum_consecutive_frames=1,
     )
 
@@ -190,3 +218,332 @@ def test_mcbyte_mask_lifecycle_keeps_missing_tracklet_until_explicit_removal() -
     assert tracker._previous_new_tracklets == []
     assert tracker._previous_removed_tracklet_ids == [7]
     assert tracker._mask_tracklet_ids == set()
+
+
+def test_mcbyte_mask_conditioned_association_combines_locked_and_reduced_matches() -> None:
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=False,
+    )
+
+    tracklets = [
+        _tracklet_with_id(10, (0.0, 0.0, 5.0, 5.0)),
+        _tracklet_with_id(20, (5.0, 5.0, 10.0, 10.0)),
+        _tracklet_with_id(30, (10.0, 10.0, 15.0, 15.0)),
+    ]
+    detection_boxes = np.array(
+        [
+            [0.0, 0.0, 5.0, 5.0],
+            [5.0, 5.0, 10.0, 10.0],
+            [10.0, 10.0, 15.0, 15.0],
+        ],
+        dtype=np.float32,
+    )
+
+    similarity = np.array(
+        [
+            [0.9, 0.1, 0.0],
+            [0.1, 0.7, 0.6],
+            [0.0, 0.6, 0.7],
+        ],
+        dtype=np.float32,
+    )
+
+    matched, unmatched_tracks, unmatched_detections = tracker._get_mask_conditioned_associated_indices(
+        similarity_matrix=similarity,
+        raw_iou_similarity=similarity,
+        tracklets=tracklets,
+        detection_boxes=detection_boxes,
+        min_similarity_thresh=0.5,
+    )
+
+    # Locked match: (0,0). Reduced matches: (1,1), (2,2) - mapped back from (0,0), (1,1)
+    assert matched == [
+        (0, 0),
+        (1, 1),
+        (2, 2),
+    ]
+    assert unmatched_tracks == []
+    assert unmatched_detections == []
+
+
+def test_mcbyte_mask_conditioned_association_remaps_unmatched_indices() -> None:
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=False,
+    )
+
+    tracklets = [
+        _tracklet_with_id(10, (0.0, 0.0, 5.0, 5.0)),
+        _tracklet_with_id(20, (5.0, 5.0, 10.0, 10.0)),
+        _tracklet_with_id(30, (10.0, 10.0, 15.0, 15.0)),
+    ]
+    detection_boxes = np.array(
+        [
+            [0.0, 0.0, 5.0, 5.0],
+            [5.0, 5.0, 10.0, 10.0],
+            [10.0, 10.0, 15.0, 15.0],
+        ],
+        dtype=np.float32,
+    )
+
+    similarity = np.array(
+        [
+            [0.9, 0.1, 0.0],
+            [0.1, 0.4, 0.3],
+            [0.0, 0.2, 0.1],
+        ],
+        dtype=np.float32,
+    )
+
+    matched, unmatched_tracks, unmatched_detections = tracker._get_mask_conditioned_associated_indices(
+        similarity_matrix=similarity,
+        raw_iou_similarity=similarity,
+        tracklets=tracklets,
+        detection_boxes=detection_boxes,
+        min_similarity_thresh=0.5,
+    )
+
+    assert matched == [(0, 0)]
+    assert unmatched_tracks == [1, 2]  # mapped back from [0, 1]
+    assert unmatched_detections == [1, 2]  # mapped back from [0, 1]
+
+
+def test_mcbyte_mask_conditioned_association_changes_ambiguous_assignment() -> None:
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=False,
+    )
+
+    tracklets = [
+        _tracklet_with_id(10, (0.0, 0.0, 5.0, 5.0)),
+        _tracklet_with_id(20, (5.0, 5.0, 10.0, 10.0)),
+    ]
+    detection_boxes = np.array(
+        [
+            [0.0, 0.0, 5.0, 5.0],
+            [5.0, 5.0, 10.0, 10.0],
+        ],
+        dtype=np.float32,
+    )
+
+    similarity = np.array(
+        [
+            [0.6, 0.7],
+            [0.7, 0.6],
+        ],
+        dtype=np.float32,
+    )
+
+    matches_without_masks, _, _ = tracker._get_mask_conditioned_associated_indices(
+        similarity_matrix=similarity,
+        raw_iou_similarity=similarity,
+        tracklets=tracklets,
+        detection_boxes=detection_boxes,
+        min_similarity_thresh=0.5,
+    )
+
+    masks = np.zeros((2, 10, 10), dtype=bool)
+    # it will result in fill-ratio bonus of 1.0 for first detection (0.6 + 1.0 = 1.6)
+    masks[0, 0:5, 0:5] = True
+    # it will result in fill-ratio bonus of 1.0 for second detection (0.6 + 1.0 = 1.6)
+    masks[1, 5:10, 5:10] = True
+
+    tracker._last_mask_output = MaskOutput(
+        masks=masks,
+        tracklet_mask_dict={
+            10: 0,
+            20: 1,
+        },
+        mask_avg_prob_dict={
+            10: 0.9,
+            20: 0.9,
+        },
+    )
+
+    matches_with_masks, unmatched_tracks, unmatched_detections = tracker._get_mask_conditioned_associated_indices(
+        similarity_matrix=similarity,
+        raw_iou_similarity=similarity,
+        tracklets=tracklets,
+        detection_boxes=detection_boxes,
+        min_similarity_thresh=0.5,
+    )
+
+    assert matches_without_masks == [
+        (0, 1),
+        (1, 0),
+    ]
+    assert matches_with_masks == [
+        (0, 0),
+        (1, 1),
+    ]
+    assert unmatched_tracks == []
+    assert unmatched_detections == []
+
+
+def test_mcbyte_mask_conditioned_association_rescues_isolated_pair_when_enabled() -> None:
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=False,
+        enable_isolated_mask_matching=True,
+    )
+
+    tracklets = [
+        _tracklet_with_id(10, (0.0, 0.0, 10.0, 10.0)),
+    ]
+    detection_boxes = np.array(
+        [
+            [0.0, 0.0, 10.0, 10.0],
+        ],
+        dtype=np.float32,
+    )
+
+    tracker._last_mask_output = MaskOutput(
+        masks=np.ones((1, 10, 10), dtype=bool),
+        tracklet_mask_dict={10: 0},
+        mask_avg_prob_dict={10: 0.9},
+    )
+
+    matched, unmatched_tracks, unmatched_detections = tracker._get_mask_conditioned_associated_indices(
+        similarity_matrix=np.array([[0.2]], dtype=np.float32),
+        raw_iou_similarity=np.array([[0.2]], dtype=np.float32),
+        tracklets=tracklets,
+        detection_boxes=detection_boxes,
+        min_similarity_thresh=0.5,
+    )
+
+    # Without isolation, match would be empty, unmatched_tracks would be [0],
+    # unmatched_detections would be [0]
+    assert matched == [(0, 0)]
+    assert unmatched_tracks == []
+    assert unmatched_detections == []
+
+
+def test_mcbyte_builds_real_mask_pipeline_when_enabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    created: dict[str, object] = {}
+
+    class FakeSAMBoxMaskGenerator:
+        def __init__(
+            self,
+            checkpoint_path: str | None = None,
+            model_type: str = "vit_b",
+            device: str = "cpu",
+        ) -> None:
+            created["sam"] = {
+                "checkpoint_path": checkpoint_path,
+                "model_type": model_type,
+                "device": device,
+            }
+
+    class FakeCutieMaskPropagator:
+        def __init__(
+            self,
+            weights_path: str | None = None,
+            model_type: str = "base-mega",
+            config_path: str | None = None,
+            config_name: str = "eval_config",
+            device: str = "cuda",
+            use_amp: bool = True,
+        ) -> None:
+            created["cutie"] = {
+                "weights_path": weights_path,
+                "model_type": model_type,
+                "config_path": config_path,
+                "config_name": config_name,
+                "device": device,
+                "use_amp": use_amp,
+            }
+
+        def reset(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        mcbyte_tracker_module,
+        "SAMBoxMaskGenerator",
+        FakeSAMBoxMaskGenerator,
+    )
+    monkeypatch.setattr(
+        mcbyte_tracker_module,
+        "CutieMaskPropagator",
+        FakeCutieMaskPropagator,
+    )
+
+    # "cuda:1" only for testing of the passed values. No actual CUDA device is used,
+    # because the classes are fake and do not initialize PyTorch or allocate anything.
+    # enable_mask_manager=True must lead to creating MaskManager with
+    # SAMBoxMaskGenerator and CutieMaskPropagator (being replaced by
+    # FakeSAMBoxMaskGenerator and FakeCutieMaskPropagator)
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=True,
+        mask_config=McByteMaskConfig(
+            device="cuda:1",
+            sam_model_type="vit_b",
+            cutie_model_type="base-mega",
+            cutie_config_name="eval_config",
+            cutie_use_amp=False,
+            mask_creation_bbox_overlap_threshold=0.7,
+        ),
+    )
+
+    # Verify a real MaskManager was created
+    assert isinstance(tracker.mask_manager, MaskManager)
+
+    # Verify SAM received the right parameters (via McByteMaskConfig at McByteTracker)
+    assert created["sam"] == {
+        "checkpoint_path": None,
+        "model_type": "vit_b",
+        "device": "cuda:1",
+    }
+
+    # Verify Cutie received the right parameters (via McByteMaskConfig at McByteTracker)
+    assert created["cutie"] == {
+        "weights_path": None,
+        "model_type": "base-mega",
+        "config_path": None,
+        "config_name": "eval_config",
+        "device": "cuda:1",
+        "use_amp": False,
+    }
+
+    # Verify the MaskManager-specific threshold
+    assert tracker.mask_manager.mask_creation_bbox_overlap_threshold == 0.7
+
+
+def test_mcbyte_uses_custom_mask_manager_without_real_model_construction() -> None:
+    custom_manager = _dummy_mask_manager()
+
+    tracker = McByteTracker(
+        enable_cmc=False,
+        mask_manager=custom_manager,
+    )
+
+    # There is some conditional flow in the MaskManager, hence we are ensuring the one
+    # below here.
+    assert tracker.mask_manager is custom_manager
+
+
+def test_mcbyte_rejects_mask_config_with_custom_manager() -> None:
+    with pytest.raises(
+        ValueError,
+        match="cannot be used together",
+    ):
+        McByteTracker(
+            enable_cmc=False,
+            mask_manager=_dummy_mask_manager(),
+            mask_config=McByteMaskConfig(),
+        )
+
+
+def test_mcbyte_rejects_unused_mask_config() -> None:
+    with pytest.raises(
+        ValueError,
+        match="requires enable_mask_manager=True",
+    ):
+        McByteTracker(
+            enable_cmc=False,
+            enable_mask_manager=False,
+            mask_config=McByteMaskConfig(),
+        )

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -6,12 +6,14 @@
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType
+
 import numpy as np
 import pytest
 import supervision as sv
 from pytest import MonkeyPatch
 
-import trackers.core.mcbyte.tracker as mcbyte_tracker_module
 from trackers.core.mcbyte.mask_manager import MaskManager
 from trackers.core.mcbyte.masks.base import MaskOutput, TrackletSnapshot
 from trackers.core.mcbyte.masks.dummy import (
@@ -459,15 +461,24 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
         def reset(self) -> None:
             pass
 
-    monkeypatch.setattr(
-        mcbyte_tracker_module,
-        "SAMBoxMaskGenerator",
-        FakeSAMBoxMaskGenerator,
+    # mcbyte_tracker_module.SAMBoxMaskGenerator and
+    # mcbyte_tracker_module.CutieMaskPropagator are imported locally in
+    # _build_default_mask_manager() in tracker.py
+    fake_sam_module = ModuleType("trackers.core.mcbyte.masks.sam")
+    fake_sam_module.SAMBoxMaskGenerator = FakeSAMBoxMaskGenerator  # type: ignore[attr-defined]
+
+    fake_cutie_module = ModuleType("trackers.core.mcbyte.masks.cutie")
+    fake_cutie_module.CutieMaskPropagator = FakeCutieMaskPropagator  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "trackers.core.mcbyte.masks.sam",
+        fake_sam_module,
     )
-    monkeypatch.setattr(
-        mcbyte_tracker_module,
-        "CutieMaskPropagator",
-        FakeCutieMaskPropagator,
+    monkeypatch.setitem(
+        sys.modules,
+        "trackers.core.mcbyte.masks.cutie",
+        fake_cutie_module,
     )
 
     # "cuda:1" only for testing of the passed values. No actual CUDA device is used,

--- a/visual_tests/visualize_mcbyte_from_detections.py
+++ b/visual_tests/visualize_mcbyte_from_detections.py
@@ -1,0 +1,781 @@
+# ------------------------------------------------------------------------
+# Trackers
+# Copyright (c) 2026 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Compare locked-IoU and mask-conditioned McByte on one sequence.
+
+The script supports two detection-file layouts:
+
+``mot_tlwh``:
+    ``frame,id,left,top,width,height,confidence,...``
+
+``xyxy``:
+    ``frame,x1,y1,x2,y2,confidence``
+
+For ``mot_tlwh``, the input identity column is ignored because tracker
+identities are produced by McByte. Both formats are converted internally to
+``xyxy`` bounding boxes.
+
+The script can be used with datasets such as MOT17, DanceTrack, SportsMOT,
+and SoccerNet-tracking, provided their frame filenames follow one of the
+supported naming conventions.
+
+The script runs the same detections through two McByte configurations:
+
+1. ``locked_iou``:
+   McByte clear-match locking and reduced assignment, without MaskManager.
+2. ``mask_conditioned``:
+   Full McByte using SAM mask initialization, Cutie propagation, clear-match
+   locking, and mask-conditioned association.
+
+Both runs save:
+
+- per-frame visualizations;
+- MOTChallenge-style tracking results.
+
+The full mask-conditioned run additionally overlays the propagated masks and
+displays mask lifecycle information.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TextIO, cast
+
+import cv2
+import numpy as np
+import supervision as sv
+import torch
+
+from trackers.core.mcbyte.masks.base import MaskOutput
+from trackers.core.mcbyte.tracker import McByteMaskConfig, McByteTracker
+from trackers.utils.cmc import CMCMethod
+
+DEFAULT_OUTPUT_DIR = Path("visual_tests/outputs/visualize_mcbyte_from_detections")
+IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".bmp", ".webp")
+RUN_MODES = ("locked_iou", "mask_conditioned")
+SUPPORTED_CMC_METHODS = ("orb", "sift", "sparseOptFlow", "ecc")
+
+DetectionFileFormat = Literal["mot_tlwh", "xyxy"]
+SUPPORTED_DETECTION_FORMATS = ("mot_tlwh", "xyxy")
+
+
+@dataclass(frozen=True)
+class DetectionRecord:
+    """One detection parsed from a MOT-style detection file."""
+
+    xyxy: np.ndarray
+    confidence: float
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=("Compare locked-IoU and mask-conditioned McByte on one sequence."))
+    parser.add_argument(
+        "--image-dir",
+        type=Path,
+        required=True,
+        help="Directory containing sequence frames.",
+    )
+    parser.add_argument(
+        "--det-file",
+        type=Path,
+        required=True,
+        help="Path to the detection file.",
+    )
+    parser.add_argument(
+        "--det-format",
+        choices=SUPPORTED_DETECTION_FORMATS,
+        default="mot_tlwh",
+        help=(
+            "Detection-file column format. "
+            "'mot_tlwh' expects "
+            "frame,id,left,top,width,height,confidence,...; "
+            "'xyxy' expects frame,x1,y1,x2,y2,confidence."
+        ),
+    )
+    parser.add_argument(
+        "--start-frame",
+        type=int,
+        required=True,
+        help="First frame number to process, inclusive.",
+    )
+    parser.add_argument(
+        "--end-frame",
+        type=int,
+        required=True,
+        help="Last frame number to process, inclusive.",
+    )
+    parser.add_argument(
+        "--frame-rate",
+        type=float,
+        default=30.0,
+        help="Sequence frame rate used to scale the lost-track buffer.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda",
+        help="Device used by SAM and Cutie in the mask-conditioned run.",
+    )
+    parser.add_argument(
+        "--enable-cmc",
+        action="store_true",
+        help="Enable camera motion compensation in both runs.",
+    )
+    parser.add_argument(
+        "--cmc-method",
+        type=str,
+        default="sparseOptFlow",
+        choices=SUPPORTED_CMC_METHODS,
+        help="Camera-motion compensation method.",
+    )
+    parser.add_argument(
+        "--cmc-downscale",
+        type=int,
+        default=2,
+        help="Image downscale factor used by CMC.",
+    )
+    parser.add_argument(
+        "--modes",
+        nargs="+",
+        choices=RUN_MODES,
+        default=list(RUN_MODES),
+        help=(
+            "Tracker configurations to run. By default, both the mask-free "
+            "locked-IoU baseline and full mask-conditioned McByte are run."
+        ),
+    )
+    parser.add_argument(
+        "--enable-isolated-mask-matching",
+        action="store_true",
+        help=("Allow mask evidence to rescue isolated positive-IoU pairs below the normal association threshold."),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Root directory for both comparison runs.",
+    )
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    """Validate paths, frame range, device, and numeric arguments."""
+    if not args.image_dir.is_dir():
+        raise NotADirectoryError(f"Image directory does not exist: {args.image_dir}")
+
+    if not args.det_file.is_file():
+        raise FileNotFoundError(f"Detection file does not exist: {args.det_file}")
+
+    if args.start_frame <= 0:
+        raise ValueError("start-frame must be positive.")
+
+    if args.end_frame < args.start_frame:
+        raise ValueError("end-frame must be greater than or equal to start-frame.")
+
+    if args.frame_rate <= 0:
+        raise ValueError("frame-rate must be positive.")
+
+    if args.cmc_downscale <= 0:
+        raise ValueError("cmc-downscale must be positive.")
+
+    if args.device.startswith("cuda") and not torch.cuda.is_available():
+        raise RuntimeError(
+            "CUDA was requested, but torch.cuda.is_available() is False. "
+            "Use --device cpu or install CUDA-enabled PyTorch."
+        )
+
+
+def read_detection_file(
+    det_file: Path,
+    detection_format: DetectionFileFormat,
+) -> dict[int, list[DetectionRecord]]:
+    """Read detections and group them by frame number.
+
+    Supported formats are:
+
+    ``mot_tlwh``:
+        ``frame,id,left,top,width,height,confidence,...``
+
+        The input identity column is ignored. Bounding boxes are interpreted as
+        top-left coordinates plus width and height.
+
+    ``xyxy``:
+        ``frame,x1,y1,x2,y2,confidence``
+
+        Bounding boxes are interpreted directly as top-left and bottom-right
+        coordinates.
+
+    Detection confidence is preserved and used by McByte's high- and
+    low-confidence association stages.
+    """
+    detections_by_frame: dict[int, list[DetectionRecord]] = defaultdict(list)
+
+    minimum_column_count = 7 if detection_format == "mot_tlwh" else 6
+
+    with det_file.open("r", encoding="utf-8") as file:
+        for line_number, line in enumerate(file, start=1):
+            line = line.strip()
+            if not line:
+                continue
+
+            values = [value.strip() for value in line.split(",")]
+
+            if len(values) < minimum_column_count:
+                raise ValueError(
+                    f"Detection format {detection_format!r} requires at least "
+                    f"{minimum_column_count} columns. Invalid line "
+                    f"{line_number}: {line}"
+                )
+
+            try:
+                frame_number = int(float(values[0]))
+
+                if detection_format == "mot_tlwh":
+                    left = float(values[2])
+                    top = float(values[3])
+                    width = float(values[4])
+                    height = float(values[5])
+                    confidence = float(values[6])
+
+                    if width <= 0 or height <= 0:
+                        continue
+
+                    right = left + width
+                    bottom = top + height
+
+                else:
+                    left = float(values[1])
+                    top = float(values[2])
+                    right = float(values[3])
+                    bottom = float(values[4])
+                    confidence = float(values[5])
+
+                    if right <= left or bottom <= top:
+                        continue
+
+            except ValueError as exc:
+                raise ValueError(
+                    f"Could not parse detection line {line_number} using format {detection_format!r}: {line}"
+                ) from exc
+
+            if frame_number <= 0:
+                raise ValueError(f"Invalid non-positive frame number on line {line_number}.")
+
+            numeric_values = np.array(
+                [left, top, right, bottom, confidence],
+                dtype=np.float64,
+            )
+            if not np.all(np.isfinite(numeric_values)):
+                raise ValueError(f"Non-finite value on detection line {line_number}: {line}")
+
+            xyxy = np.array(
+                [left, top, right, bottom],
+                dtype=np.float32,
+            )
+
+            detections_by_frame[frame_number].append(
+                DetectionRecord(
+                    xyxy=xyxy,
+                    confidence=confidence,
+                )
+            )
+
+    return dict(detections_by_frame)
+
+
+def find_frame_path(
+    image_dir: Path,
+    frame_number: int,
+) -> Path:
+    """Find a frame using common MOT filename widths and image extensions."""
+    filename_stems = (
+        f"{frame_number:06d}",
+        f"{frame_number:08d}",
+    )
+
+    for stem in filename_stems:
+        for extension in IMAGE_EXTENSIONS:
+            frame_path = image_dir / f"{stem}{extension}"
+            if frame_path.is_file():
+                return frame_path
+
+    attempted_names = [f"{stem}{extension}" for stem in filename_stems for extension in IMAGE_EXTENSIONS]
+    raise FileNotFoundError(f"Could not find frame {frame_number} in {image_dir}. Tried: {attempted_names}")
+
+
+def load_rgb_frame(frame_path: Path) -> np.ndarray:
+    """Load one image and convert it from OpenCV BGR to RGB."""
+    frame_bgr = cv2.imread(str(frame_path))
+    if frame_bgr is None:
+        raise RuntimeError(f"cv2.imread failed for frame: {frame_path}")
+
+    return cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+
+
+def build_detections(
+    records: list[DetectionRecord],
+) -> sv.Detections:
+    """Convert parsed detection records into ``sv.Detections``."""
+    if not records:
+        return sv.Detections.empty()
+
+    return sv.Detections(
+        xyxy=np.stack([record.xyxy for record in records]).astype(np.float32),
+        confidence=np.array(
+            [record.confidence for record in records],
+            dtype=np.float32,
+        ),
+    )
+
+
+def create_tracker(
+    *,
+    use_masks: bool,
+    frame_rate: float,
+    device: str,
+    enable_cmc: bool,
+    cmc_method: CMCMethod,
+    cmc_downscale: int,
+    enable_isolated_mask_matching: bool,
+) -> McByteTracker:
+    """Create mask-free locked-IoU or full mask-conditioned McByte."""
+    if use_masks:
+        return McByteTracker(
+            frame_rate=frame_rate,
+            enable_cmc=enable_cmc,
+            cmc_method=cmc_method,
+            cmc_downscale=cmc_downscale,
+            enable_mask_manager=True,
+            mask_config=McByteMaskConfig(
+                device=device,
+            ),
+            enable_isolated_mask_matching=(enable_isolated_mask_matching),
+        )
+
+    return McByteTracker(
+        frame_rate=frame_rate,
+        enable_cmc=enable_cmc,
+        cmc_method=cmc_method,
+        cmc_downscale=cmc_downscale,
+        enable_mask_manager=False,
+        enable_isolated_mask_matching=False,
+    )
+
+
+def prepare_run_directory(
+    output_root: Path,
+    mode_name: str,
+) -> tuple[Path, Path]:
+    """Recreate the output directory for one comparison mode.
+
+    Any existing directory for the selected mode is removed before new outputs are
+    written.
+    """
+    run_dir = output_root / mode_name
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+
+    frames_dir = run_dir / "frames"
+    frames_dir.mkdir(parents=True, exist_ok=True)
+
+    results_path = run_dir / "results.txt"
+    return frames_dir, results_path
+
+
+def color_from_id(tracker_id: int) -> tuple[int, int, int]:
+    """Return a deterministic RGB color for a tracker ID."""
+    if tracker_id < 0:
+        return 180, 180, 180
+
+    rng = np.random.default_rng(tracker_id)
+    color = rng.integers(40, 256, size=3, dtype=np.uint8)
+    return int(color[0]), int(color[1]), int(color[2])
+
+
+def get_mask_tracklet_ids_in_order(
+    tracklet_mask_dict: dict[int, int],
+) -> list[int]:
+    """Return tracklet IDs ordered according to ``MaskOutput.masks``."""
+    return [
+        tracklet_id
+        for tracklet_id, _ in sorted(
+            tracklet_mask_dict.items(),
+            key=lambda item: item[1],
+        )
+    ]
+
+
+def overlay_masks(
+    frame: np.ndarray,
+    mask_output: MaskOutput | None,
+    alpha: float = 0.45,
+) -> np.ndarray:
+    """Overlay propagated masks using deterministic tracklet colors."""
+    if mask_output is None or mask_output.masks is None:
+        return frame.copy()
+
+    tracklet_ids = get_mask_tracklet_ids_in_order(mask_output.tracklet_mask_dict)
+
+    if len(tracklet_ids) != mask_output.masks.shape[0]:
+        raise ValueError(
+            "The mask count does not match tracklet_mask_dict. "
+            f"Got {mask_output.masks.shape[0]} masks and "
+            f"{len(tracklet_ids)} mapped tracklet IDs."
+        )
+
+    output = frame.copy()
+
+    for mask, tracker_id in zip(mask_output.masks, tracklet_ids):
+        mask_bool = mask.astype(bool, copy=False)
+        if not np.any(mask_bool):
+            continue
+
+        color = np.array(color_from_id(tracker_id), dtype=np.uint8)
+        colored_mask = np.zeros_like(output)
+        colored_mask[mask_bool] = color
+
+        output = np.where(
+            mask_bool[..., None],
+            (alpha * colored_mask + (1.0 - alpha) * output).astype(np.uint8),
+            output,
+        )
+
+    return output
+
+
+def draw_tracking_boxes(
+    frame: np.ndarray,
+    tracked_detections: sv.Detections,
+) -> np.ndarray:
+    """Draw tracker boxes and stable IDs on an RGB frame."""
+    output = frame.copy()
+
+    tracker_ids = tracked_detections.tracker_id
+    if tracker_ids is None:
+        tracker_ids = np.full(len(tracked_detections), -1, dtype=int)
+
+    for xyxy, tracker_id_value in zip(
+        tracked_detections.xyxy,
+        tracker_ids,
+    ):
+        tracker_id = int(tracker_id_value)
+        x1, y1, x2, y2 = np.rint(xyxy).astype(int)
+
+        color = color_from_id(tracker_id)
+        label = str(tracker_id) if tracker_id >= 0 else "unmatched"
+
+        cv2.rectangle(
+            output,
+            (x1, y1),
+            (x2, y2),
+            color=color,
+            thickness=2,
+        )
+        cv2.putText(
+            output,
+            label,
+            (x1, max(y1 - 6, 0)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.65,
+            color,
+            2,
+            cv2.LINE_AA,
+        )
+
+    return output
+
+
+def draw_text_panel(
+    frame: np.ndarray,
+    lines: list[str],
+) -> np.ndarray:
+    """Draw readable status text in the top-left corner."""
+    output = frame.copy()
+    x = 20
+    initial_y = 30
+    line_height = 24
+
+    for line_index, line in enumerate(lines):
+        y = initial_y + line_index * line_height
+
+        cv2.putText(
+            output,
+            line,
+            (x, y),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.65,
+            (255, 255, 255),
+            3,
+            cv2.LINE_AA,
+        )
+        cv2.putText(
+            output,
+            line,
+            (x, y),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.65,
+            (0, 0, 0),
+            1,
+            cv2.LINE_AA,
+        )
+
+    return output
+
+
+def get_pending_tracklet_ids(
+    tracker: McByteTracker,
+) -> set[int]:
+    """Return pending mask IDs for visual debugging.
+
+    This visual test intentionally inspects MaskManager's internal lifecycle state.
+    """
+    if tracker.mask_manager is None:
+        return set()
+
+    return set(tracker.mask_manager._pending_tracklet_ids)
+
+
+def get_masked_tracklet_ids(
+    mask_output: MaskOutput | None,
+) -> set[int]:
+    """Return tracklet IDs represented in the current mask output."""
+    if mask_output is None or mask_output.masks is None:
+        return set()
+
+    return set(mask_output.tracklet_mask_dict)
+
+
+def visualize_frame(
+    *,
+    frame: np.ndarray,
+    frame_number: int,
+    mode_name: str,
+    input_detection_count: int,
+    tracked_detections: sv.Detections,
+    tracker: McByteTracker,
+    use_masks: bool,
+) -> np.ndarray:
+    """Create one complete comparison visualization frame."""
+    visual = frame.copy()
+
+    if use_masks:
+        visual = overlay_masks(
+            frame=visual,
+            mask_output=tracker._last_mask_output,
+        )
+
+    visual = draw_tracking_boxes(
+        frame=visual,
+        tracked_detections=tracked_detections,
+    )
+
+    tracker_ids = tracked_detections.tracker_id
+    valid_tracker_ids = (
+        [] if tracker_ids is None else sorted(int(tracker_id) for tracker_id in tracker_ids if tracker_id >= 0)
+    )
+
+    status_lines = [
+        f"Mode: {mode_name}",
+        f"Frame: {frame_number}",
+        f"Input detections: {input_detection_count}",
+        f"Output IDs: {valid_tracker_ids}",
+    ]
+
+    if use_masks:
+        status_lines.extend(
+            [
+                (f"Masks: {sorted(get_masked_tracklet_ids(tracker._last_mask_output))}"),
+                (f"Pending: {sorted(get_pending_tracklet_ids(tracker))}"),
+            ]
+        )
+
+    return draw_text_panel(
+        frame=visual,
+        lines=status_lines,
+    )
+
+
+def append_mot_results(
+    *,
+    results_file: TextIO,
+    frame_number: int,
+    tracked_detections: sv.Detections,
+) -> None:
+    """Append confirmed tracker outputs in MOTChallenge result format.
+
+    Detections with negative tracker IDs are omitted.
+    """
+    tracker_ids = tracked_detections.tracker_id
+    if tracker_ids is None:
+        return
+
+    confidences = tracked_detections.confidence
+    if confidences is None:
+        confidences = np.ones(len(tracked_detections), dtype=np.float32)
+
+    for xyxy, tracker_id_value, confidence_value in zip(
+        tracked_detections.xyxy,
+        tracker_ids,
+        confidences,
+    ):
+        tracker_id = int(tracker_id_value)
+        if tracker_id < 0:
+            continue
+
+        left, top, right, bottom = map(float, xyxy)
+        width = right - left
+        height = bottom - top
+        confidence = float(confidence_value)
+
+        results_file.write(
+            f"{frame_number},{tracker_id},{left:.2f},{top:.2f},{width:.2f},{height:.2f},{confidence:.6f},-1,-1,-1\n"
+        )
+
+
+def save_rgb_frame(
+    frame: np.ndarray,
+    output_path: Path,
+) -> None:
+    """Save an RGB frame through OpenCV."""
+    frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+
+    if not cv2.imwrite(str(output_path), frame_bgr):
+        raise RuntimeError(f"Could not save visualization: {output_path}")
+
+
+def run_mode(
+    *,
+    mode_name: str,
+    detections_by_frame: dict[int, list[DetectionRecord]],
+    image_dir: Path,
+    start_frame: int,
+    end_frame: int,
+    output_root: Path,
+    frame_rate: float,
+    device: str,
+    enable_cmc: bool,
+    cmc_method: CMCMethod,
+    cmc_downscale: int,
+    enable_isolated_mask_matching: bool,
+) -> None:
+    """Run one McByte configuration over the requested inclusive frame range.
+
+    Tracking results are written in MOTChallenge format and one annotated image is
+    saved for every processed frame.
+    """
+    use_masks = mode_name == "mask_conditioned"
+
+    print(f"\nRunning mode: {mode_name}")
+
+    frames_dir, results_path = prepare_run_directory(
+        output_root=output_root,
+        mode_name=mode_name,
+    )
+
+    tracker = create_tracker(
+        use_masks=use_masks,
+        frame_rate=frame_rate,
+        device=device,
+        enable_cmc=enable_cmc,
+        cmc_method=cmc_method,
+        cmc_downscale=cmc_downscale,
+        enable_isolated_mask_matching=enable_isolated_mask_matching,
+    )
+
+    total_frames = end_frame - start_frame + 1
+
+    with results_path.open("w", encoding="utf-8") as results_file:
+        for processed_index, frame_number in enumerate(
+            range(start_frame, end_frame + 1),
+            start=1,
+        ):
+            frame_path = find_frame_path(
+                image_dir=image_dir,
+                frame_number=frame_number,
+            )
+            frame = load_rgb_frame(frame_path)
+
+            input_detections = build_detections(detections_by_frame.get(frame_number, []))
+
+            tracked_detections = tracker.update(
+                detections=input_detections,
+                frame=frame,
+            )
+
+            append_mot_results(
+                results_file=results_file,
+                frame_number=frame_number,
+                tracked_detections=tracked_detections,
+            )
+
+            visual = visualize_frame(
+                frame=frame,
+                frame_number=frame_number,
+                mode_name=mode_name,
+                input_detection_count=len(input_detections),
+                tracked_detections=tracked_detections,
+                tracker=tracker,
+                use_masks=use_masks,
+            )
+
+            save_rgb_frame(
+                frame=visual,
+                output_path=frames_dir / f"{frame_number:06d}.jpg",
+            )
+
+            if processed_index == 1 or processed_index == total_frames or processed_index % 25 == 0:
+                print(f"[{mode_name}] frame {frame_number} ({processed_index}/{total_frames})")
+
+    tracker.reset()
+
+    print(f"[{mode_name}] Frames: {frames_dir}")
+    print(f"[{mode_name}] Results: {results_path}")
+
+
+def main() -> None:
+    """Run locked-IoU and full mask-conditioned McByte sequentially."""
+    args = parse_args()
+    validate_args(args)
+
+    detections_by_frame = read_detection_file(
+        det_file=args.det_file,
+        detection_format=cast(DetectionFileFormat, args.det_format),
+    )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Image directory: {args.image_dir}")
+    print(f"Detection file: {args.det_file}")
+    print(f"Detection format: {args.det_format}")
+    print(f"Frame range: {args.start_frame} to {args.end_frame} (inclusive)")
+    print(f"Output root: {args.output_dir}")
+
+    for mode_name in args.modes:
+        run_mode(
+            mode_name=mode_name,
+            detections_by_frame=detections_by_frame,
+            image_dir=args.image_dir,
+            start_frame=args.start_frame,
+            end_frame=args.end_frame,
+            output_root=args.output_dir,
+            frame_rate=args.frame_rate,
+            device=args.device,
+            enable_cmc=args.enable_cmc,
+            cmc_method=args.cmc_method,
+            cmc_downscale=args.cmc_downscale,
+            enable_isolated_mask_matching=(args.enable_isolated_mask_matching),
+        )
+
+    print("\nFinished selected McByte comparison run(s).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What does this PR do?

This PR completes the core McByte tracker by adding mask-conditioned association and integrating it into the complete ByteTrack-style multi-stage tracking pipeline.

McByte first identifies clear threshold-valid associations that are unique for both their tracklet and detection. These matches are locked and removed from the remaining assignment problem. For ambiguous associations, propagated mask evidence is used to condition the corresponding similarity scores before linear assignment.

Mask evidence is accepted only when the propagated mask satisfies the configured average-confidence, mask-coverage and mask-fill-ratio thresholds. The qualifying mask fill ratio is added directly to the association score without clamping.

An optional isolated-mask-matching mode is also introduced. When enabled, mask evidence may recover an isolated pair with positive IoU that remains below the normal association threshold.

The same association procedure is integrated consistently into:

- high-confidence association with confirmed and lost tracklets;
- low-confidence association with remaining tracked tracklets;
- association of unconfirmed tracklets with remaining high-confidence detections (lock matches only, no masks for unconfirmed tracklets).

The tracker can also operate without a `MaskManager`. In that configuration, it still applies McByte clear-match locking and reduced assignment, but without mask-based score conditioning.

Main additions:

- Added clear-match locking for threshold-valid associations that are unique in both their row and column
- Added reduced association after removing locked tracklet and detection pairs
- Added mask-conditioned similarity updates for ambiguous associations
- Added configurable mask-quality thresholds:
  - minimum propagated-mask average confidence
  - minimum mask coverage inside a detection
  - minimum mask fill ratio inside a detection
- Added optional recovery of isolated positive-IoU associations below the normal threshold
- Integrated mask-conditioned association into two first McByte association stages (no masks for unconfirmed tracklets).
- Added explicit configuration for constructing the default SAM + Cutie mask pipeline
- Added support for injecting a custom `MaskManager`
- Preserved masks for temporarily lost tracklets until the tracklets are explicitly terminated
- Updated and expanded the `McByteTracker` docstring
- Added extensive unit tests for mask-conditioned association and tracker integration
- Added a sequence-level visual comparison script:
  - `visualize_mcbyte_from_detections.py`
- Added a complete benchmark example runner:
  - `run_mcbyte_benchmarks_example.py`

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

Added unit tests covering:

- Computation of mask coverage and mask fill ratio
- Clear-match locking and removal from the remaining assignment problem
- Ambiguity arising from multiple eligible candidates in a row
- Ambiguity arising from multiple eligible candidates in a column
- Independent mask conditioning of multiple ambiguous associations
- Preservation of the original matrix when determining ambiguity
- Preservation and remapping of original tracklet and detection indices
- Combination of locked matches with matches from the reduced assignment problem
- Remapping of unmatched tracklet and detection indices
- Mask bonuses above `1.0` without clamping
- Missing mask outputs
- Missing tracklet-to-mask mappings
- Invalid mask indices
- Empty and invisible masks
- Invalid mask dimensions and input matrix shapes
- Minimum propagated-mask confidence
- Minimum mask coverage
- Minimum mask fill ratio
- Isolated positive-IoU matching below the normal association threshold
- Disabled isolated-mask-matching behavior
- Use of raw IoU, rather than score-fused similarity, for isolation detection
- Mask-conditioned integration in the first association stage
- Mask-conditioned integration in the second association stage
- Mask-conditioned integration for unconfirmed tracklets
- Tracker mask lifecycle and explicit mask removal
- Retention of masks for temporarily lost tracklets
- Tracker reset behavior
- Construction of the default SAM + Cutie `MaskManager`
- Injection of a custom `MaskManager`
- Validation of incompatible mask-manager configuration options

Manual validation:

- Compared mask-free locked-IoU McByte and full mask-conditioned McByte on complete video sequences
- Verified propagated-mask overlays and tracklet-mask mappings
- Verified MOTChallenge-format result generation
- Verified parsing of SoccerNet MOT-style detections
- Verified parsing of XYXY detections used by MOT17, DanceTrack and SportsMOT
- Ran complete benchmark evaluations on MOT17, DanceTrack, SportsMOT and SoccerNet-tracking
- Verified that each benchmark sequence uses a fresh tracker
- Verified tracker cleanup and CUDA cache release between sequences
- Verified failure recording and continuation with the remaining sequences
- Verified generation of MOT17 submission files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ]  [Docstrings only, McByte is not yet merged into the `develop` branch] I have updated the documentation accordingly (if applicable)

## Additional Context

This PR builds directly on the previous seven McByte PRs (#388 #418 #441 #452 #459 #481 #491)  and completes the main McByte tracking pipeline.

The complete processing flow is now:

`Detections ---> Kalman prediction ---> Optional camera motion compensation ---> Multi-stage IoU association ---> Clear-match locking ---> Mask-conditioned ambiguous association ---> Reduced linear assignment ---> Tracklet lifecycle update`

With mask management enabled, the frame-level mask flow is:

`Previous tracker state ---> MaskManager ---> SAM mask initialization / Cutie mask propagation ---> Mask-conditioned association on the current frame ---> Current tracker state stored for the next frame`

Clear associations are preserved before mask conditioning. Mask evidence is applied only to ambiguous candidates and, optionally, to isolated positive-IoU candidates below the normal association threshold.


**Important remark:
The default value of `minimum_iou_threshold_first_assoc` (minimum association similarity for matching high-confidence detections to confirmed and lost tracks) is now set to ``0.1``. It is intentionally lower than in BoT-SORT and other trackers as now it not only rejects unlikely track-detection pairs, but also allows mask-conditioned association to evaluate a set of plausible candidates before resolving ambiguities and optional isolations.**

### Visual comparison script

`visualize_mcbyte_from_detections.py` compares two configurations:

1. `locked_iou`
   - McByte clear-match locking and reduced assignment
   - no mask manager

2. `mask_conditioned`
   - complete McByte
   - SAM mask initialization
   - Cutie mask propagation
   - clear-match locking
   - mask-conditioned association

Both configurations produce:

- per-frame visualizations;
- MOTChallenge-format tracking results.

The mask-conditioned configuration additionally displays propagated masks and mask lifecycle information.

The script supports two detection formats:

- `mot_tlwh`:
  `frame,id,left,top,width,height,confidence,...`
- `xyxy`:
  `frame,x1,y1,x2,y2,confidence`

#### SoccerNet-tracking example

```
python visual_tests/visualize_mcbyte_from_detections.py \
  --image-dir /path/to/SoccerNet/tracking/test/SNMOT-128/img1 \
  --det-file /path/to/SoccerNet/tracking/test/SNMOT-128/det/det.txt \
  --det-format mot_tlwh \
  --start-frame 1 \
  --end-frame 100 \
  --frame-rate 30 \
  --device cuda \
  --output-dir visual_tests/outputs/SNMOT-128
```

#### MOT17 example

```
python visual_tests/visualize_mcbyte_from_detections.py \
  --image-dir /path/to/MOT17/test/MOT17-01-FRCNN/img1 \
  --det-file /path/to/detections/MOT17/test/MOT17-01.txt \
  --det-format xyxy \
  --start-frame 1 \
  --end-frame 100 \
  --frame-rate 30 \
  --device cuda \
  --output-dir visual_tests/outputs/MOT17-01
```

#### DanceTrack example

```
python visual_tests/visualize_mcbyte_from_detections.py \
  --image-dir /path/to/dancetrack/test/dancetrack0003/img1 \
  --det-file /path/to/detections/dancetrack/test/dancetrack0003.txt \
  --det-format xyxy \
  --start-frame 1 \
  --end-frame 100 \
  --frame-rate 30 \
  --device cuda \
  --output-dir visual_tests/outputs/dancetrack0003
```

#### SportsMOT example

```
python visual_tests/visualize_mcbyte_from_detections.py \
  --image-dir /path/to/sportsmot/test/v_-9kabh1K8UA_c008/img1 \
  --det-file /path/to/detections/sportsmot/test/v_-9kabh1K8UA_c008.txt \
  --det-format xyxy \
  --start-frame 1 \
  --end-frame 100 \
  --frame-rate 30 \
  --device cuda \
  --output-dir visual_tests/outputs/sportsmot_v_-9kabh1K8UA_c008
```

By default, both comparison modes are executed. Individual modes can be selected using `--modes`.

Camera motion compensation can be enabled using `--enable-cmc`.

Isolated positive-IoU matching can be enabled using -`-enable-isolated-mask-matching`.

### Complete benchmark runner

Before running the benchmark script, the `detection_root` and `image_root` entries in the DATASETS dictionary must be configured according to the local dataset organization.

To run all configured datasets from the script directory:

```
cd src/trackers/scripts

python run_mcbyte_benchmarks_example.py \
  --enable-isolated-mask-matching
```

This creates the benchmark output directory relative to:

`src/trackers/scripts/
`
Specific datasets can be selected by repeating `--dataset`:

```
cd src/trackers/scripts

python run_mcbyte_benchmarks_example.py \
  --enable-isolated-mask-matching \
  --dataset mot17 \
  --dataset dancetrack \
  --dataset sportsmot \
  --dataset soccernet
```

The script can alternatively be run from the repository root:

```
python src/trackers/scripts/run_mcbyte_benchmarks_example.py \
  --enable-isolated-mask-matching
```

In that case, the default output directory is created relative to the repository root.

Each benchmark sequence is processed independently using a fresh McByte tracker. Results are first written to a temporary `.partial` file and moved to the final output only after successful sequence completion. Failures are recorded without stopping the remaining benchmark sequences.

### Benchmark results

The following results compare **McByte** against **BoT-SORT without re-identification** in Trackers, which serves as the baseline implementation for McByte in Trackers.

Both trackers use their **default parameters**, without any dataset-specific tuning.

#### DanceTrack

| Tracker | HOTA | IDF1 | MOTA |
|:--------|-----:|-----:|-----:|
| BoT-SORT | 57.8 | 57.9 | 92.2 |
| **McByte** | **67.2** | **68.6** | **92.5** |

#### SportsMOT

| Tracker | HOTA | IDF1 | MOTA |
|:--------|-----:|-----:|-----:|
| BoT-SORT | 73.8 | 73.4 | 96.9 |
| **McByte** | **76.5** | **76.9** | **97.0** |

#### SoccerNet-tracking

| Tracker | HOTA | IDF1 | MOTA |
|:--------|-----:|-----:|-----:|
| BoT-SORT | 84.5 | 79.3 | 96.6 |
| **McByte** | **85.0** | **79.9** | **97.0** |

#### MOT17

| Tracker | HOTA | IDF1 | MOTA |
|:--------|-----:|-----:|-----:|
| BoT-SORT | 63.7 | 78.7 | **79.2** |
| **McByte** | **64.1** | **79.7** | 79.1 |

No additional external dependencies beyond those introduced by the previous SAM and Cutie integration PRs (#441 #452) are required.

As described in the previous mask-model integration PRs, the required model weights are downloaded automatically when no explicit checkpoint paths are supplied.

Tested on GPU using CUDA 12.6 and separate Anaconda environments.