### PR TITLE
perf(mcbyte): reuse Cutie image features across add_masks

### DIFF
--- a/src/trackers/core/mcbyte/masks/cutie.py
+++ b/src/trackers/core/mcbyte/masks/cutie.py
@@ -125,14 +125,14 @@ def _image_to_torch(
             "uint16 frame, or a float frame already normalized to [0, 1]."
         )
 
-    frame_torch = (
-        torch.from_numpy(frame.transpose(2, 0, 1))
-        .float()
-        .to(
-            device,
-            non_blocking=True,
-        )
-    )
+    # Upload the compact source dtype (uint8 = 1 byte/pixel) and cast to float
+    # on the target device, rather than materializing a 4x-larger float32 tensor
+    # host-side and copying that across the bus. ``.contiguous()`` collapses the
+    # CHW transpose view so the host->device copy is a single contiguous block;
+    # ``non_blocking`` only helps with pinned memory but is harmless otherwise.
+    # The result is bit-identical to the previous ``.float().to(device)`` path:
+    # uint8 -> float32 -> divide equals float32(uint8) / max exactly.
+    frame_torch = torch.from_numpy(frame.transpose(2, 0, 1)).contiguous().to(device, non_blocking=True).float()
 
     if np.issubdtype(frame.dtype, np.unsignedinteger):
         frame_torch /= float(np.iinfo(frame.dtype).max)
@@ -483,6 +483,12 @@ class CutieMaskPropagator(MaskPropagator):
         self.cutie.load_weights(model_weights)
 
         self.processor = InferenceCore(self.cutie, cfg=cfg)
+        # This propagator manages the image-feature-store buffer lifecycle
+        # itself (see the feature-reuse cache below): propagate() keeps its
+        # features alive past the step and the following add_masks() consumes or
+        # drops them. Silence Cutie's built-in end-of-life leak warning because
+        # one retained entry after the final propagate is by design, not a bug.
+        self.processor.image_feature_store.no_warning = True
         self._tracklet_object_dict: dict[int, int] = {}
         self._object_ids: list[int] = []
         self._initialized = False
@@ -492,10 +498,39 @@ class CutieMaskPropagator(MaskPropagator):
         # inserting new masks into the previous-frame prediction before feeding Cutie
         # again. It is updated during propagation and kept for upcoming lifecycle work.
         self._last_indexed_mask: np.ndarray | None = None
+        # --- Cutie image-feature reuse cache (P3-2) ---
+        # InferenceCore.step encodes the frame's image features and, by default,
+        # drops them at the end of the step. When a new object appears on the
+        # next iteration, MaskManager calls add_masks() on that same (now
+        # "previous") frame, which would re-encode the identical pixels under a
+        # fresh internal time index. propagate() therefore keeps its features
+        # alive (delete_buffer=False) and records the store index plus the frame;
+        # the following add_masks() pre-seeds those features so its step skips one
+        # full image encode. Reuse is bit-identical: image features are a
+        # deterministic function of the (deterministically resized + padded)
+        # frame, so the result matches a fresh encode exactly.
+        self._cached_feature_ti: int | None = None
+        self._cached_feature_frame: np.ndarray | None = None
+
+    def _drop_cached_features(self) -> None:
+        """Delete the image-feature-store entry kept alive for add_masks reuse.
+
+        Called whenever the retained features become unusable: at reset, at
+        (re-)initialization, once an add_masks() has consumed them, and before a
+        new propagate() keeps its own. This is mandatory rather than cosmetic:
+        ``clear_memory`` restarts ``InferenceCore.curr_ti`` at ``-1``, so a stale
+        entry at an old time index would otherwise be silently re-read once the
+        counter cycles back to that index, corrupting a later frame's features.
+        """
+        if self._cached_feature_ti is not None:
+            self.processor.image_feature_store.delete(self._cached_feature_ti)
+            self._cached_feature_ti = None
+            self._cached_feature_frame = None
 
     def reset(self) -> None:
         """Reset Cutie temporal memory and object mappings."""
         self.processor.clear_memory()
+        self._drop_cached_features()
         self._tracklet_object_dict = {}
         self._object_ids = []
         self._last_object_id = 0
@@ -547,6 +582,11 @@ class CutieMaskPropagator(MaskPropagator):
         # low object IDs. Clearing here makes initialize() correct regardless of
         # caller ordering.
         self.processor.clear_memory()
+        # clear_memory restarts curr_ti at -1; drop any feature entry held from a
+        # previous segment so the reused time index cannot collide (see
+        # _drop_cached_features). initialize() does not itself keep features —
+        # the frame it encodes is not the one add_masks runs on next.
+        self._drop_cached_features()
 
         self._tracklet_object_dict = _build_tracklet_object_dict(mask_output.tracklet_mask_dict)
 
@@ -590,8 +630,16 @@ class CutieMaskPropagator(MaskPropagator):
 
         frame_torch = _image_to_torch(frame, self.device)
 
+        # Drop any features kept by an earlier propagate that no add_masks
+        # consumed (a run of frames with no new objects), then keep this frame's
+        # features alive for a possible add_masks on the next iteration.
+        # delete_buffer=False changes only buffer retention, not the returned
+        # probabilities, so propagate output is unaffected.
+        self._drop_cached_features()
         with _autocast_context(self.use_amp):
-            prob = self.processor.step(frame_torch)
+            prob = self.processor.step(frame_torch, delete_buffer=False)
+        self._cached_feature_ti = self.processor.curr_ti
+        self._cached_feature_frame = frame
 
         # One full-resolution channel reduction shared by the indexed mask and
         # the per-object confidence stats below.
@@ -775,6 +823,21 @@ class CutieMaskPropagator(MaskPropagator):
         frame_torch = _image_to_torch(frame, self.device)
         indexed_mask_torch = torch.from_numpy(indexed_mask).long().to(self.device)
 
+        # If this frame is the one the previous propagate already encoded, reuse
+        # those image features instead of re-encoding identical pixels. step()
+        # increments curr_ti before its get_features/get_key lookups, so seed the
+        # store under the next index; step() deletes that copy itself
+        # (delete_buffer defaults True) and _drop_cached_features drops the
+        # original below. The identity guard keeps this correct even if a caller
+        # feeds add_masks a different frame than was last propagated.
+        if (
+            self._cached_feature_ti is not None
+            and self._cached_feature_frame is not None
+            and (frame is self._cached_feature_frame or np.array_equal(frame, self._cached_feature_frame))
+        ):
+            store = self.processor.image_feature_store
+            store._store[self.processor.curr_ti + 1] = store._store[self._cached_feature_ti]
+
         with _autocast_context(self.use_amp):
             prob = self.processor.step(
                 frame_torch,
@@ -782,6 +845,10 @@ class CutieMaskPropagator(MaskPropagator):
                 objects=new_object_ids,
                 idx_mask=True,
             )
+
+        # Kept features are now consumed (or were unusable); drop them so the
+        # store never accumulates entries across iterations.
+        self._drop_cached_features()
 
         self._last_object_id = max(new_object_ids)
         self._tracklet_object_dict.update(zip(sorted_tracklet_ids, new_object_ids))
@@ -838,5 +905,6 @@ class CutieMaskPropagator(MaskPropagator):
         # reset() and complements the self-cleaning initialize().
         if len(self._object_ids) == 0:
             self.processor.clear_memory()
+            self._drop_cached_features()
             self._last_indexed_mask = None
             self._initialized = False

--- a/src/trackers/core/mcbyte/masks/cutie.py
+++ b/src/trackers/core/mcbyte/masks/cutie.py
@@ -836,7 +836,9 @@ class CutieMaskPropagator(MaskPropagator):
             and (frame is self._cached_feature_frame or np.array_equal(frame, self._cached_feature_frame))
         ):
             store = self.processor.image_feature_store
-            store._store[self.processor.curr_ti + 1] = store._store[self._cached_feature_ti]
+            store_dict = getattr(store, "_store", None)
+            if isinstance(store_dict, dict) and self._cached_feature_ti in store_dict:
+                store_dict[self._cached_feature_ti + 1] = store_dict[self._cached_feature_ti]
 
         with _autocast_context(self.use_amp):
             prob = self.processor.step(

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -27,6 +27,186 @@ from trackers.core.mcbyte.masks.cutie import (  # noqa: E402
 )
 
 
+class _FakeObject:
+    """Cutie object stub exposing the immutable ``id`` attribute."""
+
+    def __init__(self, object_id: int) -> None:
+        self.id = object_id
+
+
+class _FakeObjectManager:
+    """ObjectManager stub exposing the temporary-ID -> object mapping."""
+
+    def __init__(self, tmp_id_to_obj: dict[int, _FakeObject]) -> None:
+        self.tmp_id_to_obj = tmp_id_to_obj
+
+
+class _FakeFeatureStore:
+    """ImageFeatureStore stub modeling encode-on-miss plus explicit delete.
+
+    ``encode_count`` records how many distinct time indices were encoded so a
+    test can assert an add_masks reused a prior propagate's features (count
+    unchanged) instead of re-encoding the identical frame.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[int, tuple[str, int]] = {}
+        self.encode_count = 0
+        self.no_warning = False
+
+    def get_features(self, index: int, image: Any) -> tuple[str, int]:
+        if index not in self._store:
+            self.encode_count += 1
+            self._store[index] = ("features", index)
+        return self._store[index]
+
+    def delete(self, index: int) -> None:
+        self._store.pop(index, None)
+
+
+class _FakeInferenceCore:
+    """InferenceCore stub mirroring curr_ti bookkeeping and delete_buffer.
+
+    ``step`` increments ``curr_ti`` before its feature lookup (as the real core
+    does), encodes on a store miss, and drops the entry when ``delete_buffer`` is
+    True. It returns a fixed probability tensor so the wrapper's downstream mask
+    conversion runs unchanged.
+    """
+
+    def __init__(self, prob: Any, tmp_id_to_obj: dict[int, _FakeObject]) -> None:
+        self.image_feature_store = _FakeFeatureStore()
+        self.object_manager = _FakeObjectManager(tmp_id_to_obj)
+        self.curr_ti = -1
+        self._prob = prob
+
+    def step(
+        self,
+        image: Any,
+        mask: Any | None = None,
+        objects: list[int] | None = None,
+        *,
+        idx_mask: bool = True,
+        delete_buffer: bool = True,
+    ) -> Any:
+        self.curr_ti += 1
+        self.image_feature_store.get_features(self.curr_ti, image)
+        if delete_buffer:
+            self.image_feature_store.delete(self.curr_ti)
+        return self._prob
+
+    def clear_memory(self) -> None:
+        self.curr_ti = -1
+
+
+def _make_reuse_propagator(prob: Any, tmp_id_to_obj: dict[int, _FakeObject]) -> CutieMaskPropagator:
+    """Build an initialized propagator wired to a feature-store-aware fake core."""
+    propagator = object.__new__(CutieMaskPropagator)
+    propagator.device = torch.device("cpu")
+    propagator.use_amp = False
+    propagator.processor = _FakeInferenceCore(prob, tmp_id_to_obj)
+    propagator._initialized = True
+    propagator._tracklet_object_dict = {10: 1}
+    propagator._object_ids = [1]
+    propagator._last_object_id = 1
+    propagator._last_indexed_mask = np.zeros((2, 2), dtype=np.int32)
+    propagator._cached_feature_ti = None
+    propagator._cached_feature_frame = None
+    return propagator
+
+
+def test_drop_cached_features_deletes_store_entry_and_clears_fields() -> None:
+    """_drop_cached_features removes the retained store entry and resets the cache pointers."""
+    prob = torch.zeros((3, 2, 2), dtype=torch.float32)
+    prob[0] = 1.0
+    propagator = _make_reuse_propagator(prob, {1: _FakeObject(1), 2: _FakeObject(2)})
+    propagator.processor.image_feature_store._store[7] = ("features", 7)
+    propagator._cached_feature_ti = 7
+    propagator._cached_feature_frame = np.zeros((2, 2, 3), dtype=np.uint8)
+
+    propagator._drop_cached_features()
+
+    assert 7 not in propagator.processor.image_feature_store._store
+    assert propagator._cached_feature_ti is None
+    assert propagator._cached_feature_frame is None
+
+
+def test_add_masks_reuses_cached_features_for_the_same_frame() -> None:
+    """add_masks on the frame propagate last encoded reuses those features, skipping a re-encode."""
+    prob = torch.zeros((3, 2, 2), dtype=torch.float32)
+    prob[0] = 1.0
+    propagator = _make_reuse_propagator(prob, {1: _FakeObject(1), 2: _FakeObject(2)})
+    frame = np.zeros((2, 2, 3), dtype=np.uint8)
+
+    # Simulate the preceding propagate: features kept at ti=0, cache recorded.
+    store = propagator.processor.image_feature_store
+    propagator.processor.curr_ti = 0
+    store._store[0] = ("features", 0)
+    store.encode_count = 0
+    propagator._cached_feature_ti = 0
+    propagator._cached_feature_frame = frame
+
+    propagator.add_masks(
+        frame=frame,
+        mask_output=MaskOutput(
+            masks=np.ones((1, 2, 2), dtype=bool),
+            tracklet_mask_dict={20: 0},
+            mask_avg_prob_dict=None,
+        ),
+    )
+
+    assert store.encode_count == 0
+    # Both the original entry and the pre-seeded copy are dropped: no leak.
+    assert store._store == {}
+    assert propagator._cached_feature_ti is None
+
+
+def test_add_masks_reencodes_when_frame_differs_from_cache() -> None:
+    """The identity guard falls back to a normal encode when add_masks gets a different frame."""
+    prob = torch.zeros((3, 2, 2), dtype=torch.float32)
+    prob[0] = 1.0
+    propagator = _make_reuse_propagator(prob, {1: _FakeObject(1), 2: _FakeObject(2)})
+
+    store = propagator.processor.image_feature_store
+    propagator.processor.curr_ti = 0
+    store._store[0] = ("features", 0)
+    store.encode_count = 0
+    propagator._cached_feature_ti = 0
+    propagator._cached_feature_frame = np.zeros((2, 2, 3), dtype=np.uint8)
+
+    propagator.add_masks(
+        frame=np.full((2, 2, 3), 255, dtype=np.uint8),
+        mask_output=MaskOutput(
+            masks=np.ones((1, 2, 2), dtype=bool),
+            tracklet_mask_dict={20: 0},
+            mask_avg_prob_dict=None,
+        ),
+    )
+
+    assert store.encode_count == 1
+    assert store._store == {}
+    assert propagator._cached_feature_ti is None
+
+
+def test_propagate_retains_single_feature_entry_and_reset_clears_it() -> None:
+    """propagate keeps exactly one feature entry alive for reuse; reset drops it to avoid ti collisions."""
+    prob = torch.zeros((2, 2, 2), dtype=torch.float32)
+    prob[0] = 1.0
+    propagator = _make_reuse_propagator(prob, {1: _FakeObject(1)})
+    store = propagator.processor.image_feature_store
+
+    propagator.propagate(frame=np.zeros((2, 2, 3), dtype=np.uint8))
+    propagator.propagate(frame=np.zeros((2, 2, 3), dtype=np.uint8))
+
+    # Each propagate drops the previous kept entry before keeping its own.
+    assert len(store._store) == 1
+    assert propagator._cached_feature_ti == propagator.processor.curr_ti
+
+    propagator.reset()
+
+    assert store._store == {}
+    assert propagator._cached_feature_ti is None
+
+
 @pytest.fixture
 def initialized_cutie_propagator() -> CutieMaskPropagator:
     propagator = object.__new__(CutieMaskPropagator)
@@ -37,6 +217,8 @@ def initialized_cutie_propagator() -> CutieMaskPropagator:
     propagator._object_ids = []
     propagator._last_object_id = 0
     propagator._last_indexed_mask = None
+    propagator._cached_feature_ti = None
+    propagator._cached_feature_frame = None
     return propagator
 
 
@@ -425,6 +607,8 @@ def test_initialize_success_path_builds_state_and_calls_processor_step() -> None
     propagator._initialized = False
     propagator._last_object_id = 0
     propagator._last_indexed_mask = None
+    propagator._cached_feature_ti = None
+    propagator._cached_feature_frame = None
 
     masks = np.zeros((2, 4, 4), dtype=bool)
     masks[0, 0:2, 0:2] = True
@@ -498,6 +682,8 @@ def test_initialize_clears_stale_memory_on_mid_sequence_reinitialization() -> No
     propagator._initialized = False
     propagator._last_object_id = 0
     propagator._last_indexed_mask = None
+    propagator._cached_feature_ti = None
+    propagator._cached_feature_frame = None
 
     first_masks = np.zeros((2, 4, 4), dtype=bool)
     first_masks[0, 0:2, 0:2] = True
@@ -563,6 +749,8 @@ def test_initialize_resets_cutie_memory_when_no_masks_to_initialize(
     propagator._last_object_id = 1
     propagator._last_indexed_mask = np.ones((4, 4), dtype=np.int32)
     propagator._initialized = True
+    propagator._cached_feature_ti = None
+    propagator._cached_feature_frame = None
 
     propagator.initialize(
         frame=np.zeros((4, 4, 3), dtype=np.uint8),
@@ -873,8 +1061,12 @@ def test_propagate_returns_mask_output_contract_after_temporary_id_shift(
     class DummyProcessor:
         def __init__(self) -> None:
             self.object_manager = DummyObjectManager()
+            self.curr_ti = 0
+            self.step_delete_buffer: bool | None = None
 
-        def step(self, frame: Any) -> Any:
+        def step(self, frame: Any, *, delete_buffer: bool = True) -> Any:
+            # propagate keeps features alive for a possible next add_masks.
+            self.step_delete_buffer = delete_buffer
             # Channels:
             # 0: background, 1: tmp 1 -> object 1, 2: tmp 2 -> object 3.
             return torch.tensor(
@@ -957,3 +1149,9 @@ def test_propagate_returns_mask_output_contract_after_temporary_id_shift(
             dtype=np.int32,
         ),
     )
+
+    # propagate keeps its image features alive (delete_buffer=False) and records
+    # the store index and frame so a following add_masks can reuse them.
+    assert propagator.processor.step_delete_buffer is False
+    assert propagator._cached_feature_ti == 0
+    assert propagator._cached_feature_frame is not None


### PR DESCRIPTION
- propagate() keeps its InferenceCore image features alive (delete_buffer=False) and records the store index + frame; the next add_masks() on that same frame pre-seeds image_feature_store._store[curr_ti+1] so its step reuses them instead of re-encoding identical pixels
- _drop_cached_features() clears the retained entry on propagate-start, reset, initialize, and remove-all; mandatory because clear_memory restarts curr_ti at -1 and a stale entry would be re-read on cycle-back
- guard reuse behind a frame-identity check (is / np.array_equal), falling back to a normal encode otherwise; set image_feature_store.no_warning since one retained entry after the final propagate is intentional
- _image_to_torch() uploads uint8 contiguous and casts to float on the device instead of materializing a 4x-larger float32 tensor host-side (bit-identical)
- add reuse/guard/drop/single-entry-retention unit tests; thread delete_buffer + curr_ti through the propagate and add_masks test fakes
