### PR TITLE
fix(ocsort): keep Kalman scale positive across frame-step gaps

### DIFF
--- a/docs/learn/dynamic-frame-rate.md
+++ b/docs/learn/dynamic-frame-rate.md
@@ -67,6 +67,7 @@ On each predict, the filter adjusts how far it extrapolates and how uncertain it
 
 - **Position** moves with constant velocity, scaled by the difference in timestamps scaled by the previous frame rate (`frame_step`).
 - **Process noise** grows on longer gaps so the box does not stay artificially tight. At `frame_step = 1.0` you get the same as with default usage. On bigger steps the library rescales noise the way a constant-velocity model expects (stronger growth on position than velocity), instead of naively multiplying a one-frame matrix by Δt.
+- **Scale velocity** is frozen if the projected area over the gap would go non-positive.
 
 ---
 

--- a/src/trackers/utils/state_representations.py
+++ b/src/trackers/utils/state_representations.py
@@ -130,11 +130,17 @@ class BaseStateEstimator(ABC):
         """
 
     @abstractmethod
-    def clamp_velocity(self) -> None:
+    def clamp_velocity(self, frame_step: float = 1.0) -> None:
         """Clamp velocity components to prevent degenerate predictions.
 
         Called before `predict` to ensure physical plausibility
         (e.g. non-negative scale). Modifies the filter state in-place.
+
+        Args:
+            frame_step: Elapsed time in frame units for the upcoming predict.
+                The guard must consider the *projected* state over this step
+                (state + frame_step * velocity), because `predict` extrapolates
+                by `frame_step`, not by a single nominal frame.
         """
 
     def predict(self, frame_step: float = 1.0) -> None:
@@ -145,7 +151,7 @@ class BaseStateEstimator(ABC):
                 frame. Pass a larger value after a gap between updates so the
                 filter extrapolates further and widens process noise accordingly.
         """
-        self.clamp_velocity()
+        self.clamp_velocity(frame_step)
         self.motion.apply(self.kf, frame_step)
         self.kf.predict()
 
@@ -237,8 +243,18 @@ class XCYCSRStateEstimator(BaseStateEstimator):
     def state_to_bbox(self) -> np.ndarray:
         return xcycsr_to_xyxy(self.kf.state[:4].reshape((4,)))
 
-    def clamp_velocity(self) -> None:
-        if (self.kf.state[6] + self.kf.state[2]) <= 0:
+    def clamp_velocity(self, frame_step: float = 1.0) -> None:
+        """Freeze scale velocity when the projected scale would turn non-positive.
+
+        ``predict`` extrapolates scale as ``s + frame_step * vs``. A negative
+        ``vs`` that passes the one-frame check (``s + vs > 0``) can still drive
+        the projection non-positive over a gap (``frame_step > 1``), and
+        ``xcycsr_to_xyxy`` decodes a non-positive scale as NaN.
+
+        Args:
+            frame_step: Elapsed time in frame units for the upcoming predict.
+        """
+        if (self.kf.state[2] + frame_step * self.kf.state[6]) <= 0:
             self.kf.state[6] = 0.0
 
 
@@ -269,7 +285,7 @@ class XCYCWHStateEstimator(BaseStateEstimator):
     def state_to_bbox(self) -> np.ndarray:
         return xywh_to_xyxy(self.kf.state[:4].reshape((4,)))
 
-    def clamp_velocity(self) -> None:
+    def clamp_velocity(self, frame_step: float = 1.0) -> None:
         pass
 
 
@@ -295,7 +311,7 @@ class XYXYStateEstimator(BaseStateEstimator):
     def state_to_bbox(self) -> np.ndarray:
         return self.kf.state[:4].reshape((4,))
 
-    def clamp_velocity(self) -> None:
+    def clamp_velocity(self, frame_step: float = 1.0) -> None:
         pass
 
 

--- a/src/trackers/utils/state_representations.py
+++ b/src/trackers/utils/state_representations.py
@@ -249,11 +249,16 @@ class XCYCSRStateEstimator(BaseStateEstimator):
         ``predict`` extrapolates scale as ``s + frame_step * vs``. A negative
         ``vs`` that passes the one-frame check (``s + vs > 0``) can still drive
         the projection non-positive over a gap (``frame_step > 1``), and
-        ``xcycsr_to_xyxy`` decodes a non-positive scale as NaN.
+        ``xcycsr_to_xyxy`` decodes a non-positive scale as NaN. If the motion
+        model stops being linear in scale, this clamp should be revisited.
 
         Args:
             frame_step: Elapsed time in frame units for the upcoming predict.
         """
+        # Clamp is intentionally hard: if the projected scale would go non-positive, we
+        # freeze vs to 0 instead of soft-clamping to keep behavior simple and defensive.
+        # Growth is unchecked here by design; any resulting non-finite boxes are caught by
+        # BaseIoU.compute()'s np.isfinite guard (iou.py:62-65).
         if (self.kf.state[2] + frame_step * self.kf.state[6]) <= 0:
             self.kf.state[6] = 0.0
 
@@ -286,7 +291,13 @@ class XCYCWHStateEstimator(BaseStateEstimator):
         return xywh_to_xyxy(self.kf.state[:4].reshape((4,)))
 
     def clamp_velocity(self, frame_step: float = 1.0) -> None:
-        pass
+        """Ignore `frame_step`; kept for interface compatibility.
+
+        No-op by design: unlike XCYCSR, this representation has no sqrt-decode
+        step, so a negative projected `w`/`h` over a large gap yields a
+        finite (not NaN) inverted box rather than crashing. This pre-existing
+        gap is tracked separately, out of scope for the frame_step clamp fix.
+        """
 
 
 class XYXYStateEstimator(BaseStateEstimator):
@@ -312,7 +323,7 @@ class XYXYStateEstimator(BaseStateEstimator):
         return self.kf.state[:4].reshape((4,))
 
     def clamp_velocity(self, frame_step: float = 1.0) -> None:
-        pass
+        """Ignore `frame_step`; kept for interface compatibility because XYXY-style velocity is unconstrained."""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_timestamp_plumbing.py
+++ b/tests/core/test_timestamp_plumbing.py
@@ -491,6 +491,16 @@ def test_same_confirmation_pattern_at_reference_fps(
             {"state_estimator_class": XCYCSRStateEstimator},
             id="bytetrack-xcycsr",
         ),
+        pytest.param(
+            BoTSORTTracker,
+            {"state_estimator_class": XCYCSRStateEstimator, "enable_cmc": False},
+            id="botsort-xcycsr",
+        ),
+        pytest.param(
+            CBIoUTracker,
+            {"state_estimator_class": XCYCSRStateEstimator},
+            id="cbiou-xcycsr",
+        ),
     ],
 )
 def test_xcycsr_shrinking_box_survives_timestamp_gap_without_nan(
@@ -521,9 +531,11 @@ def test_xcycsr_shrinking_box_survives_timestamp_gap_without_nan(
         w *= 0.97
         h *= 0.97
 
+    # NOTE: Large frame-step gaps may trigger pre-existing Kalman covariance RuntimeWarnings in dt^4 propagation; this is intentionally out of scope.
     # Half-second gap: frame_step = 15, well within the lost-track horizon.
     result = tracker.update(sv.Detections.empty(), timestamp=t + 0.5)
 
     assert result is not None
+    assert len(tracker.tracks) > 0, "Tracker lost all tracks after timestamp gap"
     for tracklet in tracker.tracks:
         assert np.all(np.isfinite(tracklet.get_state_bbox()))

--- a/tests/core/test_timestamp_plumbing.py
+++ b/tests/core/test_timestamp_plumbing.py
@@ -29,6 +29,7 @@ from trackers.core.ocsort.tracklet import OCSORTTracklet
 from trackers.core.sort.tracker import SORTTracker
 from trackers.core.sort.tracklet import SORTTracklet
 from trackers.utils.base_tracklet import BaseTracklet
+from trackers.utils.state_representations import XCYCSRStateEstimator
 
 TIMESTAMP_AWARE_TRACKERS: list[Any] = [
     pytest.param(SORTTracker, SORTTracklet, {}, id="sort"),
@@ -474,3 +475,55 @@ def test_same_confirmation_pattern_at_reference_fps(
     fixed_pattern = _confirmation_pattern(tracker_cls, tracklet_cls, extra_kwargs, use_timestamps=False)
     dynamic_pattern = _confirmation_pattern(tracker_cls, tracklet_cls, extra_kwargs, use_timestamps=True)
     assert fixed_pattern == dynamic_pattern
+
+
+@pytest.mark.parametrize(
+    ("tracker_cls", "extra_kwargs"),
+    [
+        pytest.param(OCSORTTracker, {}, id="ocsort-default-xcycsr"),
+        pytest.param(
+            SORTTracker,
+            {"state_estimator_class": XCYCSRStateEstimator},
+            id="sort-xcycsr",
+        ),
+        pytest.param(
+            ByteTrackTracker,
+            {"state_estimator_class": XCYCSRStateEstimator},
+            id="bytetrack-xcycsr",
+        ),
+    ],
+)
+def test_xcycsr_shrinking_box_survives_timestamp_gap_without_nan(
+    tracker_cls: type[BaseTracker], extra_kwargs: dict[str, Any]
+) -> None:
+    """A shrinking box plus a sub-second timestamp gap must not crash XCYCSR trackers.
+
+    The XCYCSR filter tracks scale (area) with a velocity term. A box that
+    shrinks each frame builds a negative scale velocity ``vs`` that still passes
+    the one-frame guard (``s + vs > 0``). In timestamp mode a gap produces
+    ``frame_step = elapsed * frame_rate > 1``, and ``predict`` extrapolates scale
+    as ``s + frame_step * vs``. Guarding only the one-frame case let the scale go
+    negative, so ``xcycsr_to_xyxy`` took ``sqrt`` of it and emitted NaN boxes,
+    crashing association with ``ValueError: boxes_1 contains non-finite values``.
+    The clamp now guards the projected scale over ``frame_step``. OC-SORT uses
+    XCYCSR by default; SORT and ByteTrack hit the same path when configured
+    with it.
+    """
+    params: dict[str, Any] = {"frame_rate": 30.0, **extra_kwargs}  # defaults otherwise
+    tracker = tracker_cls(**params)
+    fps = 30.0
+    t = 0.0
+    w, h = 120.0, 260.0
+    for _ in range(8):  # establish a shrinking track -> negative scale velocity
+        x1, y1 = 500 - w / 2, 300 - h / 2
+        tracker.update(_make_detections([[x1, y1, x1 + w, y1 + h]], [0.9]), timestamp=t)
+        t += 1.0 / fps
+        w *= 0.97
+        h *= 0.97
+
+    # Half-second gap: frame_step = 15, well within the lost-track horizon.
+    result = tracker.update(sv.Detections.empty(), timestamp=t + 0.5)
+
+    assert result is not None
+    for tracklet in tracker.tracks:
+        assert np.all(np.isfinite(tracklet.get_state_bbox()))

--- a/tests/core/test_timestamp_plumbing.py
+++ b/tests/core/test_timestamp_plumbing.py
@@ -130,7 +130,7 @@ def test_explicit_none_timestamp_matches_omitted(
     t2 = _make_timestamp_aware_tracker(tracker_cls, tracklet_cls, extra_kwargs, frame_rate=frame_rate)
     r2 = t2.update(_DET, timestamp=None)
 
-    assert list(r1.tracker_id) == list(r2.tracker_id)
+    assert r1.tracker_id is not None and r2.tracker_id is not None and list(r1.tracker_id) == list(r2.tracker_id)
 
 
 @pytest.mark.parametrize(
@@ -456,7 +456,7 @@ def _confirmation_pattern(
     for i in range(n_frames):
         ts = i / frame_rate if use_timestamps else None
         result = tracker.update(_DET, timestamp=ts)
-        if len(result.tracker_id):
+        if result.tracker_id is not None and len(result.tracker_id):
             confirmed.append(int(result.tracker_id[0]) >= 0)
         else:
             confirmed.append(False)
@@ -531,7 +531,8 @@ def test_xcycsr_shrinking_box_survives_timestamp_gap_without_nan(
         w *= 0.97
         h *= 0.97
 
-    # NOTE: Large frame-step gaps may trigger pre-existing Kalman covariance RuntimeWarnings in dt^4 propagation; this is intentionally out of scope.
+    # NOTE: Large frame-step gaps may trigger pre-existing Kalman covariance
+    # RuntimeWarnings in dt^4 propagation; this is intentionally out of scope.
     # Half-second gap: frame_step = 15, well within the lost-track horizon.
     result = tracker.update(sv.Detections.empty(), timestamp=t + 0.5)
 

--- a/tests/utils/test_state_estimators.py
+++ b/tests/utils/test_state_estimators.py
@@ -84,3 +84,101 @@ def test_xcycsr_clamp_velocity_guards_projected_scale_over_frame_step(
     est.clamp_velocity(20.0)
 
     assert est.kf.state[6] == pytest.approx(expected_scale_velocity)
+
+
+def test_xcycsr_clamp_velocity_exact_zero_projection_bound() -> None:
+    est = XCYCSRStateEstimator(BBOX.copy())
+    est.kf.state[2] = 1000.0
+    est.kf.state[6] = -100.0  # 1000.0 + 10.0 * -100.0 == 0.0
+
+    est.clamp_velocity(10.0)
+
+    assert est.kf.state[6] == pytest.approx(0.0)
+    assert est.kf.state[2] + 10.0 * est.kf.state[6] > 0.0
+
+
+def test_xcycsr_clamp_velocity_large_gap_growing_box_keeps_state_unchanged() -> None:
+    est = XCYCSRStateEstimator(BBOX.copy())
+    before = est.kf.state.copy()
+
+    est.kf.state[0] = 12.0
+    est.kf.state[1] = 14.0
+    est.kf.state[2] = 1000.0
+    est.kf.state[3] = 0.75
+    est.kf.state[4] = 50.0
+    est.kf.state[5] = -30.0
+    est.kf.state[6] = 200.0
+    before = est.kf.state.copy()
+
+    est.clamp_velocity(10.0)
+
+    np.testing.assert_array_equal(est.kf.state, before)
+
+
+def test_xcycsr_clamp_velocity_large_gap_shrink_mutates_only_scale_velocity() -> None:
+    est = XCYCSRStateEstimator(BBOX.copy())
+    est.kf.state[0] = 24.0
+    est.kf.state[1] = 27.0
+    est.kf.state[2] = 1000.0
+    est.kf.state[3] = 1.25
+    est.kf.state[4] = 10.0
+    est.kf.state[5] = 20.0
+    est.kf.state[6] = -100.0
+    before = est.kf.state.copy()
+
+    est.clamp_velocity(20.0)
+
+    assert est.kf.state[6] == pytest.approx(0.0)
+    np.testing.assert_array_equal(est.kf.state[:6], before[:6])
+
+
+def test_xcycsr_clamp_velocity_fractional_frame_step() -> None:
+    est = XCYCSRStateEstimator(BBOX.copy())
+    est.kf.state[2] = 1000.0
+    est.kf.state[6] = -1500.0  # 1000.0 + 0.5 * -1500.0 == 250.0 (still positive)
+
+    est.clamp_velocity(0.5)
+
+    assert est.kf.state[6] == pytest.approx(-1500.0)
+    assert est.kf.state[2] + 0.5 * est.kf.state[6] == pytest.approx(250.0)
+
+
+def test_xcycsr_clamp_velocity_single_frame_step_regression() -> None:
+    legacy_like = XCYCSRStateEstimator(BBOX.copy())
+    explicit_step = XCYCSRStateEstimator(BBOX.copy())
+
+    for est in (legacy_like, explicit_step):
+        est.kf.state[2] = 1000.0
+        est.kf.state[6] = -1200.0
+
+    legacy_like.clamp_velocity()
+    explicit_step.clamp_velocity(1.0)
+
+    assert legacy_like.kf.state[6] == pytest.approx(0.0)
+    assert legacy_like.kf.state[6] == explicit_step.kf.state[6]
+
+
+def test_xcycsr_clamp_velocity_unfixed_skip_for_zero_negative_nan_inf_steps() -> None:
+    # This intentionally documents current estimator behavior when callers pass
+    # edge-case frame steps directly to clamp_velocity: NaN comparisons are
+    # always False in Python, so the clamp guard is skipped and velocity is not
+    # reset. This remains safe for tracker runtime because base.py filters these
+    # values before invoking predict()/clamp_velocity.
+    est = XCYCSRStateEstimator(BBOX.copy())
+    est.kf.state[2] = 1000.0
+    est.kf.state[6] = -1200.0
+    est.clamp_velocity(1.0)
+    assert est.kf.state[6] == pytest.approx(0.0)
+
+    for frame_step, scale_velocity in [
+        (0.0, 1200.0),
+        (-2.0, -1200.0),
+        (float("nan"), 1200.0),
+        (float("inf"), 1200.0),
+    ]:
+        est = XCYCSRStateEstimator(BBOX.copy())
+        est.kf.state[2] = 1000.0
+        est.kf.state[6] = scale_velocity
+        est.clamp_velocity(frame_step)
+
+        assert est.kf.state[6] == pytest.approx(scale_velocity)

--- a/tests/utils/test_state_estimators.py
+++ b/tests/utils/test_state_estimators.py
@@ -58,3 +58,29 @@ def test_set_state_resets_motion_cache(
     est.set_state(state)
 
     assert est.motion.cached_step is None
+
+
+@pytest.mark.parametrize(
+    ("scale_velocity", "expected_scale_velocity"),
+    [
+        pytest.param(-100.0, 0.0, id="projection-non-positive-frozen"),
+        pytest.param(-10.0, -10.0, id="projection-positive-preserved"),
+    ],
+)
+def test_xcycsr_clamp_velocity_guards_projected_scale_over_frame_step(
+    scale_velocity: float, expected_scale_velocity: float
+) -> None:
+    """``clamp_velocity`` guards the *projected* scale ``s + frame_step * vs``.
+
+    A negative scale velocity that passes the one-frame check (``s + vs > 0``)
+    used to extrapolate scale below zero over a gap, and ``xcycsr_to_xyxy``
+    then took ``sqrt`` of a negative scale -> NaN boxes. The guard must fire
+    on a non-positive projection and stay out of the way otherwise.
+    """
+    est = XCYCSRStateEstimator(BBOX.copy())
+    est.kf.state[2] = 1000.0  # scale (area); s + vs > 0, so the one-frame check passes
+    est.kf.state[6] = scale_velocity  # s + 20 * vs: -1000 (fires) vs 800 (preserved)
+
+    est.clamp_velocity(20.0)
+
+    assert est.kf.state[6] == pytest.approx(expected_scale_velocity)


### PR DESCRIPTION
## What breaks

`OCSORTTracker.update(..., timestamp=...)` raises `ValueError: boxes_1 contains non-finite values (NaN or inf)` with default parameters when a tracked box has been shrinking and then a frame is dropped. This is a common case in any variable-FPS or RTSP source: a person walking away from the camera, then a short gap.

Minimal repro on `develop`, default config (XCYCSR):

```python
tracker = OCSORTTracker()  # frame_rate=30, XCYCSRStateEstimator
t, w, h = 0.0, 120.0, 260.0
for _ in range(8):                              # shrinking box -> negative scale velocity
    x1, y1 = 500 - w / 2, 300 - h / 2
    tracker.update(det([x1, y1, x1 + w, y1 + h]), timestamp=t)
    t += 1 / 30; w *= 0.97; h *= 0.97
tracker.update(sv.Detections.empty(), timestamp=t + 0.5)   # 0.5s gap -> ValueError
```

## Root cause

`BaseStateEstimator.predict(frame_step)` extrapolates the state over `frame_step`, so the scale advances as `s + frame_step * vs`:

```python
def predict(self, frame_step: float = 1.0) -> None:
    self.clamp_velocity()                 # guards only the one-frame case
    self.motion.apply(self.kf, frame_step)
    self.kf.predict()
```

But `XCYCSRStateEstimator.clamp_velocity` only checked one nominal frame:

```python
if (self.kf.state[6] + self.kf.state[2]) <= 0:   # s + vs
    self.kf.state[6] = 0.0
```

In timestamp mode `frame_step = elapsed * frame_rate` has no cap (`core/base.py`) and `predict` runs once with it. A shrinking box builds a negative scale velocity `vs` that still passes the one-frame guard (`s + vs > 0`), and then a gap below one second is enough to make `s + frame_step * vs < 0`. `xcycsr_to_xyxy` decodes a non-positive scale as `NaN` — this is intentional and tested (`test_xcycsr_to_xyxy_negative_scale`), so keeping the scale positive is the responsibility of `clamp_velocity`. The `NaN` box then fails the finite-input check in `iou.compute` (`utils/iou.py`).

The guard is older than the `frame_step` parameter that dynamic frame rate (#446) added to `predict`, it was never updated to match it.

## Fix

Clamp using the projected scale over the actual step:

```python
def clamp_velocity(self, frame_step: float = 1.0) -> None:
    if (self.kf.state[2] + frame_step * self.kf.state[6]) <= 0:
        self.kf.state[6] = 0.0
```

`frame_step` is passed through the abstract method and the three estimators, and `predict` forwards it. At `frame_step == 1` the condition is the same as before, so fixed-rate behaviour does not change — the `ocsort` golden integration metrics (DanceTrack 78.004, SportsMOT 83.862) stay identical. The only path that changes is the timestamp-mode path that currently crashes.

## Scope

XCYCSR is the default estimator of OC-SORT, so OC-SORT crashes with the default config. `SORTTracker` and `ByteTrackTracker` crash in the same way when configured with `state_estimator_class=XCYCSRStateEstimator` (both verified, the regression test covers the three cases). BoT-SORT and C-BIoU also accept XCYCSR but they don't crash: `BoTSORTTracklet._clamp_state_bbox` floors scale and ratio at `1e-3` after every predict (`core/botsort/tracklet.py`), so a gap collapses the box to near-zero area instead of `NaN`. With the projected guard the box keeps its size through the gap. Their default `XCYCWHStateEstimator` has no `sqrt` in `state_to_bbox`, and its `clamp_velocity` stays a no-op.

## Tests

- `test_xcycsr_shrinking_box_survives_timestamp_gap_without_nan` — the repro above through the public API, parametrized over OC-SORT (default config), SORT and ByteTrack with XCYCSR. It reproduces the exact `ValueError` on `develop` in the three cases.
- `test_xcycsr_clamp_velocity_guards_projected_scale_over_frame_step` — the guard at the estimator level, parametrized in both directions: it freezes the velocity when the projection is non-positive, and it preserves the velocity otherwise.

All five fail on `develop` and pass with the fix, and the CI suite (`pytest -m "not integration"`) is green (945 passed, 5 skipped).
