### PR TITLE
perf(mcbyte): default-off precision/compile knobs

### DIFF
--- a/src/trackers/core/mcbyte/masks/cutie.py
+++ b/src/trackers/core/mcbyte/masks/cutie.py
@@ -154,6 +154,8 @@ def _apply_backend_perf_options(
     if channels_last:
         model = model.to(memory_format=torch.channels_last)
     if compile_model:
+        if not hasattr(torch, "compile"):
+            raise RuntimeError("compile_model=True requires torch.compile (PyTorch >= 2.0).")
         for method_name in ("encode_image", "transform_key"):
             method = getattr(model, method_name, None)
             if method is not None:

--- a/src/trackers/core/mcbyte/masks/cutie.py
+++ b/src/trackers/core/mcbyte/masks/cutie.py
@@ -95,13 +95,70 @@ def _get_cutie_package_dir(cutie_module: Any) -> Path:
     return Path(module_paths[0]).resolve()
 
 
-def _autocast_context(use_amp: bool) -> Any:
-    """Return the appropriate autocast context for the current AMP setting."""
+def _autocast_context(use_amp: bool, device: torch.device) -> Any:
+    """Return the appropriate autocast context for the current AMP setting.
+
+    The autocast device type follows ``device`` rather than a hardcoded
+    ``"cuda"`` so the helper is backend-generic. In practice callers gate
+    ``use_amp`` to CUDA (Cutie wraps precision-sensitive ops in
+    ``torch.cuda.amp.autocast(enabled=False)`` blocks that an MPS autocast would
+    not honor), so the returned context is a CUDA autocast on the default path
+    and a no-op otherwise.
+
+    Args:
+        use_amp: Whether automatic mixed precision is requested.
+        device: Device whose ``type`` selects the autocast backend.
+    """
     if use_amp:
         if hasattr(torch, "amp"):
-            return torch.amp.autocast("cuda", enabled=True)
+            return torch.amp.autocast(device.type, enabled=True)
         return torch.cuda.amp.autocast(enabled=True)
     return nullcontext()
+
+
+def _apply_backend_perf_options(
+    model: Any,
+    *,
+    channels_last: bool,
+    compile_model: bool,
+) -> Any:
+    """Apply optional, opt-in backend performance transforms to the Cutie model.
+
+    Both transforms are off by default; when disabled the model is returned
+    unchanged so the default pipeline stays bit-identical. Neither transform is
+    guaranteed to preserve outputs bit-for-bit once enabled (channels_last and
+    ``torch.compile`` may select different kernels), so each must pass a
+    per-backend fp32-parity check before being recommended.
+
+    Args:
+        model: The Cutie ``CUTIE`` network, already moved to its device and
+            loaded with weights.
+        channels_last: When True, convert 4D convolution weights to the
+            ``channels_last`` memory format. 1D/non-4D parameters are left
+            untouched. Most beneficial for convolutional encoders on CUDA
+            tensor cores.
+        compile_model: When True, wrap the shape-stable per-frame encoder
+            entry points (``encode_image`` and ``transform_key``) with
+            ``torch.compile``. Cutie's ``InferenceCore`` calls these network
+            submethods directly rather than ``model(...)``, so a module-level
+            ``torch.compile`` would never run; ``segment`` and ``encode_mask``
+            are deliberately left eager because their object-count dimension
+            varies frame to frame and would trigger repeated recompilation.
+            Their input shape, by contrast, is fixed after Cutie's internal
+            resize and ``pad_divide_by(16)``, so compiling them is churn-free.
+
+    Returns:
+        The transformed model (the same object; transforms are applied in
+        place and the reference is returned for call-site clarity).
+    """
+    if channels_last:
+        model = model.to(memory_format=torch.channels_last)
+    if compile_model:
+        for method_name in ("encode_image", "transform_key"):
+            method = getattr(model, method_name, None)
+            if method is not None:
+                setattr(model, method_name, torch.compile(method))
+    return model
 
 
 def _image_to_torch(
@@ -406,6 +463,15 @@ class CutieMaskPropagator(MaskPropagator):
         use_long_term: Whether Cutie uses bounded long-term memory,
             recommended for videos longer than roughly one minute. ``None``
             keeps the value from the loaded Cutie configuration.
+        channels_last: Opt-in ``channels_last`` memory format for the Cutie
+            model's convolution weights. Off by default (unchanged model);
+            may change kernel selection, so validate fp32 output parity on
+            your backend before enabling. Primarily helps CUDA.
+        compile_model: Opt-in ``torch.compile`` of Cutie's shape-stable
+            per-frame encoder methods (``encode_image``, ``transform_key``).
+            Off by default. Incurs first-call warmup and may alter numerics,
+            so validate fp32 output parity before enabling; ``torch.compile``
+            support on MPS is experimental.
     """
 
     def __init__(
@@ -419,6 +485,8 @@ class CutieMaskPropagator(MaskPropagator):
         max_internal_size: int = 480,
         mem_every: int | None = 10,
         use_long_term: bool | None = True,
+        channels_last: bool = False,
+        compile_model: bool = False,
     ) -> None:
         try:
             import cutie
@@ -444,6 +512,8 @@ class CutieMaskPropagator(MaskPropagator):
         self.max_internal_size = max_internal_size
         self.mem_every = mem_every
         self.use_long_term = use_long_term
+        self.channels_last = channels_last
+        self.compile_model = compile_model
 
         asset = CUTIE_ASSETS.get(model_type)
         if asset is None:
@@ -481,6 +551,17 @@ class CutieMaskPropagator(MaskPropagator):
         # checkpoint is a plain state_dict consumed by load_weights, so it loads cleanly.
         model_weights = torch.load(self.weights_path, map_location=self.device, weights_only=True)
         self.cutie.load_weights(model_weights)
+
+        # Opt-in backend transforms (both off by default -> unchanged model).
+        # Applied after weights load so channels_last converts the loaded
+        # parameters and torch.compile wraps the final methods. InferenceCore
+        # and ImageFeatureStore both hold this same object, so patching its
+        # submethods here propagates to Cutie's actual call sites.
+        self.cutie = _apply_backend_perf_options(
+            self.cutie,
+            channels_last=self.channels_last,
+            compile_model=self.compile_model,
+        )
 
         self.processor = InferenceCore(self.cutie, cfg=cfg)
         # This propagator manages the image-feature-store buffer lifecycle
@@ -609,7 +690,7 @@ class CutieMaskPropagator(MaskPropagator):
         frame_torch = _image_to_torch(frame, self.device)
         masks_torch = _binary_masks_to_non_overlapping_torch(mask_output.masks, self.device)
 
-        with _autocast_context(self.use_amp):
+        with _autocast_context(self.use_amp, self.device):
             _ = self.processor.step(
                 frame_torch,
                 masks_torch,
@@ -636,7 +717,7 @@ class CutieMaskPropagator(MaskPropagator):
         # delete_buffer=False changes only buffer retention, not the returned
         # probabilities, so propagate output is unaffected.
         self._drop_cached_features()
-        with _autocast_context(self.use_amp):
+        with _autocast_context(self.use_amp, self.device):
             prob = self.processor.step(frame_torch, delete_buffer=False)
         self._cached_feature_ti = self.processor.curr_ti
         self._cached_feature_frame = frame
@@ -840,7 +921,7 @@ class CutieMaskPropagator(MaskPropagator):
             if isinstance(store_dict, dict) and self._cached_feature_ti in store_dict:
                 store_dict[self._cached_feature_ti + 1] = store_dict[self._cached_feature_ti]
 
-        with _autocast_context(self.use_amp):
+        with _autocast_context(self.use_amp, self.device):
             prob = self.processor.step(
                 frame_torch,
                 indexed_mask_torch,

--- a/src/trackers/core/mcbyte/masks/sam.py
+++ b/src/trackers/core/mcbyte/masks/sam.py
@@ -76,11 +76,21 @@ def _ensure_checkpoint_exists(
     )
 
 
-def _autocast_context(use_amp: bool) -> Any:
-    """Return the appropriate autocast context for the current AMP setting."""
+def _autocast_context(use_amp: bool, device: torch.device) -> Any:
+    """Return the appropriate autocast context for the current AMP setting.
+
+    The autocast device type follows ``device`` rather than a hardcoded
+    ``"cuda"`` so the helper is backend-generic. Callers gate ``use_amp`` to
+    CUDA, so the returned context is a CUDA autocast on the default path and a
+    no-op otherwise.
+
+    Args:
+        use_amp: Whether automatic mixed precision is requested.
+        device: Device whose ``type`` selects the autocast backend.
+    """
     if use_amp:
         if hasattr(torch, "amp"):
-            return torch.amp.autocast("cuda", enabled=True)
+            return torch.amp.autocast(device.type, enabled=True)
         return torch.cuda.amp.autocast(enabled=True)
     return nullcontext()
 
@@ -182,7 +192,7 @@ class SAMBoxMaskGenerator(MaskGenerator):
 
         box_tensor = torch.as_tensor(boxes, dtype=torch.float32, device=self.device)
 
-        with _autocast_context(self.use_amp):
+        with _autocast_context(self.use_amp, self.device):
             # set_image runs the SAM image encoder and predict_torch the mask
             # decoder; both are the dominant SAM cost and benefit from AMP on CUDA.
             self.predictor.set_image(frame)

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -114,6 +114,14 @@ class McByteMaskConfig:
         cutie_use_long_term: Whether Cutie uses bounded long-term memory,
             recommended for videos longer than roughly one minute. ``None``
             keeps the value from the loaded Cutie configuration.
+        cutie_channels_last: Opt-in ``channels_last`` memory format for the
+            Cutie model. Off by default so default runs are unchanged; it may
+            alter kernel selection, so validate fp32 tracking-quality parity on
+            your backend before enabling. Primarily helps CUDA.
+        cutie_compile: Opt-in ``torch.compile`` of Cutie's shape-stable
+            per-frame encoder path. Off by default; incurs first-call warmup
+            and may alter numerics, so validate fp32 parity before enabling.
+            ``torch.compile`` support on MPS is experimental.
         mask_creation_bbox_overlap_threshold: Bounding-box overlap fraction at
             or above which mask creation is delayed by ``MaskManager``.
     """
@@ -131,6 +139,8 @@ class McByteMaskConfig:
     cutie_max_internal_size: int = 480
     cutie_mem_every: int | None = 10
     cutie_use_long_term: bool | None = True
+    cutie_channels_last: bool = False
+    cutie_compile: bool = False
 
     mask_creation_bbox_overlap_threshold: float = MASK_CREATION_BBOX_OVERLAP_THRESHOLD
 
@@ -159,6 +169,8 @@ def _build_default_mask_manager(
         max_internal_size=config.cutie_max_internal_size,
         mem_every=config.cutie_mem_every,
         use_long_term=config.cutie_use_long_term,
+        channels_last=config.cutie_channels_last,
+        compile_model=config.cutie_compile,
     )
 
     return MaskManager(

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import Any
 
 import numpy as np
@@ -16,6 +17,8 @@ torch = pytest.importorskip("torch")
 from trackers.core.mcbyte.masks.base import MaskOutput  # noqa: E402
 from trackers.core.mcbyte.masks.cutie import (  # noqa: E402
     CutieMaskPropagator,
+    _apply_backend_perf_options,
+    _autocast_context,
     _binary_masks_to_indexed_mask,
     _binary_masks_to_non_overlapping_torch,
     _build_tracklet_object_dict,
@@ -1155,3 +1158,74 @@ def test_propagate_returns_mask_output_contract_after_temporary_id_shift(
     assert propagator.processor.step_delete_buffer is False
     assert propagator._cached_feature_ti == 0
     assert propagator._cached_feature_frame is not None
+
+
+def test_autocast_context_disabled_returns_nullcontext() -> None:
+    """With AMP off the helper returns a no-op context regardless of device."""
+    context = _autocast_context(use_amp=False, device=torch.device("cuda"))
+
+    assert isinstance(context, nullcontext)
+
+
+@pytest.mark.parametrize(
+    "device_type",
+    [
+        pytest.param("cuda", id="cuda"),
+        pytest.param("cpu", id="cpu"),
+    ],
+)
+def test_autocast_context_enabled_follows_device_type(device_type: str) -> None:
+    """With AMP on the autocast backend follows the device type, not a hardcoded 'cuda'."""
+    context = _autocast_context(use_amp=True, device=torch.device(device_type))
+
+    assert context.device == device_type
+
+
+def test_apply_backend_perf_options_disabled_returns_model_unchanged() -> None:
+    """Both transforms off leave the model object and its weight layout untouched."""
+    model = torch.nn.Sequential(torch.nn.Conv2d(3, 8, 3))
+
+    result = _apply_backend_perf_options(model, channels_last=False, compile_model=False)
+
+    assert result is model
+    # Default 4D convolution weight stays standard-contiguous (not channels_last).
+    assert model[0].weight.is_contiguous()
+
+
+def test_apply_backend_perf_options_channels_last_converts_conv_weights() -> None:
+    """channels_last=True converts the model's 4D convolution weights in place."""
+    model = torch.nn.Sequential(torch.nn.Conv2d(3, 8, 3))
+
+    result = _apply_backend_perf_options(model, channels_last=True, compile_model=False)
+
+    assert result is model
+    assert model[0].weight.is_contiguous(memory_format=torch.channels_last)
+
+
+def test_apply_backend_perf_options_compiles_only_shape_stable_encoder_methods() -> None:
+    """compile_model=True wraps encode_image/transform_key but leaves the variable-shape methods eager."""
+
+    class _FakeCutieNet:
+        """Network stub whose methods are stable instance attributes for identity checks."""
+
+        def __init__(self) -> None:
+            self.encode_image = lambda image: image
+            self.transform_key = lambda features: features
+            self.segment = lambda *args: args
+            self.encode_mask = lambda *args: args
+
+    model = _FakeCutieNet()
+    original_encode_image = model.encode_image
+    original_transform_key = model.transform_key
+    original_segment = model.segment
+    original_encode_mask = model.encode_mask
+
+    result = _apply_backend_perf_options(model, channels_last=False, compile_model=True)
+
+    assert result is model
+    # Shape-stable per-frame encoder path is compiled.
+    assert model.encode_image is not original_encode_image
+    assert model.transform_key is not original_transform_key
+    # Variable object-count methods stay eager to avoid recompilation churn.
+    assert model.segment is original_segment
+    assert model.encode_mask is original_encode_mask

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -1177,10 +1177,7 @@ def test_autocast_context_disabled_returns_nullcontext(monkeypatch: pytest.Monke
 
 @pytest.mark.parametrize(
     "device_type",
-    [
-        pytest.param("cuda", id="cuda"),
-        pytest.param("cpu", id="cpu"),
-    ],
+    ["cuda","cpu"]
 )
 def test_autocast_context_enabled_follows_device_type(device_type: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """With AMP on the autocast backend follows the device type, not a hardcoded 'cuda'."""

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -1161,11 +1161,18 @@ def test_propagate_returns_mask_output_contract_after_temporary_id_shift(
     assert propagator._cached_feature_frame is not None
 
 
-def test_autocast_context_disabled_returns_nullcontext() -> None:
-    """With AMP off the helper returns a no-op context regardless of device."""
+def test_autocast_context_disabled_returns_nullcontext(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With AMP off the helper returns a no-op context and never constructs an autocast."""
+    autocast_calls: list[tuple[Any, Any]] = []
+    monkeypatch.setattr(
+        "trackers.core.mcbyte.masks.cutie.torch",
+        SimpleNamespace(amp=SimpleNamespace(autocast=lambda *args, **kwargs: autocast_calls.append((args, kwargs)))),
+    )
+
     context = _autocast_context(use_amp=False, device=torch.device("cuda"))
 
     assert isinstance(context, nullcontext)
+    assert autocast_calls == []
 
 
 @pytest.mark.parametrize(
@@ -1193,40 +1200,77 @@ def test_autocast_context_enabled_follows_device_type(device_type: str, monkeypa
     assert calls == [(device_type, True)]
 
 
-def test_apply_backend_perf_options_disabled_returns_model_unchanged() -> None:
-    """Both transforms off leave the model object and its weight layout untouched."""
-    model = torch.nn.Sequential(torch.nn.Conv2d(3, 8, 3))
+class _FakePerfModel:
+    """Cutie-network stub for backend-perf-option tests.
+
+    Records every ``.to`` memory-format call and exposes the four Cutie
+    inference entry points as stable instance attributes, so a test can assert
+    exactly which ones ``_apply_backend_perf_options`` rewires (and how many
+    times ``.to`` runs) without a real model or a real compile.
+    """
+
+    def __init__(self) -> None:
+        self.to_calls: list[Any] = []
+        self.encode_image = lambda image: image
+        self.transform_key = lambda features: features
+        self.segment = lambda *args: args
+        self.encode_mask = lambda *args: args
+
+    def to(self, *, memory_format: Any) -> _FakePerfModel:
+        self.to_calls.append(memory_format)
+        return self
+
+
+def _patch_cutie_backend_torch(monkeypatch: pytest.MonkeyPatch, compile_calls: list[Any]) -> None:
+    """Replace the cutie module's ``torch`` with a stub recording ``torch.compile`` calls.
+
+    ``channels_last`` passes the genuine memory-format sentinel through so the
+    helper still forwards the real value to ``model.to``; ``compile`` appends
+    each wrapped method and returns a distinguishable marker, letting the wiring
+    be asserted without invoking the real (slow) compiler.
+    """
+
+    def fake_compile(method: Any) -> tuple[str, Any]:
+        compile_calls.append(method)
+        return ("compiled", method)
+
+    monkeypatch.setattr(
+        "trackers.core.mcbyte.masks.cutie.torch",
+        SimpleNamespace(channels_last=torch.channels_last, compile=fake_compile),
+    )
+
+
+def test_apply_backend_perf_options_disabled_invokes_no_transform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both transforms off: neither model.to nor torch.compile runs and the model is returned as-is."""
+    compile_calls: list[Any] = []
+    _patch_cutie_backend_torch(monkeypatch, compile_calls)
+    model = _FakePerfModel()
 
     result = _apply_backend_perf_options(model, channels_last=False, compile_model=False)
 
     assert result is model
-    # Default 4D convolution weight stays standard-contiguous (not channels_last).
-    assert model[0].weight.is_contiguous()
+    assert model.to_calls == []
+    assert compile_calls == []
 
 
-def test_apply_backend_perf_options_channels_last_converts_conv_weights() -> None:
-    """channels_last=True converts the model's 4D convolution weights in place."""
-    model = torch.nn.Sequential(torch.nn.Conv2d(3, 8, 3))
+def test_apply_backend_perf_options_channels_last_converts_model_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """channels_last=True calls model.to exactly once with the channels_last format and compiles nothing."""
+    compile_calls: list[Any] = []
+    _patch_cutie_backend_torch(monkeypatch, compile_calls)
+    model = _FakePerfModel()
 
     result = _apply_backend_perf_options(model, channels_last=True, compile_model=False)
 
     assert result is model
-    assert model[0].weight.is_contiguous(memory_format=torch.channels_last)
+    assert model.to_calls == [torch.channels_last]
+    assert compile_calls == []
 
 
-def test_apply_backend_perf_options_compiles_only_shape_stable_encoder_methods() -> None:
-    """compile_model=True wraps encode_image/transform_key but leaves the variable-shape methods eager."""
-
-    class _FakeCutieNet:
-        """Network stub whose methods are stable instance attributes for identity checks."""
-
-        def __init__(self) -> None:
-            self.encode_image = lambda image: image
-            self.transform_key = lambda features: features
-            self.segment = lambda *args: args
-            self.encode_mask = lambda *args: args
-
-    model = _FakeCutieNet()
+def test_apply_backend_perf_options_compiles_only_shape_stable_encoder_methods(monkeypatch: pytest.MonkeyPatch) -> None:
+    """compile_model=True compiles exactly encode_image + transform_key, leaving the variable-shape methods eager."""
+    compile_calls: list[Any] = []
+    _patch_cutie_backend_torch(monkeypatch, compile_calls)
+    model = _FakePerfModel()
     original_encode_image = model.encode_image
     original_transform_key = model.transform_key
     original_segment = model.segment
@@ -1235,9 +1279,11 @@ def test_apply_backend_perf_options_compiles_only_shape_stable_encoder_methods()
     result = _apply_backend_perf_options(model, channels_last=False, compile_model=True)
 
     assert result is model
-    # Shape-stable per-frame encoder path is compiled.
-    assert model.encode_image is not original_encode_image
-    assert model.transform_key is not original_transform_key
+    # Exactly the two shape-stable encoder methods are compiled, in order.
+    assert compile_calls == [original_encode_image, original_transform_key]
+    assert model.to_calls == []
+    assert model.encode_image == ("compiled", original_encode_image)
+    assert model.transform_key == ("compiled", original_transform_key)
     # Variable object-count methods stay eager to avoid recompilation churn.
     assert model.segment is original_segment
     assert model.encode_mask is original_encode_mask

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -1175,10 +1175,7 @@ def test_autocast_context_disabled_returns_nullcontext(monkeypatch: pytest.Monke
     assert autocast_calls == []
 
 
-@pytest.mark.parametrize(
-    "device_type",
-    ["cuda","cpu"]
-)
+@pytest.mark.parametrize("device_type", ["cuda", "cpu"])
 def test_autocast_context_enabled_follows_device_type(device_type: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """With AMP on the autocast backend follows the device type, not a hardcoded 'cuda'."""
     calls: list[tuple[str, bool]] = []

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -1174,11 +1175,22 @@ def test_autocast_context_disabled_returns_nullcontext() -> None:
         pytest.param("cpu", id="cpu"),
     ],
 )
-def test_autocast_context_enabled_follows_device_type(device_type: str) -> None:
+def test_autocast_context_enabled_follows_device_type(device_type: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """With AMP on the autocast backend follows the device type, not a hardcoded 'cuda'."""
+    calls: list[tuple[str, bool]] = []
+
+    def fake_autocast(actual_device_type: str, *, enabled: bool) -> nullcontext[Any]:
+        calls.append((actual_device_type, enabled))
+        return nullcontext()
+
+    monkeypatch.setattr(
+        "trackers.core.mcbyte.masks.cutie.torch",
+        SimpleNamespace(amp=SimpleNamespace(autocast=fake_autocast)),
+    )
     context = _autocast_context(use_amp=True, device=torch.device(device_type))
 
-    assert context.device == device_type
+    assert isinstance(context, nullcontext)
+    assert calls == [(device_type, True)]
 
 
 def test_apply_backend_perf_options_disabled_returns_model_unchanged() -> None:

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -7,8 +7,8 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
-from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -1163,16 +1163,13 @@ def test_propagate_returns_mask_output_contract_after_temporary_id_shift(
 
 def test_autocast_context_disabled_returns_nullcontext(monkeypatch: pytest.MonkeyPatch) -> None:
     """With AMP off the helper returns a no-op context and never constructs an autocast."""
-    autocast_calls: list[tuple[Any, Any]] = []
-    monkeypatch.setattr(
-        "trackers.core.mcbyte.masks.cutie.torch",
-        SimpleNamespace(amp=SimpleNamespace(autocast=lambda *args, **kwargs: autocast_calls.append((args, kwargs)))),
-    )
+    autocast_mock = MagicMock()
+    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.amp.autocast", autocast_mock)
 
     context = _autocast_context(use_amp=False, device=torch.device("cuda"))
 
     assert isinstance(context, nullcontext)
-    assert autocast_calls == []
+    autocast_mock.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -1184,93 +1181,46 @@ def test_autocast_context_disabled_returns_nullcontext(monkeypatch: pytest.Monke
 )
 def test_autocast_context_enabled_follows_device_type(device_type: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """With AMP on the autocast backend follows the device type, not a hardcoded 'cuda'."""
-    calls: list[tuple[str, bool]] = []
+    autocast_mock = MagicMock()
+    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.amp.autocast", autocast_mock)
 
-    def fake_autocast(actual_device_type: str, *, enabled: bool) -> nullcontext[Any]:
-        calls.append((actual_device_type, enabled))
-        return nullcontext()
-
-    monkeypatch.setattr(
-        "trackers.core.mcbyte.masks.cutie.torch",
-        SimpleNamespace(amp=SimpleNamespace(autocast=fake_autocast)),
-    )
     context = _autocast_context(use_amp=True, device=torch.device(device_type))
 
-    assert isinstance(context, nullcontext)
-    assert calls == [(device_type, True)]
-
-
-class _FakePerfModel:
-    """Cutie-network stub for backend-perf-option tests.
-
-    Records every ``.to`` memory-format call and exposes the four Cutie
-    inference entry points as stable instance attributes, so a test can assert
-    exactly which ones ``_apply_backend_perf_options`` rewires (and how many
-    times ``.to`` runs) without a real model or a real compile.
-    """
-
-    def __init__(self) -> None:
-        self.to_calls: list[Any] = []
-        self.encode_image = lambda image: image
-        self.transform_key = lambda features: features
-        self.segment = lambda *args: args
-        self.encode_mask = lambda *args: args
-
-    def to(self, *, memory_format: Any) -> _FakePerfModel:
-        self.to_calls.append(memory_format)
-        return self
-
-
-def _patch_cutie_backend_torch(monkeypatch: pytest.MonkeyPatch, compile_calls: list[Any]) -> None:
-    """Replace the cutie module's ``torch`` with a stub recording ``torch.compile`` calls.
-
-    ``channels_last`` passes the genuine memory-format sentinel through so the
-    helper still forwards the real value to ``model.to``; ``compile`` appends
-    each wrapped method and returns a distinguishable marker, letting the wiring
-    be asserted without invoking the real (slow) compiler.
-    """
-
-    def fake_compile(method: Any) -> tuple[str, Any]:
-        compile_calls.append(method)
-        return ("compiled", method)
-
-    monkeypatch.setattr(
-        "trackers.core.mcbyte.masks.cutie.torch",
-        SimpleNamespace(channels_last=torch.channels_last, compile=fake_compile),
-    )
+    autocast_mock.assert_called_once_with(device_type, enabled=True)
+    assert context is autocast_mock.return_value
 
 
 def test_apply_backend_perf_options_disabled_invokes_no_transform(monkeypatch: pytest.MonkeyPatch) -> None:
     """Both transforms off: neither model.to nor torch.compile runs and the model is returned as-is."""
-    compile_calls: list[Any] = []
-    _patch_cutie_backend_torch(monkeypatch, compile_calls)
-    model = _FakePerfModel()
+    compile_mock = MagicMock()
+    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.compile", compile_mock)
+    model = MagicMock()
 
     result = _apply_backend_perf_options(model, channels_last=False, compile_model=False)
 
     assert result is model
-    assert model.to_calls == []
-    assert compile_calls == []
+    model.to.assert_not_called()
+    compile_mock.assert_not_called()
 
 
 def test_apply_backend_perf_options_channels_last_converts_model_once(monkeypatch: pytest.MonkeyPatch) -> None:
     """channels_last=True calls model.to exactly once with the channels_last format and compiles nothing."""
-    compile_calls: list[Any] = []
-    _patch_cutie_backend_torch(monkeypatch, compile_calls)
-    model = _FakePerfModel()
+    compile_mock = MagicMock()
+    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.compile", compile_mock)
+    model = MagicMock()
 
     result = _apply_backend_perf_options(model, channels_last=True, compile_model=False)
 
-    assert result is model
-    assert model.to_calls == [torch.channels_last]
-    assert compile_calls == []
+    model.to.assert_called_once_with(memory_format=torch.channels_last)
+    assert result is model.to.return_value
+    compile_mock.assert_not_called()
 
 
 def test_apply_backend_perf_options_compiles_only_shape_stable_encoder_methods(monkeypatch: pytest.MonkeyPatch) -> None:
     """compile_model=True compiles exactly encode_image + transform_key, leaving the variable-shape methods eager."""
-    compile_calls: list[Any] = []
-    _patch_cutie_backend_torch(monkeypatch, compile_calls)
-    model = _FakePerfModel()
+    compile_mock = MagicMock()
+    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.compile", compile_mock)
+    model = MagicMock()
     original_encode_image = model.encode_image
     original_transform_key = model.transform_key
     original_segment = model.segment
@@ -1279,11 +1229,14 @@ def test_apply_backend_perf_options_compiles_only_shape_stable_encoder_methods(m
     result = _apply_backend_perf_options(model, channels_last=False, compile_model=True)
 
     assert result is model
-    # Exactly the two shape-stable encoder methods are compiled, in order.
-    assert compile_calls == [original_encode_image, original_transform_key]
-    assert model.to_calls == []
-    assert model.encode_image == ("compiled", original_encode_image)
-    assert model.transform_key == ("compiled", original_transform_key)
+    model.to.assert_not_called()
+    # Exactly the two shape-stable encoder methods are compiled.
+    assert compile_mock.call_count == 2
+    compile_mock.assert_any_call(original_encode_image)
+    compile_mock.assert_any_call(original_transform_key)
+    # Compiled results are assigned back to those two encoder entry points.
+    assert model.encode_image is compile_mock.return_value
+    assert model.transform_key is compile_mock.return_value
     # Variable object-count methods stay eager to avoid recompilation churn.
     assert model.segment is original_segment
     assert model.encode_mask is original_encode_mask

--- a/tests/core/test_mcbyte_cutie_mask_propagator.py
+++ b/tests/core/test_mcbyte_cutie_mask_propagator.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -1161,11 +1161,9 @@ def test_propagate_returns_mask_output_contract_after_temporary_id_shift(
     assert propagator._cached_feature_frame is not None
 
 
-def test_autocast_context_disabled_returns_nullcontext(monkeypatch: pytest.MonkeyPatch) -> None:
+@patch("trackers.core.mcbyte.masks.cutie.torch.amp.autocast")
+def test_autocast_context_disabled_returns_nullcontext(autocast_mock: MagicMock) -> None:
     """With AMP off the helper returns a no-op context and never constructs an autocast."""
-    autocast_mock = MagicMock()
-    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.amp.autocast", autocast_mock)
-
     context = _autocast_context(use_amp=False, device=torch.device("cuda"))
 
     assert isinstance(context, nullcontext)
@@ -1179,21 +1177,18 @@ def test_autocast_context_disabled_returns_nullcontext(monkeypatch: pytest.Monke
         pytest.param("cpu", id="cpu"),
     ],
 )
-def test_autocast_context_enabled_follows_device_type(device_type: str, monkeypatch: pytest.MonkeyPatch) -> None:
+@patch("trackers.core.mcbyte.masks.cutie.torch.amp.autocast")
+def test_autocast_context_enabled_follows_device_type(autocast_mock: MagicMock, device_type: str) -> None:
     """With AMP on the autocast backend follows the device type, not a hardcoded 'cuda'."""
-    autocast_mock = MagicMock()
-    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.amp.autocast", autocast_mock)
-
     context = _autocast_context(use_amp=True, device=torch.device(device_type))
 
     autocast_mock.assert_called_once_with(device_type, enabled=True)
     assert context is autocast_mock.return_value
 
 
-def test_apply_backend_perf_options_disabled_invokes_no_transform(monkeypatch: pytest.MonkeyPatch) -> None:
+@patch("trackers.core.mcbyte.masks.cutie.torch.compile")
+def test_apply_backend_perf_options_disabled_invokes_no_transform(compile_mock: MagicMock) -> None:
     """Both transforms off: neither model.to nor torch.compile runs and the model is returned as-is."""
-    compile_mock = MagicMock()
-    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.compile", compile_mock)
     model = MagicMock()
 
     result = _apply_backend_perf_options(model, channels_last=False, compile_model=False)
@@ -1203,10 +1198,9 @@ def test_apply_backend_perf_options_disabled_invokes_no_transform(monkeypatch: p
     compile_mock.assert_not_called()
 
 
-def test_apply_backend_perf_options_channels_last_converts_model_once(monkeypatch: pytest.MonkeyPatch) -> None:
+@patch("trackers.core.mcbyte.masks.cutie.torch.compile")
+def test_apply_backend_perf_options_channels_last_converts_model_once(compile_mock: MagicMock) -> None:
     """channels_last=True calls model.to exactly once with the channels_last format and compiles nothing."""
-    compile_mock = MagicMock()
-    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.compile", compile_mock)
     model = MagicMock()
 
     result = _apply_backend_perf_options(model, channels_last=True, compile_model=False)
@@ -1216,10 +1210,9 @@ def test_apply_backend_perf_options_channels_last_converts_model_once(monkeypatc
     compile_mock.assert_not_called()
 
 
-def test_apply_backend_perf_options_compiles_only_shape_stable_encoder_methods(monkeypatch: pytest.MonkeyPatch) -> None:
+@patch("trackers.core.mcbyte.masks.cutie.torch.compile")
+def test_apply_backend_perf_options_compiles_only_shape_stable_encoder_methods(compile_mock: MagicMock) -> None:
     """compile_model=True compiles exactly encode_image + transform_key, leaving the variable-shape methods eager."""
-    compile_mock = MagicMock()
-    monkeypatch.setattr("trackers.core.mcbyte.masks.cutie.torch.compile", compile_mock)
     model = MagicMock()
     original_encode_image = model.encode_image
     original_transform_key = model.transform_key

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -535,6 +535,8 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
             max_internal_size: int = 480,
             mem_every: int | None = 10,
             use_long_term: bool | None = True,
+            channels_last: bool = False,
+            compile_model: bool = False,
         ) -> None:
             created["cutie"] = {
                 "weights_path": weights_path,
@@ -546,6 +548,8 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
                 "max_internal_size": max_internal_size,
                 "mem_every": mem_every,
                 "use_long_term": use_long_term,
+                "channels_last": channels_last,
+                "compile_model": compile_model,
             }
 
         def reset(self) -> None:
@@ -588,6 +592,8 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
             cutie_max_internal_size=576,
             cutie_mem_every=7,
             cutie_use_long_term=False,
+            cutie_channels_last=True,
+            cutie_compile=True,
             mask_creation_bbox_overlap_threshold=0.7,
         ),
     )
@@ -613,6 +619,8 @@ def test_mcbyte_builds_real_mask_pipeline_when_enabled(
         "max_internal_size": 576,
         "mem_every": 7,
         "use_long_term": False,
+        "channels_last": True,
+        "compile_model": True,
     }
 
     # Verify the MaskManager-specific threshold


### PR DESCRIPTION
Generalize _autocast_context(use_amp) to (use_amp, device) in the Cutie and SAM wrappers so the autocast backend follows device.type instead of a hardcoded "cuda"; gating stays cuda-only, so the default path is unchanged.

Add _apply_backend_perf_options to CutieMaskPropagator: an opt-in channels_last memory format and an opt-in torch.compile of the shape-stable encoder methods encode_image and transform_key. Cutie's InferenceCore calls network submethods directly rather than forward(), so a module-level compile is inert; segment and encode_mask stay eager to avoid recompilation on their varying object-count dimension.

Thread cutie_channels_last and cutie_compile through McByteMaskConfig. All new knobs default off, leaving the default pipeline bit-identical. Add unit tests for the autocast context, the perf-option helper, and config threading.
