### PR TITLE
perf(kf): trim KF copies + OCSORT assoc hygiene

### DIFF
--- a/src/trackers/core/ocsort/tracker.py
+++ b/src/trackers/core/ocsort/tracker.py
@@ -139,6 +139,11 @@ class OCSORTTracker(BaseTracker):
                 detection.
             unmatched_detections: Sorted list of detection indices not matched
                 to any track.
+
+        Raises:
+            ValueError: If ``direction_consistency_matrix`` is ``None`` while
+                ``direction_consistency_weight`` is nonzero — ``None`` is only a
+                valid input when the weight is 0.
         """
         matched_indices = []
         n_tracks, n_detections = iou_matrix.shape
@@ -146,9 +151,18 @@ class OCSORTTracker(BaseTracker):
         unmatched_detections = set(range(n_detections))
         if n_tracks > 0 and n_detections > 0:
             # Find optimal assignment using scipy.optimize.linear_sum_assignment.
-            # ``direction_consistency_matrix is None`` means the weight is 0, so the
-            # cost is IoU alone (bounded finite matrix ⇒ ``iou + 0.0 * matrix == iou``).
+            # ``direction_consistency_matrix is None`` is the weight-0 sentinel passed
+            # by ``update()``: cost is IoU alone (bounded finite matrix ⇒
+            # ``iou + 0.0 * matrix == iou``). Guard the invariant so a caller that
+            # passes ``None`` while a nonzero weight is configured gets a loud error
+            # instead of a silently dropped direction term.
             if direction_consistency_matrix is None:
+                if self.direction_consistency_weight != 0:
+                    raise ValueError(
+                        "direction_consistency_matrix is None but direction_consistency_weight is "
+                        f"{self.direction_consistency_weight}; None is only valid when the weight is 0 "
+                        "(IoU-only association)."
+                    )
                 cost_matrix = iou_matrix
             else:
                 cost_matrix = iou_matrix + self.direction_consistency_weight * direction_consistency_matrix

--- a/src/trackers/core/ocsort/tracker.py
+++ b/src/trackers/core/ocsort/tracker.py
@@ -121,14 +121,16 @@ class OCSORTTracker(BaseTracker):
     def _get_associated_indices(
         self,
         iou_matrix: np.ndarray,
-        direction_consistency_matrix: np.ndarray,
+        direction_consistency_matrix: np.ndarray | None,
     ) -> tuple[list[tuple[int, int]], list[int], list[int]]:
         """
         Associate detections to tracks based on IOU.
 
         Args:
             iou_matrix: IOU cost matrix.
-            direction_consistency_matrix: Direction of the tracklet consistency cost matrix.
+            direction_consistency_matrix: Direction of the tracklet consistency
+                cost matrix, or ``None`` when ``direction_consistency_weight`` is
+                0 (IoU-only association).
 
         Returns:
             matched: List of ``(track_index, detection_index)`` tuples for
@@ -144,7 +146,12 @@ class OCSORTTracker(BaseTracker):
         unmatched_detections = set(range(n_detections))
         if n_tracks > 0 and n_detections > 0:
             # Find optimal assignment using scipy.optimize.linear_sum_assignment.
-            cost_matrix = iou_matrix + self.direction_consistency_weight * direction_consistency_matrix
+            # ``direction_consistency_matrix is None`` means the weight is 0, so the
+            # cost is IoU alone (bounded finite matrix ⇒ ``iou + 0.0 * matrix == iou``).
+            if direction_consistency_matrix is None:
+                cost_matrix = iou_matrix
+            else:
+                cost_matrix = iou_matrix + self.direction_consistency_weight * direction_consistency_matrix
             row_indices, col_indices = linear_sum_assignment(cost_matrix, maximize=True)
             for row, col in zip(row_indices, col_indices):
                 if iou_matrix[row, col] >= self.minimum_iou_threshold:
@@ -230,7 +237,14 @@ class OCSORTTracker(BaseTracker):
         predicted_boxes = np.array([t.get_state_bbox() for t in self.tracks])
         iou_matrix = self.iou.compute(predicted_boxes, detection_boxes)
 
-        direction_consistency_matrix = self._compute_direction_consistency_matrix(detection_boxes, confidences)
+        # Skip the direction-consistency computation entirely when it carries no
+        # weight. Bit-identical: the matrix is finite and bounded, so the old
+        # ``iou_matrix + 0.0 * matrix`` reduces exactly to ``iou_matrix``.
+        direction_consistency_matrix = (
+            self._compute_direction_consistency_matrix(detection_boxes, confidences)
+            if self.direction_consistency_weight != 0
+            else None
+        )
 
         # 1st association (OCM)
         matched_indices, unmatched_tracks, unmatched_detections = self._get_associated_indices(
@@ -334,7 +348,10 @@ class OCSORTTracker(BaseTracker):
             [t.velocity if t.velocity is not None else np.array([0.0, 0.0]) for t in self.tracks]
         )
         reference_boxes = np.array(
-            [t.get_k_previous_obs() if t.get_k_previous_obs() is not None else t.last_observation for t in self.tracks]
+            [
+                previous_obs if (previous_obs := t.get_k_previous_obs()) is not None else t.last_observation
+                for t in self.tracks
+            ]
         )
         velocity_mask = np.array(
             [t.velocity is not None for t in self.tracks],

--- a/src/trackers/utils/kalman_filter.py
+++ b/src/trackers/utils/kalman_filter.py
@@ -86,9 +86,12 @@ class KalmanFilter:
         self.state = self.transition_mtx @ self.state
         self.state_covariance = self.transition_mtx @ self.state_covariance @ self.transition_mtx.T + self.process_noise
 
-        # Save prior
-        self.state_prior = self.state.copy()
-        self.state_covariance_prior = self.state_covariance.copy()
+        # Reference the prior (debug/inspection only). predict/update always
+        # reassign self.state[_covariance] to freshly allocated arrays and never
+        # mutate them in place on the hot path, so a plain reference is a faithful
+        # snapshot without paying a per-step copy.
+        self.state_prior = self.state
+        self.state_covariance_prior = self.state_covariance
 
     def update(self, z: NDArray[np.float64] | None) -> None:
         """Update state estimate with measurement.
@@ -99,9 +102,9 @@ class KalmanFilter:
             z: Measurement vector (dim_z, 1) or None for no observation.
         """
         if z is None:
-            # No observation - posterior equals prior
-            self.state_post = self.state.copy()
-            self.state_covariance_post = self.state_covariance.copy()
+            # No observation - posterior equals prior (reference; see predict()).
+            self.state_post = self.state
+            self.state_covariance_post = self.state_covariance
             self.innovation = np.zeros((self.dim_z, 1), dtype=np.float64)
             return
 
@@ -128,9 +131,9 @@ class KalmanFilter:
             I_KH @ self.state_covariance @ I_KH.T + self.kalman_gain @ self.measurement_noise @ self.kalman_gain.T
         )
 
-        # Save posterior
-        self.state_post = self.state.copy()
-        self.state_covariance_post = self.state_covariance.copy()
+        # Reference the posterior (debug/inspection only; see predict()).
+        self.state_post = self.state
+        self.state_covariance_post = self.state_covariance
 
     def get_state(self) -> dict:
         """Get current filter state for saving.

--- a/tests/core/test_associated_indices.py
+++ b/tests/core/test_associated_indices.py
@@ -104,6 +104,25 @@ class TestGetAssociatedIndicesSortedOutput:
         assert unmatched_detections == sorted(unmatched_detections)
 
 
+def test_ocsort_none_direction_matrix_matches_explicit_zero_matrix() -> None:
+    """OCSORT weight-0 path (``None`` direction matrix) associates identically to a zero matrix.
+
+    The direction-consistency matrix is finite and bounded, so the historical
+    ``iou_matrix + weight * matrix`` reduced to ``iou_matrix`` whenever the matrix
+    was all zeros. Passing ``None`` (the weight-0 early-out) must be bit-identical
+    to passing an explicit zero matrix.
+    """
+    tracker = OCSORTTracker()
+    iou_matrix = np.zeros((4, 5))
+    iou_matrix[1, 2] = 0.9
+    iou_matrix[3, 0] = 0.5
+
+    with_none = tracker._get_associated_indices(iou_matrix, None)
+    with_zeros = tracker._get_associated_indices(iou_matrix, np.zeros_like(iou_matrix))
+
+    assert with_none == with_zeros
+
+
 @pytest.mark.parametrize("call_fn", _TRACKER_CALL_FNS)
 def test_all_trackers_associated_indices_are_deterministically_sorted(
     call_fn: CallFn,

--- a/tests/core/test_associated_indices.py
+++ b/tests/core/test_associated_indices.py
@@ -14,9 +14,11 @@ stable across CPython versions and implementations.
 from __future__ import annotations
 
 from collections.abc import Callable
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import supervision as sv
 
 from trackers.core.botsort.tracker import BoTSORTTracker
 from trackers.core.bytetrack.tracker import ByteTrackTracker
@@ -136,3 +138,34 @@ def test_all_trackers_associated_indices_are_deterministically_sorted(
 
     assert unmatched_tracks == [0, 2, 3]
     assert unmatched_detections == [0, 1, 3, 4]
+
+
+@pytest.mark.parametrize(
+    ("weight", "expect_matrix_built"),
+    [
+        pytest.param(0.0, False, id="weight-zero-skips-matrix"),
+        pytest.param(0.2, True, id="weight-nonzero-builds-matrix"),
+    ],
+)
+def test_ocsort_direction_matrix_built_only_when_weight_nonzero(
+    weight: float, expect_matrix_built: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """OCSORT builds the direction-consistency matrix iff direction_consistency_weight != 0.
+
+    Exercises the weight-0 early-out itself: with weight 0 the matrix build is
+    skipped entirely (not merely cancelled by an explicit zero matrix), while a
+    nonzero weight still triggers it. A track is established on the first frame so
+    the matrix would be built on the second frame whenever the weight allows it.
+    """
+    tracker = OCSORTTracker(direction_consistency_weight=weight)
+    detections = sv.Detections(
+        xyxy=np.array([[10.0, 10.0, 50.0, 50.0]], dtype=np.float64),
+        confidence=np.array([0.9]),
+    )
+    tracker.update(detections)  # frame 1: establish a track
+    spy = MagicMock(wraps=tracker._compute_direction_consistency_matrix)
+    monkeypatch.setattr(tracker, "_compute_direction_consistency_matrix", spy)
+
+    tracker.update(detections)  # frame 2: track present; matrix built iff weight != 0
+
+    assert spy.called is expect_matrix_built

--- a/tests/core/test_associated_indices.py
+++ b/tests/core/test_associated_indices.py
@@ -112,9 +112,10 @@ def test_ocsort_none_direction_matrix_matches_explicit_zero_matrix() -> None:
     The direction-consistency matrix is finite and bounded, so the historical
     ``iou_matrix + weight * matrix`` reduced to ``iou_matrix`` whenever the matrix
     was all zeros. Passing ``None`` (the weight-0 early-out) must be bit-identical
-    to passing an explicit zero matrix.
+    to passing an explicit zero matrix. ``None`` is only valid at weight 0, so the
+    tracker is constructed with ``direction_consistency_weight=0``.
     """
-    tracker = OCSORTTracker()
+    tracker = OCSORTTracker(direction_consistency_weight=0.0)
     iou_matrix = np.zeros((4, 5))
     iou_matrix[1, 2] = 0.9
     iou_matrix[3, 0] = 0.5
@@ -123,6 +124,16 @@ def test_ocsort_none_direction_matrix_matches_explicit_zero_matrix() -> None:
     with_zeros = tracker._get_associated_indices(iou_matrix, np.zeros_like(iou_matrix))
 
     assert with_none == with_zeros
+
+
+def test_ocsort_none_direction_matrix_with_nonzero_weight_raises() -> None:
+    """Passing ``None`` while direction_consistency_weight != 0 raises — None is the weight-0 sentinel only."""
+    tracker = OCSORTTracker(direction_consistency_weight=0.2)
+    iou_matrix = np.zeros((2, 3))
+    iou_matrix[0, 1] = 0.9
+
+    with pytest.raises(ValueError, match="only valid when the weight is 0"):
+        tracker._get_associated_indices(iou_matrix, None)
 
 
 @pytest.mark.parametrize("call_fn", _TRACKER_CALL_FNS)


### PR DESCRIPTION
- KalmanFilter.predict/update: reference prior/post snapshots instead of copying (debug-only attrs, no readers; reassignment-only writes keep state/covariance evolution bit-identical)
- OCSORT: compute get_k_previous_obs once per track (walrus); skip the direction-consistency matrix when its weight is 0 (_get_associated_indices now accepts None, uses IoU-only cost)
- test: None direction matrix associates identically to an explicit zero matrix
