### PR TITLE
feat(mcbyte): MPS support + Cutie streaming cfg

### DIFF
--- a/src/trackers/core/mcbyte/masks/cutie.py
+++ b/src/trackers/core/mcbyte/masks/cutie.py
@@ -361,7 +361,9 @@ class CutieMaskPropagator(MaskPropagator):
         device: Device used by Cutie, for example ``"cpu"``, ``"cuda"``, or
             ``"mps"``. The default ``"auto"`` selects the best available
             accelerator (CUDA, then Apple MPS, then CPU).
-        use_amp: Whether to use CUDA automatic mixed precision during Cutie calls.
+        use_amp: Whether to use CUDA automatic mixed precision during Cutie
+            calls. Off by default so default runs stay fp32 on every backend;
+            opt in after validating quality parity on your hardware.
         max_internal_size: Maximum shortest side of internally processed
             frames. Larger frames are downscaled before Cutie's encoder and
             the propagated masks are restored to the original resolution by
@@ -382,7 +384,7 @@ class CutieMaskPropagator(MaskPropagator):
         config_path: str | Path | None = None,
         config_name: str = "eval_config",
         device: str = "auto",
-        use_amp: bool = True,
+        use_amp: bool = False,
         max_internal_size: int = 480,
         mem_every: int | None = 10,
         use_long_term: bool | None = True,

--- a/src/trackers/core/mcbyte/masks/cutie.py
+++ b/src/trackers/core/mcbyte/masks/cutie.py
@@ -17,6 +17,7 @@ import numpy as np
 import torch
 
 from trackers.core.mcbyte.masks.base import MaskOutput, MaskPropagator
+from trackers.utils.device import _best_device
 from trackers.utils.downloader import _download_file
 
 logger = logging.getLogger(__name__)
@@ -357,8 +358,21 @@ class CutieMaskPropagator(MaskPropagator):
         config_path: Optional path to Cutie's Hydra config directory. If not
             provided, the path is inferred from the installed ``cutie`` package.
         config_name: Hydra config name used by Cutie.
-        device: Device used by Cutie, for example ``"cpu"`` or ``"cuda"``.
+        device: Device used by Cutie, for example ``"cpu"``, ``"cuda"``, or
+            ``"mps"``. The default ``"auto"`` selects the best available
+            accelerator (CUDA, then Apple MPS, then CPU).
         use_amp: Whether to use CUDA automatic mixed precision during Cutie calls.
+        max_internal_size: Maximum shortest side of internally processed
+            frames. Larger frames are downscaled before Cutie's encoder and
+            the propagated masks are restored to the original resolution by
+            ``InferenceCore``, so returned masks always match the input frame
+            shape. ``-1`` disables internal resizing (full-resolution
+            propagation; substantially slower on high-resolution streams).
+        mem_every: How often, in frames, Cutie updates its working memory.
+            ``None`` keeps the value from the loaded Cutie configuration.
+        use_long_term: Whether Cutie uses bounded long-term memory,
+            recommended for videos longer than roughly one minute. ``None``
+            keeps the value from the loaded Cutie configuration.
     """
 
     def __init__(
@@ -367,8 +381,11 @@ class CutieMaskPropagator(MaskPropagator):
         model_type: str = "base-mega",
         config_path: str | Path | None = None,
         config_name: str = "eval_config",
-        device: str = "cuda",
+        device: str = "auto",
         use_amp: bool = True,
+        max_internal_size: int = 480,
+        mem_every: int | None = 10,
+        use_long_term: bool | None = True,
     ) -> None:
         try:
             import cutie
@@ -385,9 +402,15 @@ class CutieMaskPropagator(MaskPropagator):
             )
             raise ImportError(msg) from exc
 
+        if device == "auto":
+            device = str(_best_device())
         self.device = torch.device(device)
 
         self.use_amp = use_amp and self.device.type == "cuda"
+
+        self.max_internal_size = max_internal_size
+        self.mem_every = mem_every
+        self.use_long_term = use_long_term
 
         asset = CUTIE_ASSETS.get(model_type)
         if asset is None:
@@ -590,7 +613,14 @@ class CutieMaskPropagator(MaskPropagator):
         config_path: str | Path | None,
         config_name: str,
     ) -> Any:
-        """Load Cutie Hydra config and inject the selected weights path."""
+        """Load Cutie Hydra config and inject runtime overrides.
+
+        Besides the selected weights path, streaming-oriented runtime options
+        (``max_internal_size``, ``mem_every``, ``use_long_term``) are written
+        into the top-level config. Non-``None`` top-level values survive
+        Cutie's ``get_dataset_cfg`` escalation and are read by
+        ``InferenceCore`` and ``MemoryManager`` at construction time.
+        """
         try:
             from hydra import compose, initialize_config_dir
             from omegaconf import open_dict
@@ -625,6 +655,11 @@ class CutieMaskPropagator(MaskPropagator):
 
         with open_dict(cfg):
             cfg["weights"] = self.weights_path
+            cfg["max_internal_size"] = self.max_internal_size
+            if self.mem_every is not None:
+                cfg["mem_every"] = self.mem_every
+            if self.use_long_term is not None:
+                cfg["use_long_term"] = self.use_long_term
 
         return cfg
 

--- a/src/trackers/core/mcbyte/masks/sam.py
+++ b/src/trackers/core/mcbyte/masks/sam.py
@@ -17,6 +17,7 @@ import numpy as np
 import torch
 
 from trackers.core.mcbyte.masks.base import MaskGenerator, MaskOutput, TrackletSnapshot
+from trackers.utils.device import _best_device
 from trackers.utils.downloader import _download_file
 
 logger = logging.getLogger(__name__)
@@ -96,17 +97,19 @@ class SAMBoxMaskGenerator(MaskGenerator):
             provided, the default checkpoint path for ``model_type`` is used.
         model_type: SAM model type. Currently only ``"vit_b"`` has a default
             checkpoint URL/path.
-        device: Device used by SAM, for example ``"cpu"`` or ``"cuda"``.
+        device: Device used by SAM, for example ``"cpu"``, ``"cuda"``, or
+            ``"mps"``. The default ``"auto"`` selects the best available
+            accelerator (CUDA, then Apple MPS, then CPU).
         use_amp: Whether to use CUDA automatic mixed precision during SAM
             inference. Only takes effect when ``device`` is a CUDA device;
-            it is ignored on CPU.
+            it is ignored on CPU and MPS.
     """
 
     def __init__(
         self,
         checkpoint_path: str | Path | None = None,
         model_type: str = "vit_b",
-        device: str = "cpu",
+        device: str = "auto",
         use_amp: bool = True,
     ) -> None:
         try:
@@ -132,6 +135,8 @@ class SAMBoxMaskGenerator(MaskGenerator):
             checkpoint_path=self.checkpoint_path,
             model_type=model_type,
         )
+        if device == "auto":
+            device = str(_best_device())
         self.device = torch.device(device)
         self.use_amp = use_amp and self.device.type == "cuda"
 

--- a/src/trackers/core/mcbyte/masks/sam.py
+++ b/src/trackers/core/mcbyte/masks/sam.py
@@ -102,7 +102,8 @@ class SAMBoxMaskGenerator(MaskGenerator):
             accelerator (CUDA, then Apple MPS, then CPU).
         use_amp: Whether to use CUDA automatic mixed precision during SAM
             inference. Only takes effect when ``device`` is a CUDA device;
-            it is ignored on CPU and MPS.
+            it is ignored on CPU and MPS. Off by default so default runs stay
+            fp32 on every backend.
     """
 
     def __init__(
@@ -110,7 +111,7 @@ class SAMBoxMaskGenerator(MaskGenerator):
         checkpoint_path: str | Path | None = None,
         model_type: str = "vit_b",
         device: str = "auto",
-        use_amp: bool = True,
+        use_amp: bool = False,
     ) -> None:
         try:
             from segment_anything import (  # type: ignore[import-untyped]

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -96,7 +96,10 @@ class McByteMaskConfig:
             omitted, it is inferred from the installed Cutie package.
         cutie_config_name: Hydra configuration name loaded by Cutie.
         cutie_use_amp: Whether Cutie may use automatic mixed precision. AMP is
-            activated only when Cutie runs on a CUDA device.
+            activated only when Cutie runs on a CUDA device. Disabled by
+            default so that default runs use full fp32 precision on every
+            backend; opt in explicitly after validating tracking-quality
+            parity on your hardware.
         cutie_max_internal_size: Maximum shortest side of frames processed
             internally by Cutie. Larger frames are downscaled before the
             encoder and the propagated masks are restored to the original
@@ -122,7 +125,7 @@ class McByteMaskConfig:
     cutie_model_type: str = "base-mega"
     cutie_config_path: str | Path | None = None
     cutie_config_name: str = "eval_config"
-    cutie_use_amp: bool = True
+    cutie_use_amp: bool = False
     cutie_max_internal_size: int = 480
     cutie_mem_every: int | None = 10
     cutie_use_long_term: bool | None = True

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -38,8 +38,9 @@ from trackers.utils.state_representations import (
 
 logger = logging.getLogger(__name__)
 
-# Number of consecutive CUDA out-of-memory failures in the mask pipeline after
-# which mask-conditioned association is disabled for the remainder of the run.
+# Number of consecutive out-of-memory failures (CUDA or MPS) in the mask
+# pipeline after which mask-conditioned association is disabled for the
+# remainder of the run.
 _MAX_CONSECUTIVE_MASK_FAILURES = 3
 
 # Detections with confidence at or below this floor are discarded entirely.
@@ -48,20 +49,22 @@ _MAX_CONSECUTIVE_MASK_FAILURES = 3
 _MINIMUM_DETECTION_CONFIDENCE = 0.1
 
 
-def _is_cuda_out_of_memory(exc: BaseException) -> bool:
-    """Return whether an exception represents a CUDA/torch out-of-memory error.
+def _is_out_of_memory(exc: BaseException) -> bool:
+    """Return whether an exception represents a torch out-of-memory error.
 
     Detected without importing ``torch`` (an optional McByte dependency): a
     ``torch.cuda.OutOfMemoryError`` is a ``RuntimeError`` subclass, so it is
-    recognised by class name, and plain CUDA out-of-memory ``RuntimeError``
-    instances are recognised by their canonical message.
+    recognised by class name, and plain out-of-memory ``RuntimeError``
+    instances are recognised by their canonical message. This also covers the
+    MPS backend, whose OOM is a plain ``RuntimeError`` with an
+    ``"MPS backend out of memory"`` message.
 
     Args:
         exc: Exception raised by the mask pipeline.
 
     Returns:
-        ``True`` when ``exc`` is a CUDA/torch out-of-memory error, otherwise
-        ``False``.
+        ``True`` when ``exc`` is a torch out-of-memory error (CUDA or MPS),
+        otherwise ``False``.
     """
     if any(klass.__name__ == "OutOfMemoryError" for klass in type(exc).__mro__):
         return True
@@ -78,7 +81,9 @@ class McByteMaskConfig:
 
     Args:
         device: Device shared by SAM and Cutie, for example ``"cuda"``,
-            ``"cuda:0"``, or ``"cpu"``.
+            ``"cuda:0"``, ``"mps"``, or ``"cpu"``. The default ``"auto"``
+            selects the best available accelerator (CUDA, then Apple MPS,
+            then CPU).
         sam_checkpoint_path: Optional SAM checkpoint path. When omitted, the
             default checkpoint for ``sam_model_type`` is used and downloaded
             automatically when necessary.
@@ -92,11 +97,23 @@ class McByteMaskConfig:
         cutie_config_name: Hydra configuration name loaded by Cutie.
         cutie_use_amp: Whether Cutie may use automatic mixed precision. AMP is
             activated only when Cutie runs on a CUDA device.
+        cutie_max_internal_size: Maximum shortest side of frames processed
+            internally by Cutie. Larger frames are downscaled before the
+            encoder and the propagated masks are restored to the original
+            resolution, matching Cutie's own streaming preset. Use ``-1`` to
+            propagate at full input resolution (Cutie's offline-benchmark
+            behavior; substantially slower on high-resolution streams).
+        cutie_mem_every: How often, in frames, Cutie updates its working
+            memory. Higher values speed up processing. ``None`` keeps the
+            value from the loaded Cutie configuration.
+        cutie_use_long_term: Whether Cutie uses bounded long-term memory,
+            recommended for videos longer than roughly one minute. ``None``
+            keeps the value from the loaded Cutie configuration.
         mask_creation_bbox_overlap_threshold: Bounding-box overlap fraction at
             or above which mask creation is delayed by ``MaskManager``.
     """
 
-    device: str = "cpu"
+    device: str = "auto"
 
     sam_checkpoint_path: str | Path | None = None
     sam_model_type: str = "vit_b"
@@ -106,6 +123,9 @@ class McByteMaskConfig:
     cutie_config_path: str | Path | None = None
     cutie_config_name: str = "eval_config"
     cutie_use_amp: bool = True
+    cutie_max_internal_size: int = 480
+    cutie_mem_every: int | None = 10
+    cutie_use_long_term: bool | None = True
 
     mask_creation_bbox_overlap_threshold: float = MASK_CREATION_BBOX_OVERLAP_THRESHOLD
 
@@ -131,6 +151,9 @@ def _build_default_mask_manager(
         config_name=config.cutie_config_name,
         device=config.device,
         use_amp=config.cutie_use_amp,
+        max_internal_size=config.cutie_max_internal_size,
+        mem_every=config.cutie_mem_every,
+        use_long_term=config.cutie_use_long_term,
     )
 
     return MaskManager(
@@ -648,7 +671,7 @@ class McByteTracker(BaseTracker):
                 removed_tracklet_ids=self._previous_removed_tracklet_ids,
             )
         except RuntimeError as exc:
-            if not _is_cuda_out_of_memory(exc):
+            if not _is_out_of_memory(exc):
                 raise
             self._consecutive_mask_failures += 1
             logger.warning(

--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -493,7 +493,7 @@ class CMC:
             1) grayscale (+ optional downscale)
             2) detect corners using goodFeaturesToTrack
             3) compute correspondences via calcOpticalFlowPyrLK(prev, curr, prev_points)
-            4) keep only points with status == 1
+            4) keep only points with a nonzero status
             5) estimate affine transform with RANSAC
             6) scale translation back up if downscaled
 
@@ -573,7 +573,7 @@ class CMC:
 
         # Keep only good correspondences
         # status is (N,1) or (N,)
-        good = status.reshape(-1) == 1
+        good = status.reshape(-1) != 0
         prev_pts_np = self._prev_points[good]
         curr_pts_np = matched[good]
 

--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -572,21 +572,13 @@ class CMC:
             return affine_mtx
 
         # Keep only good correspondences
-        prev_pts: list[np.ndarray] = []
-        curr_pts: list[np.ndarray] = []
         # status is (N,1) or (N,)
-        status_flat = status.reshape(-1)
-
-        for i in range(len(status_flat)):
-            if status_flat[i]:
-                prev_pts.append(self._prev_points[i])
-                curr_pts.append(matched[i])
-
-        prev_pts_np = np.array(prev_pts)
-        curr_pts_np = np.array(curr_pts)
+        good = status.reshape(-1) == 1
+        prev_pts_np = self._prev_points[good]
+        curr_pts_np = matched[good]
 
         # Find rigid matrix
-        if (np.size(prev_pts_np, 0) > 4) and (np.size(prev_pts_np, 0) == np.size(curr_pts_np, 0)):
+        if np.size(prev_pts_np, 0) > 4:
             affine_est, _ = cv2.estimateAffinePartial2D(
                 prev_pts_np,
                 curr_pts_np,

--- a/src/trackers/utils/motion_models.py
+++ b/src/trackers/utils/motion_models.py
@@ -89,30 +89,43 @@ class ScalableProcessNoise:
     sigma_a2: NDArray[np.float64]
     extra_q_diagonal: NDArray[np.float64]
     _nonkinematic_idx: list[int] = field(default_factory=list, init=False)
+    _needs_calibration: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
         kinematic = {int(i) for i in self.pos_idx} | {int(i) for i in self.vel_idx}
         self._nonkinematic_idx = [i for i in range(self.dim_x) if i not in kinematic]
 
     def calibrate(self, Q: np.ndarray) -> None:
-        """Extract per-axis acceleration variance from Q and store the reference.
+        """Store the new one-frame reference ``Q`` and defer the extraction.
 
-        Called from ``set_kf_covariances``. The velocity-diagonal entries of
-        ``Q`` define ``sigma_a2``, which is used to scale noise for
-        ``frame_step != 1.0`` via DWNA. ``baseline_Q`` stores ``Q`` itself so
-        that ``build_Q(1.0)`` returns it directly, preserving hand-tuned
-        one-frame noise exactly.
+        Called from ``set_kf_covariances``. ``baseline_Q`` stores ``Q`` itself
+        so that ``build_Q(1.0)`` returns it directly, preserving hand-tuned
+        one-frame noise exactly. The DWNA calibration (``sigma_a2``,
+        ``extra_q_diagonal``) is deferred until the first ``build_Q`` with a
+        non-unit frame step, keeping per-frame noise refreshes (e.g. BoT-SORT
+        scale-aware noise) cheap on the fixed-rate path.
 
         Args:
             Q: Configured one-frame process noise matrix of shape
                 ``(dim_x, dim_x)``, as produced by ``_configure_noise`` via
                 ``set_kf_covariances``.
         """
-        self.sigma_a2 = np.asarray([float(Q[v, v]) for v in self.vel_idx], dtype=np.float64)
-        self.extra_q_diagonal = np.diag(Q).astype(np.float64).copy()
         self.baseline_Q = Q.copy()
-        kinematic = {int(i) for i in self.pos_idx} | {int(i) for i in self.vel_idx}
-        self._nonkinematic_idx = [i for i in range(self.dim_x) if i not in kinematic]
+        self._needs_calibration = True
+
+    def _ensure_calibrated(self) -> None:
+        """Extract per-axis acceleration variance from the stored reference Q.
+
+        The velocity-diagonal entries of ``baseline_Q`` define ``sigma_a2``,
+        which scales noise for ``frame_step != 1.0`` via DWNA. Runs only when a
+        ``calibrate`` call marked the extraction as pending.
+        """
+        if not self._needs_calibration:
+            return
+        Q = self.baseline_Q
+        self.sigma_a2 = Q[self.vel_idx, self.vel_idx].astype(np.float64)
+        self.extra_q_diagonal = np.diag(Q).astype(np.float64).copy()
+        self._needs_calibration = False
 
     def build_Q(self, frame_step: float) -> NDArray[np.float64]:
         """Return process noise Q scaled for the given frame step.
@@ -131,6 +144,7 @@ class ScalableProcessNoise:
         """
         if frame_step == 1.0:
             return self.baseline_Q.copy()
+        self._ensure_calibrated()
         return self._dwna(frame_step)
 
     def _dwna(self, frame_step: float) -> NDArray[np.float64]:
@@ -213,39 +227,40 @@ class KalmanMotionModel:
 
         Call this after ``set_kf_covariances`` updates ``process_noise`` on the
         filter so that ``build_Q`` and future cached steps use the new reference.
+        Only the cached ``Q`` is invalidated: the cached transition matrix
+        depends solely on the frame step, so it survives noise-only changes
+        (e.g. BoT-SORT's per-frame scale-aware refresh).
 
         Args:
             process_noise: Reference one-frame process noise matrix, as produced
                 by ``set_kf_covariances``. Shape must be ``(dim_x, dim_x)``.
         """
         self.process_noise.calibrate(process_noise)
-        self.cached_step = None
+        self._cached_process_noise = None
 
     def apply(self, kf: KalmanFilter, frame_step: float) -> None:
         """Set transition_matrix and Q on a Kalman filter for the given frame step.
 
-        Both matrices are cached per unique step value to avoid redundant
-        computation when the same step is repeated across consecutive frames.
+        Both matrices are cached to avoid redundant computation. The transition
+        matrix is cached per unique step value; ``Q`` is additionally
+        invalidated by ``calibrate_from_process_noise`` and rebuilt from the
+        current reference on the next call.
 
         Args:
             kf: ``KalmanFilter`` to update in-place.
             frame_step: Elapsed time in frame units for this predict step.
                 Use ``1.0`` for a single nominal frame; larger values for gaps.
         """
-        if (
-            self.cached_step is not None
-            and frame_step == self.cached_step
-            and self._cached_transition_mtx is not None
-            and self._cached_process_noise is not None
-        ):
-            kf.transition_mtx = self._cached_transition_mtx
-            kf.process_noise = self._cached_process_noise
-            return
-        kf.transition_mtx = constant_velocity_transition_matrix(self.dim_x, self.pos_idx, self.vel_idx, frame_step)
-        kf.process_noise = self.process_noise.build_Q(frame_step)
-        self._cached_transition_mtx = kf.transition_mtx
-        self._cached_process_noise = kf.process_noise
-        self.cached_step = frame_step
+        if frame_step != self.cached_step or self._cached_transition_mtx is None:
+            self._cached_transition_mtx = constant_velocity_transition_matrix(
+                self.dim_x, self.pos_idx, self.vel_idx, frame_step
+            )
+            self.cached_step = frame_step
+            self._cached_process_noise = None
+        if self._cached_process_noise is None:
+            self._cached_process_noise = self.process_noise.build_Q(frame_step)
+        kf.transition_mtx = self._cached_transition_mtx
+        kf.process_noise = self._cached_process_noise
 
     def reset_cache(self) -> None:
         """Clear cached step and matrices.

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -530,8 +530,11 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
             model_type: str = "base-mega",
             config_path: str | None = None,
             config_name: str = "eval_config",
-            device: str = "cuda",
+            device: str = "auto",
             use_amp: bool = True,
+            max_internal_size: int = 480,
+            mem_every: int | None = 10,
+            use_long_term: bool | None = True,
         ) -> None:
             created["cutie"] = {
                 "weights_path": weights_path,
@@ -540,6 +543,9 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
                 "config_name": config_name,
                 "device": device,
                 "use_amp": use_amp,
+                "max_internal_size": max_internal_size,
+                "mem_every": mem_every,
+                "use_long_term": use_long_term,
             }
 
         def reset(self) -> None:
@@ -579,6 +585,9 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
             cutie_model_type="base-mega",
             cutie_config_name="eval_config",
             cutie_use_amp=False,
+            cutie_max_internal_size=576,
+            cutie_mem_every=7,
+            cutie_use_long_term=False,
             mask_creation_bbox_overlap_threshold=0.7,
         ),
     )
@@ -601,6 +610,9 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
         "config_name": "eval_config",
         "device": "cuda:1",
         "use_amp": False,
+        "max_internal_size": 576,
+        "mem_every": 7,
+        "use_long_term": False,
     }
 
     # Verify the MaskManager-specific threshold

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -531,7 +531,7 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
             config_path: str | None = None,
             config_name: str = "eval_config",
             device: str = "auto",
-            use_amp: bool = True,
+            use_amp: bool = False,
             max_internal_size: int = 480,
             mem_every: int | None = 10,
             use_long_term: bool | None = True,

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -153,6 +153,37 @@ def test_cmc_sparse_optflow_returns_identity_on_resolution_change() -> None:
     np.testing.assert_array_equal(affine_mtx, np.eye(2, 3, dtype=np.float32))
 
 
+def test_cmc_sparse_optflow_preserves_nonzero_status_semantics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sparse optical flow treats every nonzero status as a good match."""
+    points = np.array(
+        [[[0.0, 0.0]], [[1.0, 0.0]], [[0.0, 1.0]], [[1.0, 1.0]], [[2.0, 2.0]]],
+        dtype=np.float32,
+    )
+    matched = points + np.array([2.0, 3.0], dtype=np.float32)
+    status = np.array([[255], [2], [3], [4], [5]], dtype=np.uint8)
+    expected_affine = np.array([[1.0, 0.0, 2.0], [0.0, 1.0, 3.0]], dtype=np.float64)
+
+    monkeypatch.setattr(
+        "trackers.utils.cmc.cv2.goodFeaturesToTrack",
+        lambda frame, mask=None, **kwargs: points.copy(),
+    )
+    monkeypatch.setattr(
+        "trackers.utils.cmc.cv2.calcOpticalFlowPyrLK",
+        lambda previous, current, previous_points, next_points: (matched, status, None),
+    )
+    monkeypatch.setattr(
+        "trackers.utils.cmc.cv2.estimateAffinePartial2D",
+        lambda previous_points, current_points, method: (expected_affine, None),
+    )
+
+    cmc = CMC(CMCConfig(method="sparseOptFlow", downscale=1))
+    frame = np.zeros((32, 32, 3), dtype=np.uint8)
+    cmc.estimate(frame)
+    affine_mtx = cmc.estimate(frame)
+
+    np.testing.assert_array_equal(affine_mtx, expected_affine.astype(np.float32))
+
+
 @pytest.mark.parametrize("method", CMC_METHODS)
 def test_cmc_recovers_after_resolution_change(
     method: Literal["sparseOptFlow", "orb", "sift", "ecc"],


### PR DESCRIPTION
- McByteMaskConfig, CutieMaskPropagator, and SAMBoxMaskGenerator accept device="auto", resolved via _best_device to CUDA, then Apple MPS, then CPU; the mask pipeline previously never selected MPS and CutieMaskPropagator defaulted to a hard-coded "cuda" that crashed on non-CUDA machines
- new McByteMaskConfig knobs cutie_max_internal_size (default 480), cutie_mem_every (default 10), cutie_use_long_term (default True) are injected into the Cutie Hydra config, switching defaults from the DAVIS eval preset to Cutie's own streaming preset; -1/None restore the previous behavior
- rename _is_cuda_out_of_memory to _is_out_of_memory; the message-based match also covers MPS backend OOM errors
- vectorize sparse optical-flow status filtering in CMC with a boolean mask, replacing the per-point Python loop (measured ~24x on that operation)
- KalmanMotionModel defers DWNA calibration until the first non-unit frame step and keeps the cached transition matrix across noise-only recalibration, cutting BoTSORT/CBIoU per-tracklet predict cost by ~38% (measured 17.9us -> 11.1us)
- extend the McByte pipeline-construction test with the new propagator kwargs
