### PR TITLE
fix(mcbyte): emit unmatched high-conf detections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ mask = [
     "torch",
     "torchvision",
     "rf-segment-anything==1.0",
-    "rf-cutie==1.0.0rc2",
+    "rf-cutie==1.0.0",
 ]
 
 [project.scripts]

--- a/src/trackers/core/mcbyte/mask_association.py
+++ b/src/trackers/core/mcbyte/mask_association.py
@@ -55,6 +55,15 @@ def _validate_inputs(
     if similarity.ndim != 2:
         raise ValueError(f"similarity must be a two-dimensional matrix. Got shape {similarity.shape}.")
 
+    # Mask evidence is accumulated in place with ``+= mask_fill_ratio``. On an
+    # integer matrix numpy truncates the float right-hand side to 0, silently
+    # discarding the boost, so a floating-point dtype is required.
+    if not np.issubdtype(similarity.dtype, np.floating):
+        raise ValueError(
+            "similarity must have a floating-point dtype so mask evidence can be "
+            f"accumulated without truncation. Got dtype {similarity.dtype}."
+        )
+
     if raw_iou_similarity.shape != similarity.shape:
         raise ValueError(
             "raw_iou_similarity must have the same shape as similarity. "

--- a/src/trackers/core/mcbyte/mask_manager.py
+++ b/src/trackers/core/mcbyte/mask_manager.py
@@ -32,6 +32,40 @@ def _intersection_area(box_a: np.ndarray, box_b: np.ndarray) -> float:
     return max(x2 - x1, 0.0) * max(y2 - y1, 0.0)
 
 
+def _validate_mask_resolution(
+    mask_output: MaskOutput,
+    frame: np.ndarray,
+) -> None:
+    """Ensure propagated masks share the frame's pixel grid.
+
+    McByte mask-conditioning (:func:`condition_similarity_with_masks`) measures
+    mask coverage and fill ratio in ``mask.shape`` pixel space while detection
+    boxes are expressed in original-frame pixels. The two only agree when the
+    propagated masks have the same height and width as ``frame``. A propagator
+    that internally resizes or pads without upsampling back would silently gate
+    associations in the wrong coordinate space, so the invariant is enforced
+    explicitly.
+
+    Args:
+        mask_output: Propagated mask output returned by the mask propagator.
+        frame: Current frame whose ``(H, W)`` the masks must match.
+
+    Raises:
+        ValueError: If the masks' trailing two dimensions differ from the
+            frame's height and width.
+    """
+    if mask_output.masks is None:
+        return
+
+    frame_hw = frame.shape[:2]
+    mask_hw = mask_output.masks.shape[-2:]
+    if mask_hw != frame_hw:
+        raise ValueError(
+            "Propagated masks must match the frame resolution. "
+            f"Got mask (H, W)={tuple(mask_hw)} for frame (H, W)={tuple(frame_hw)}."
+        )
+
+
 def _get_tracklets_with_lower_bottom(
     tracklet: TrackletSnapshot,
     tracklets: list[TrackletSnapshot],
@@ -211,6 +245,7 @@ class MaskManager:
 
         propagated_output = self.mask_propagator.propagate(frame)
         if propagated_output is not None:
+            _validate_mask_resolution(propagated_output, frame)
             return propagated_output
 
         self._initialized = False

--- a/src/trackers/core/mcbyte/masks/cutie.py
+++ b/src/trackers/core/mcbyte/masks/cutie.py
@@ -113,10 +113,17 @@ def _image_to_torch(
     """
     # Normalize by dtype, not by pixel magnitude. A ``max() > 1`` heuristic
     # mis-scales a near-black uint8 frame whose brightest pixel is 0 or 1
-    # (treated as already-normalized and left un-divided). An integer frame is
-    # always 0-255 and divided by 255; a floating frame is assumed to be
-    # already in [0, 1] per the RGB contract.
-    is_integer_frame = np.issubdtype(frame.dtype, np.integer)
+    # (treated as already-normalized and left un-divided). An unsigned-integer
+    # frame is divided by its dtype maximum (uint8 -> 255, uint16 -> 65535) so
+    # wider integer types are not silently scaled as if they were 0-255. A
+    # floating frame is assumed to be already in [0, 1] per the RGB contract.
+    # Signed-integer frames have an ambiguous value range and are rejected.
+    if np.issubdtype(frame.dtype, np.signedinteger):
+        raise ValueError(
+            "Signed-integer frames are not supported: dtype "
+            f"{frame.dtype} has an ambiguous value range. Provide a uint8 or "
+            "uint16 frame, or a float frame already normalized to [0, 1]."
+        )
 
     frame_torch = (
         torch.from_numpy(frame.transpose(2, 0, 1))
@@ -127,8 +134,8 @@ def _image_to_torch(
         )
     )
 
-    if is_integer_frame:
-        frame_torch /= 255.0
+    if np.issubdtype(frame.dtype, np.unsignedinteger):
+        frame_torch /= float(np.iinfo(frame.dtype).max)
 
     return frame_torch
 

--- a/src/trackers/core/mcbyte/masks/cutie.py
+++ b/src/trackers/core/mcbyte/masks/cutie.py
@@ -111,6 +111,13 @@ def _image_to_torch(
     """Convert an RGB frame from ``(H, W, 3)`` NumPy format to ``(3, H, W)`` Cutie
     tensor format.
     """
+    # Normalize by dtype, not by pixel magnitude. A ``max() > 1`` heuristic
+    # mis-scales a near-black uint8 frame whose brightest pixel is 0 or 1
+    # (treated as already-normalized and left un-divided). An integer frame is
+    # always 0-255 and divided by 255; a floating frame is assumed to be
+    # already in [0, 1] per the RGB contract.
+    is_integer_frame = np.issubdtype(frame.dtype, np.integer)
+
     frame_torch = (
         torch.from_numpy(frame.transpose(2, 0, 1))
         .float()
@@ -120,7 +127,7 @@ def _image_to_torch(
         )
     )
 
-    if frame_torch.max() > 1:
+    if is_integer_frame:
         frame_torch /= 255.0
 
     return frame_torch
@@ -152,6 +159,12 @@ def _binary_masks_to_indexed_mask(
             "Number of masks must match number of object IDs. "
             f"Got {masks.shape[0]} masks and {len(object_ids)} object IDs."
         )
+
+    # Coerce to bool: the ``mask & ~occupied`` combination below is a bitwise
+    # op that only behaves as set difference on boolean arrays. MaskOutput.masks
+    # is typed as a bare ndarray, so a float/int custom generator would
+    # otherwise crash or produce wrong regions.
+    masks = masks.astype(bool, copy=False)
 
     indexed_mask = np.zeros(masks.shape[1:], dtype=np.int32)
     occupied = np.zeros(masks.shape[1:], dtype=bool)
@@ -225,6 +238,10 @@ def _binary_masks_to_non_overlapping_torch(
     priority, matching the original McByte initialization behavior. The returned
     tensor has shape ``(N, H, W)``, dtype ``float32``, and values ``0.0`` or ``1.0``.
     """
+    # Coerce to bool for the same reason as _binary_masks_to_indexed_mask:
+    # ``mask & ~occupied`` requires boolean arrays to act as set difference.
+    masks = masks.astype(bool, copy=False)
+
     occupied = np.zeros(masks.shape[1:], dtype=bool)
     non_overlapping_masks = np.zeros_like(masks, dtype=np.float32)
 
@@ -456,6 +473,17 @@ class CutieMaskPropagator(MaskPropagator):
                 "MaskOutput tracklet_mask_dict must map tracklet IDs to local mask "
                 f"indices {expected_indices}. Got {actual_indices}."
             )
+
+        # Start from a clean slate. Cutie's InferenceCore retains temporal and
+        # sensory memory across step() calls, and only reset() clears it. A
+        # mid-sequence re-initialization — MaskManager flips ``_initialized``
+        # back to False after a failed propagate(), or every tracked object is
+        # removed and new ones later enter — would otherwise step Cutie with a
+        # fresh set of object IDs against the previous segment's residual
+        # memory, silently contaminating the new masks and colliding on reused
+        # low object IDs. Clearing here makes initialize() correct regardless of
+        # caller ordering.
+        self.processor.clear_memory()
 
         self._tracklet_object_dict = _build_tracklet_object_dict(mask_output.tracklet_mask_dict)
 
@@ -724,6 +752,10 @@ class CutieMaskPropagator(MaskPropagator):
             self._last_indexed_mask[np.isin(self._last_indexed_mask, object_ids_to_remove)] = 0
 
         # No active objects remain, so propagation has nothing valid to propagate.
+        # Clear Cutie's temporal memory now (not only object mappings) so no
+        # residual state survives into a later re-initialization; this mirrors
+        # reset() and complements the self-cleaning initialize().
         if len(self._object_ids) == 0:
+            self.processor.clear_memory()
             self._last_indexed_mask = None
             self._initialized = False

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -275,6 +275,13 @@ class McByteTracker(BaseTracker):
         self.minimum_mask_coverage = minimum_mask_coverage
         self.minimum_mask_fill_ratio = minimum_mask_fill_ratio
         self.enable_isolated_mask_matching = enable_isolated_mask_matching
+        if high_conf_det_threshold <= _MINIMUM_DETECTION_CONFIDENCE:
+            raise ValueError(
+                "high_conf_det_threshold must be greater than the detection discard "
+                f"floor ({_MINIMUM_DETECTION_CONFIDENCE}); otherwise detections at or "
+                f"below the floor would be treated as high-confidence. "
+                f"Got {high_conf_det_threshold}."
+            )
         self.tracks: list[McByteTracklet] = []
         self.state_estimator_class = state_estimator_class
         self.iou = iou if iou is not None else IoU()
@@ -300,6 +307,14 @@ class McByteTracker(BaseTracker):
             )
         else:
             self.mask_manager = None
+
+        # Retain the original manager so reset() can re-attach it. The active
+        # ``mask_manager`` is nulled after repeated CUDA out-of-memory failures
+        # (see ``_run_mask_manager``); without this reference a subsequent
+        # reset() — the documented new-video boundary where GPU memory is
+        # typically freed — could never restore mask-conditioned association,
+        # and a user-supplied custom manager would be lost permanently.
+        self._mask_manager_original = self.mask_manager
 
         self._previous_frame: np.ndarray | None = None
         self._previous_tracklets: list[TrackletSnapshot] = []
@@ -328,7 +343,12 @@ class McByteTracker(BaseTracker):
                 ``.xyxy``. Confidence (`detections.confidence`) is optional but
                 recommended. This method does not mutate the input detections; it
                 returns a new ``sv.Detections`` with ``tracker_id`` assigned.
-            frame: Current RGB frame. Required for camera motion compensation and for
+            frame: Current frame in **RGB** channel order, shape ``(H, W, 3)``.
+                Note this deviates from the ``BaseTracker.update`` default of BGR:
+                McByte's SAM and Cutie mask backends consume the frame as RGB
+                without any internal channel conversion, so a BGR frame silently
+                degrades mask quality (and therefore mask-conditioned
+                association). Required for camera motion compensation and for
                 mask-manager propagation.
             timestamp: Absolute time of the current frame in seconds, or ``None``
                 for fixed-rate mode (``frame_step = 1.0`` per call). When provided,
@@ -361,7 +381,15 @@ class McByteTracker(BaseTracker):
         current_frame = frame
         terminated_tracklet_ids: list[int] = []
 
-        if self.mask_manager is not None and current_frame is not None:
+        if timing.skip_predict:
+            # Duplicate timestamp: the Kalman predict step is skipped and
+            # association runs on the last state (see update() "Warns"). Masks
+            # must not advance either — stepping the backend one phantom frame
+            # would match freshly propagated masks against un-advanced track
+            # state (a one-frame mask/state desync). Retain the previous mask
+            # output so masks stay in lockstep with the state used here.
+            pass
+        elif self.mask_manager is not None and current_frame is not None:
             self._last_mask_output = self._run_mask_manager(self.mask_manager, current_frame)
         else:
             self._last_mask_output = None
@@ -683,7 +711,14 @@ class McByteTracker(BaseTracker):
             self._previous_tracklets = []
             self._previous_new_tracklets = []
             self._previous_removed_tracklet_ids = []
-            self._mask_tracklet_ids = set()
+            # Preserve the already-masked tracklet-ID set across an occasional
+            # frame=None call (e.g. a dropped/corrupt frame while the manager is
+            # still active). Clearing it would make the next real frame treat
+            # every visible tracklet as new: SAM would re-prompt all masks and
+            # Cutie's add_masks would raise on tracklets that already own an
+            # object. Only a fully absent mask manager warrants a full clear.
+            if self.mask_manager is None:
+                self._mask_tracklet_ids = set()
             return
 
         # Convert current output detections into TrackletSnapshots.
@@ -890,6 +925,15 @@ class McByteTracker(BaseTracker):
         for det_local_idx in unmatched_high_local:
             global_idx = int(high_indices[det_local_idx])
             conf = float(confidences[global_idx])
+
+            # Every unmatched high-confidence detection is returned, with
+            # tracker_id -1 when it does not spawn a track. This matches the
+            # documented update() contract ("unmatched/unconfirmed detections
+            # have tracker_id of -1"), the symmetric handling of unmatched
+            # low-confidence detections, and sibling ByteTrack. Only detections
+            # clearing the activation threshold spawn a new tracklet; a
+            # first-frame instant-activated spawn is emitted with its real ID.
+            tracker_id_out = -1
             if conf >= self.track_activation_threshold:
                 tracklet = McByteTracklet(
                     initial_bbox=detection_boxes[global_idx],
@@ -898,8 +942,10 @@ class McByteTracker(BaseTracker):
                 if is_first_frame and self.instant_first_frame_activation:
                     tracklet.tracker_id = self._allocate_tracker_id()
                 self.tracks.append(tracklet)
-                out_det_indices.append(global_idx)
-                out_tracker_ids.append(tracklet.tracker_id)
+                tracker_id_out = tracklet.tracker_id
+
+            out_det_indices.append(global_idx)
+            out_tracker_ids.append(tracker_id_out)
 
     def reset(self) -> None:
         """Reset tracker, camera-motion, and mask-manager state.
@@ -915,6 +961,11 @@ class McByteTracker(BaseTracker):
         self._previous_frame = None
         self._previous_tracklets = []
         self._last_mask_output = None
+        # Re-attach a mask manager that was auto-disabled after repeated CUDA
+        # out-of-memory failures. reset() marks the documented new-video
+        # boundary where GPU memory has typically been freed, so the original
+        # manager (default or user-supplied) is restored and cleared.
+        self.mask_manager = self._mask_manager_original
         if self.mask_manager is not None:
             self.mask_manager.reset()
         if self.cmc is not None:

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -963,9 +963,9 @@ class McByteTracker(BaseTracker):
         self._last_mask_output = None
         # Re-attach a mask manager that was auto-disabled after repeated CUDA
         # out-of-memory failures. reset() marks the documented new-video
-        # boundary where GPU memory has typically been freed, so the original
-        # manager (default or user-supplied) is restored and cleared.
-        self.mask_manager = self._mask_manager_original
+        # boundary where GPU memory has typically been freed.
+        if self.mask_manager is None and self._consecutive_mask_failures >= _MAX_CONSECUTIVE_MASK_FAILURES:
+            self.mask_manager = self._mask_manager_original
         if self.mask_manager is not None:
             self.mask_manager.reset()
         if self.cmc is not None:

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -57,6 +57,38 @@ def test_image_to_torch_converts_rgb_numpy_frame() -> None:
     assert torch.isclose(frame_torch[2, 0, 0], torch.tensor(1.0))
 
 
+def test_image_to_torch_normalizes_near_black_uint8_frame_by_dtype() -> None:
+    """A near-black uint8 frame is divided by 255 based on dtype, not skipped by a max>1 heuristic."""
+    frame = np.ones((2, 2, 3), dtype=np.uint8)
+
+    frame_torch = _image_to_torch(frame, device=torch.device("cpu"))
+
+    assert torch.allclose(frame_torch, torch.full((3, 2, 2), 1 / 255))
+
+
+def test_image_to_torch_leaves_normalized_float_frame_unscaled() -> None:
+    """A float frame already in [0, 1] is passed through without a second division."""
+    frame = np.full((2, 2, 3), 0.5, dtype=np.float32)
+
+    frame_torch = _image_to_torch(frame, device=torch.device("cpu"))
+
+    assert torch.allclose(frame_torch, torch.full((3, 2, 2), 0.5))
+
+
+def test_binary_masks_to_indexed_mask_accepts_non_bool_masks() -> None:
+    """Float masks are coerced to bool so the bitwise overlap resolution stays correct."""
+    masks = np.zeros((2, 4, 4), dtype=np.float32)
+    masks[0, 1:3, 1:3] = 1.0
+    masks[1, 2:4, 2:4] = 1.0
+
+    indexed_mask = _binary_masks_to_indexed_mask(masks=masks, object_ids=[1, 2])
+
+    # First mask keeps the shared pixel (2, 2); second mask yields to it.
+    assert indexed_mask[2, 2] == 1
+    assert indexed_mask[3, 3] == 2
+    assert indexed_mask.dtype == np.int32
+
+
 def test_binary_masks_to_non_overlapping_torch_resolves_overlaps_with_first_mask_priority() -> None:
     masks = np.zeros((2, 4, 4), dtype=bool)
     masks[0, 1:3, 1:3] = True
@@ -242,6 +274,10 @@ def test_initialize_success_path_builds_state_and_calls_processor_step() -> None
     class DummyProcessor:
         def __init__(self) -> None:
             self.step_calls: list[dict[str, Any]] = []
+            self.clear_memory_called = False
+
+        def clear_memory(self) -> None:
+            self.clear_memory_called = True
 
         def step(
             self,
@@ -292,6 +328,9 @@ def test_initialize_success_path_builds_state_and_calls_processor_step() -> None
     assert propagator._object_ids == [1, 2]
     assert propagator._last_object_id == 2
     assert propagator._initialized is True
+    # Cutie temporal memory is cleared before the masks-present step so a
+    # mid-sequence re-init never reuses stale memory.
+    assert processor.clear_memory_called is True
 
     expected_indexed_mask = np.zeros((4, 4), dtype=np.int32)
     expected_indexed_mask[0:2, 0:2] = 1
@@ -307,6 +346,66 @@ def test_initialize_success_path_builds_state_and_calls_processor_step() -> None
         step_call["mask"].cpu().numpy(),
         masks.astype(np.float32),
     )
+
+
+def test_initialize_clears_stale_memory_on_mid_sequence_reinitialization() -> None:
+    """Scenario: a second initialize() clears Cutie memory and rebuilds fresh object state, no prior-segment leak."""
+
+    class DummyProcessor:
+        def __init__(self) -> None:
+            self.clear_memory_calls = 0
+            self.step_calls = 0
+
+        def clear_memory(self) -> None:
+            self.clear_memory_calls += 1
+
+        def step(
+            self,
+            frame: Any,
+            mask: Any | None = None,
+            objects: list[int] | None = None,
+            *,
+            idx_mask: bool = True,
+        ) -> Any:
+            self.step_calls += 1
+            return torch.zeros((3, 4, 4), dtype=torch.float32)
+
+    processor = DummyProcessor()
+
+    propagator = object.__new__(CutieMaskPropagator)
+    propagator.device = torch.device("cpu")
+    propagator.use_amp = False
+    propagator.processor = processor
+    propagator._tracklet_object_dict = {}
+    propagator._object_ids = []
+    propagator._initialized = False
+    propagator._last_object_id = 0
+    propagator._last_indexed_mask = None
+
+    first_masks = np.zeros((2, 4, 4), dtype=bool)
+    first_masks[0, 0:2, 0:2] = True
+    first_masks[1, 2:4, 2:4] = True
+    propagator.initialize(
+        frame=np.zeros((4, 4, 3), dtype=np.uint8),
+        mask_output=MaskOutput(masks=first_masks, tracklet_mask_dict={10: 0, 20: 1}),
+    )
+
+    # Simulate the prior segment fully terminating, then a new set of tracklets
+    # entering — MaskManager re-enters the not-initialized branch and calls
+    # initialize() again on the same propagator.
+    second_masks = np.zeros((1, 4, 4), dtype=bool)
+    second_masks[0, 0:3, 0:3] = True
+    propagator.initialize(
+        frame=np.zeros((4, 4, 3), dtype=np.uint8),
+        mask_output=MaskOutput(masks=second_masks, tracklet_mask_dict={99: 0}),
+    )
+
+    assert processor.clear_memory_calls == 2
+    assert processor.step_calls == 2
+    # State reflects only the second segment; no leakage from ids 10/20.
+    assert propagator._tracklet_object_dict == {99: 1}
+    assert propagator._object_ids == [1]
+    assert propagator._last_object_id == 1
 
 
 @pytest.mark.parametrize(
@@ -600,9 +699,13 @@ def test_remove_masks_marks_uninitialized_when_no_objects_remain(
     class DummyProcessor:
         def __init__(self) -> None:
             self.deleted_objects: list[int] | None = None
+            self.clear_memory_called = False
 
         def delete_objects(self, object_ids: list[int]) -> None:
             self.deleted_objects = object_ids
+
+        def clear_memory(self) -> None:
+            self.clear_memory_called = True
 
     processor = DummyProcessor()
 
@@ -621,6 +724,8 @@ def test_remove_masks_marks_uninitialized_when_no_objects_remain(
     assert propagator._last_object_id == 1
     assert propagator._last_indexed_mask is None
     assert not propagator._initialized
+    # Removing the last object clears Cutie temporal memory, not just mappings.
+    assert processor.clear_memory_called is True
 
 
 def test_propagate_returns_mask_output_contract_after_temporary_id_shift(

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -75,6 +75,23 @@ def test_image_to_torch_leaves_normalized_float_frame_unscaled() -> None:
     assert torch.allclose(frame_torch, torch.full((3, 2, 2), 0.5))
 
 
+def test_image_to_torch_normalizes_uint16_frame_by_dtype_max() -> None:
+    """A uint16 frame is divided by 65535, not 255, so wide integer types are not mis-scaled."""
+    frame = np.full((2, 2, 3), 65535, dtype=np.uint16)
+
+    frame_torch = _image_to_torch(frame, device=torch.device("cpu"))
+
+    assert torch.allclose(frame_torch, torch.ones((3, 2, 2)))
+
+
+def test_image_to_torch_rejects_signed_integer_frame() -> None:
+    """A signed-integer frame has an ambiguous range and is rejected rather than mis-scaled."""
+    frame = np.zeros((2, 2, 3), dtype=np.int16)
+
+    with pytest.raises(ValueError, match="Signed-integer frames are not supported"):
+        _image_to_torch(frame, device=torch.device("cpu"))
+
+
 def test_binary_masks_to_indexed_mask_accepts_non_bool_masks() -> None:
     """Float masks are coerced to bool so the bitwise overlap resolution stays correct."""
     masks = np.zeros((2, 4, 4), dtype=np.float32)

--- a/tests/core/test_mcbyte_mask_association.py
+++ b/tests/core/test_mcbyte_mask_association.py
@@ -23,6 +23,22 @@ def _full_mask(
     return np.ones((height, width), dtype=bool)
 
 
+def test_condition_similarity_rejects_integer_similarity_dtype() -> None:
+    """An integer similarity matrix is rejected, since in-place mask boosts would truncate to zero."""
+    similarity = np.array([[1, 0], [0, 1]], dtype=np.int32)
+    detection_boxes = np.array([[0, 0, 5, 5], [5, 5, 10, 10]], dtype=np.float32)
+
+    with pytest.raises(ValueError, match="floating-point dtype"):
+        condition_similarity_with_masks(
+            similarity=similarity,
+            raw_iou_similarity=similarity,
+            tracklet_ids=[10, 20],
+            detection_boxes=detection_boxes,
+            mask_output=None,
+            minimum_similarity=0.5,
+        )
+
+
 def test_mask_metrics_compute_coverage_and_fill_ratio() -> None:
     mask = np.zeros((10, 10), dtype=bool)
     mask[2:6, 2:6] = True

--- a/tests/core/test_mcbyte_mask_manager.py
+++ b/tests/core/test_mcbyte_mask_manager.py
@@ -36,6 +36,27 @@ class _FlakyMaskPropagator(DummyIdentityMaskPropagator):
         return super().propagate(frame)
 
 
+class _WrongResolutionMaskPropagator(DummyIdentityMaskPropagator):
+    """Propagator that returns masks at a resolution different from the frame.
+
+    Reproduces a backend that internally resizes or pads without upsampling
+    back to the input frame grid, which would make mask-conditioning gate
+    associations in the wrong coordinate space.
+    """
+
+    def propagate(self, frame: np.ndarray) -> MaskOutput | None:
+        output = super().propagate(frame)
+        if output is None or output.masks is None:
+            return output
+        num_masks = output.masks.shape[0]
+        resized = np.zeros((num_masks, frame.shape[0] + 5, frame.shape[1]), dtype=output.masks.dtype)
+        return MaskOutput(
+            masks=resized,
+            tracklet_mask_dict=output.tracklet_mask_dict,
+            mask_avg_prob_dict=output.mask_avg_prob_dict,
+        )
+
+
 def _make_frame(h: int = 100, w: int = 120) -> np.ndarray:
     return np.zeros((h, w, 3), dtype=np.uint8)
 
@@ -182,6 +203,23 @@ def test_mask_manager_propagates_after_initialization_without_visible_tracklets(
     assert first_output is not None
     assert second_output is not None
     assert second_output.tracklet_mask_dict == {3: 0}
+
+
+def test_mask_manager_rejects_propagated_masks_at_wrong_resolution() -> None:
+    """A propagator returning masks whose (H, W) differ from the frame raises ValueError at the propagate boundary."""
+    manager = MaskManager(
+        mask_generator=DummyBoxMaskGenerator(),
+        mask_propagator=_WrongResolutionMaskPropagator(),
+    )
+
+    with pytest.raises(ValueError, match="match the frame resolution"):
+        manager.get_updated_masks(
+            frame=_make_frame(),
+            previous_frame=_make_frame(),
+            previous_tracklets=[
+                TrackletSnapshot(3, np.array([5, 6, 25, 30], dtype=np.float32)),
+            ],
+        )
 
 
 def test_mask_manager_reset_clears_state() -> None:

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -101,6 +101,96 @@ def test_mcbyte_instantiates_and_updates_with_frame_and_sparse_opt_flow_cmc_retu
     assert len(tracker.tracks) == 1
 
 
+def test_mcbyte_emits_unmatched_high_conf_detection_with_placeholder_id() -> None:
+    """A high-conf detection that neither matches nor spawns is still returned with tracker_id -1."""
+    # conf 0.65 is high (>= high_conf_det_threshold 0.6) but below the
+    # activation threshold 0.7, so on an empty tracker it matches nothing and
+    # spawns nothing. It must still be returned with tracker_id -1, matching the
+    # documented contract and the handling of unmatched low-confidence dets.
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=False,
+        high_conf_det_threshold=0.6,
+        track_activation_threshold=0.7,
+    )
+
+    result = tracker.update(_detection((100.0, 100.0, 200.0, 200.0), conf=0.65))
+
+    assert len(result) == 1
+    assert result.tracker_id is not None
+    assert result.tracker_id[0] == -1
+    assert len(tracker.tracks) == 0
+
+
+def test_mcbyte_reset_restores_mask_manager_disabled_by_cuda_oom() -> None:
+    """After repeated CUDA-OOM auto-disables the mask manager, reset() re-attaches the original manager."""
+
+    class OOMMaskManager:
+        def __init__(self) -> None:
+            self.reset_calls = 0
+
+        def get_updated_masks(
+            self,
+            frame: np.ndarray,
+            previous_frame: np.ndarray | None,
+            previous_tracklets: list[TrackletSnapshot],
+            new_tracklets: list[TrackletSnapshot] | None = None,
+            removed_tracklet_ids: list[int] | None = None,
+        ) -> MaskOutput | None:
+            raise RuntimeError("CUDA out of memory")
+
+        def reset(self) -> None:
+            self.reset_calls += 1
+
+    manager = OOMMaskManager()
+    tracker = McByteTracker(
+        enable_cmc=False,
+        mask_manager=manager,  # type: ignore[arg-type]
+        minimum_consecutive_frames=1,
+    )
+
+    frame = _make_frame()
+    for _ in range(3):
+        tracker.update(_detection((100.0, 100.0, 200.0, 200.0)), frame)
+
+    # Three consecutive OOM failures disable the pipeline for the run.
+    assert tracker.mask_manager is None
+
+    tracker.reset()
+
+    # reset() (documented new-video boundary) restores and clears the manager.
+    assert tracker.mask_manager is manager
+    assert manager.reset_calls == 1
+    assert tracker._consecutive_mask_failures == 0
+
+
+def test_mcbyte_does_not_advance_masks_on_duplicate_timestamp() -> None:
+    """A duplicate timestamp skips Kalman predict and must not step the mask backend (masks stay in sync)."""
+    mask_manager = SpyMaskManager()
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=False,
+        mask_manager=mask_manager,  # type: ignore[arg-type]
+        minimum_consecutive_frames=1,
+    )
+    frame = _make_frame()
+
+    tracker.update(_detection((100.0, 100.0, 200.0, 200.0)), frame, timestamp=1.0)
+    assert len(mask_manager.calls) == 1
+
+    with pytest.warns(UserWarning, match="duplicate timestamp"):
+        tracker.update(_detection((100.0, 100.0, 200.0, 200.0)), frame, timestamp=1.0)
+
+    # No extra mask-backend step on the duplicate frame.
+    assert len(mask_manager.calls) == 1
+
+
+def test_mcbyte_rejects_high_conf_threshold_at_or_below_discard_floor() -> None:
+    """high_conf_det_threshold at or below the 0.1 discard floor is rejected to keep the confidence split coherent."""
+    with pytest.raises(ValueError, match="discard"):
+        McByteTracker(enable_cmc=False, enable_mask_manager=False, high_conf_det_threshold=0.05)
+
+
 def test_mcbyte_reset_clears_mask_state() -> None:
     tracker = McByteTracker(
         enable_cmc=False,


### PR DESCRIPTION
- Return every unmatched high-confidence detection with tracker_id -1, gating only the tracklet spawn on the activation threshold, so detections in [high_conf_det_threshold, track_activation_threshold) are no longer silently dropped (matches the update() contract, low-detection handling, and sibling ByteTrack) — tracker.py
- Clear Cutie temporal memory at the start of initialize() so a mid-sequence re-initialization no longer reuses the previous segment's memory — masks/cutie.py
- Retain the original mask manager and re-attach it in reset() so a CUDA out-of-memory auto-disable no longer persists across videos or drops a user-supplied manager — tracker.py
- Document the frame RGB requirement and its deviation from BaseTracker's BGR default — tracker.py
- Reject propagated masks whose (H, W) differ from the frame at the propagate boundary via _validate_mask_resolution — mask_manager.py
- Reject a non-floating similarity dtype in _validate_inputs so in-place mask boosts are not truncated to zero — mask_association.py
- Skip the mask backend on a duplicate timestamp so masks stay in sync with the un-advanced Kalman state — tracker.py
- Preserve the already-masked tracklet-id set across a frame=None call to avoid a full mask re-init and a Cutie add_masks duplicate error — tracker.py
- Normalize Cutie input frames by dtype instead of a max>1 heuristic, and clear Cutie memory when the last object is removed — masks/cutie.py
- Reject high_conf_det_threshold at or below the detection discard floor — tracker.py
- Coerce masks to bool in the Cutie binary-mask combine helpers — masks/cutie.py
- Add regression tests across the tracker, mask-association, mask-manager, and Cutie-propagator suites