### PR TITLE
perf(assoc): cache predicted boxes across stages

### DIFF
--- a/src/trackers/core/botsort/tracker.py
+++ b/src/trackers/core/botsort/tracker.py
@@ -247,11 +247,19 @@ class BoTSORTTracker(BaseTracker):
             mask_boxes = high_boxes if len(high_boxes) > 0 else None
             H = self.cmc.estimate(frame, mask_boxes)
             CMC.apply_batch(H, self.tracks)
+
+        # Cache each tracklet's predicted state bbox once per update. Track state
+        # is unchanged across the three association stages: a track matched in an
+        # earlier stage never re-enters a later one, and the CMC adjustment above
+        # is already applied. Recomputing get_state_bbox() per stage would be
+        # redundant, so all stages read boxes from this map keyed by ``id()``.
+        predicted_state_boxes = {id(track): track.get_state_bbox() for track in self.tracks}
+
         # Step 1: associate high-confidence detections to confirmed + lost tracks.
         # Lost tracks are included here (following the original ByteTrack), and
         # IoU is fused with detection scores.
         strack_pool = confirmed_tracks + lost_tracks
-        iou_matrix = self._get_iou_matrix(strack_pool, high_boxes)
+        iou_matrix = self._get_iou_matrix(strack_pool, high_boxes, predicted_state_boxes)
         iou_matrix = _fuse_score(self.iou.normalize_for_fusion(iou_matrix), high_scores)
         matched, unmatched_pool, unmatched_high = self._get_associated_indices(
             iou_matrix, self.minimum_iou_threshold_first_assoc
@@ -269,7 +277,7 @@ class BoTSORTTracker(BaseTracker):
         # only (excluding lost tracks, following the original ByteTrack).
         # No score fusing in second association.
         remaining_tracked = [strack_pool[i] for i in unmatched_pool if strack_pool[i].time_since_update == 1]
-        iou_matrix = self._get_iou_matrix(remaining_tracked, low_boxes)
+        iou_matrix = self._get_iou_matrix(remaining_tracked, low_boxes, predicted_state_boxes)
         matched, _, unmatched_low = self._get_associated_indices(iou_matrix, self.minimum_iou_threshold_second_assoc)
 
         for row, col in matched:
@@ -295,7 +303,7 @@ class BoTSORTTracker(BaseTracker):
             uh_boxes = high_boxes[unmatched_high_list]
             uh_scores = high_scores[unmatched_high_list]
 
-            iou_matrix = self._get_iou_matrix(unconfirmed_tracks, uh_boxes)
+            iou_matrix = self._get_iou_matrix(unconfirmed_tracks, uh_boxes, predicted_state_boxes)
             iou_matrix = _fuse_score(self.iou.normalize_for_fusion(iou_matrix), uh_scores)
             matched_uc, unmatched_uc_indices, remaining_uh = self._get_associated_indices(
                 iou_matrix, self.minimum_iou_threshold_unconfirmed_assoc
@@ -349,11 +357,25 @@ class BoTSORTTracker(BaseTracker):
         result.tracker_id = np.array(out_tracker_ids, dtype=int)
         return result
 
-    def _get_iou_matrix(self, tracklets: list[BoTSORTTracklet], detections: np.ndarray) -> np.ndarray:
+    def _get_iou_matrix(
+        self,
+        tracklets: list[BoTSORTTracklet],
+        detections: np.ndarray,
+        tracklet_boxes_by_id: dict[int, np.ndarray],
+    ) -> np.ndarray:
+        """Compute IoU similarity between tracklet states and detection boxes.
+
+        Args:
+            tracklets: Tracklets forming the rows of the returned matrix.
+            detections: Detection boxes in ``xyxy`` format forming the columns.
+            tracklet_boxes_by_id: Mapping from ``id(track)`` to the track's
+                predicted state bbox, computed once per ``update()`` and reused
+                across association stages to avoid recomputing ``get_state_bbox``.
+        """
         if len(tracklets) == 0:
             tracklet_boxes = np.empty((0, 4))
         else:
-            tracklet_boxes = np.array([tracklet.get_state_bbox() for tracklet in tracklets])
+            tracklet_boxes = np.array([tracklet_boxes_by_id[id(tracklet)] for tracklet in tracklets])
         return self.iou.compute(tracklet_boxes, detections)
 
     def _get_associated_indices(

--- a/src/trackers/core/botsort/tracker.py
+++ b/src/trackers/core/botsort/tracker.py
@@ -371,11 +371,23 @@ class BoTSORTTracker(BaseTracker):
             tracklet_boxes_by_id: Mapping from ``id(track)`` to the track's
                 predicted state bbox, computed once per ``update()`` and reused
                 across association stages to avoid recomputing ``get_state_bbox``.
+
+        Raises:
+            KeyError: If a tracklet passed in is absent from ``tracklet_boxes_by_id``
+                — an internal-invariant violation, since the map is built from
+                ``self.tracks`` and every tracklet here is drawn from it.
         """
         if len(tracklets) == 0:
             tracklet_boxes = np.empty((0, 4))
         else:
-            tracklet_boxes = np.array([tracklet_boxes_by_id[id(tracklet)] for tracklet in tracklets])
+            try:
+                tracklet_boxes = np.array([tracklet_boxes_by_id[id(tracklet)] for tracklet in tracklets])
+            except KeyError as exc:
+                raise KeyError(
+                    f"tracklet id {exc.args[0]} missing from the per-frame decode-once box cache; "
+                    "tracklet_boxes_by_id must contain every tracklet passed to this helper "
+                    "(it is built from self.tracks once per update())"
+                ) from exc
         return self.iou.compute(tracklet_boxes, detections)
 
     def _get_associated_indices(

--- a/src/trackers/core/cbiou/tracker.py
+++ b/src/trackers/core/cbiou/tracker.py
@@ -149,11 +149,22 @@ class CBIoUTracker(BoTSORTTracker):
         tracklets: list[BoTSORTTracklet],
         boxes: np.ndarray,
         iou: BIoU,
+        tracklet_boxes_by_id: dict[int, np.ndarray],
     ) -> np.ndarray:
+        """Compute buffered-IoU similarity between tracklet states and boxes.
+
+        Args:
+            tracklets: Tracklets forming the rows of the returned matrix.
+            boxes: Detection boxes in ``xyxy`` format forming the columns.
+            iou: The buffered-IoU metric (distinct buffer per association stage).
+            tracklet_boxes_by_id: Mapping from ``id(track)`` to the track's
+                predicted state bbox, computed once per ``update()`` and reused
+                across association stages to avoid recomputing ``get_state_bbox``.
+        """
         if len(tracklets) == 0:
             track_boxes = np.empty((0, 4))
         else:
-            track_boxes = np.array([t.get_state_bbox() for t in tracklets])
+            track_boxes = np.array([tracklet_boxes_by_id[id(t)] for t in tracklets])
         return iou.compute(track_boxes, boxes)
 
     def update(
@@ -244,10 +255,17 @@ class CBIoUTracker(BoTSORTTracker):
             else:
                 unconfirmed_tracks.append(track)
 
+        # Cache each tracklet's predicted state bbox once per update. Track state
+        # is unchanged across the three association stages: a track matched in an
+        # earlier stage never re-enters a later one, and C-BIoU performs no CMC.
+        # Recomputing get_state_bbox() per stage would be redundant, so all stages
+        # read boxes from this map keyed by ``id()``.
+        predicted_state_boxes = {id(track): track.get_state_bbox() for track in self.tracks}
+
         # Step 1: associate high-confidence detections to confirmed + lost tracks.
         # Paper b1 (small buffer); BIoU fused with detection scores.
         strack_pool = confirmed_tracks + lost_tracks
-        iou_matrix = self._biou_matrix(strack_pool, high_boxes, self.iou_first)
+        iou_matrix = self._biou_matrix(strack_pool, high_boxes, self.iou_first, predicted_state_boxes)
         iou_matrix = _fuse_score(self.iou_first.normalize_for_fusion(iou_matrix), high_scores)
         matched, unmatched_pool, unmatched_high = self._get_associated_indices(
             iou_matrix, self.minimum_iou_threshold_first_assoc
@@ -264,7 +282,7 @@ class CBIoUTracker(BoTSORTTracker):
         # Step 2: associate low-confidence detections to remaining *tracked* tracks
         # only (excluding lost tracks). Paper b2 (large buffer); no score fusion.
         remaining_tracked = [strack_pool[i] for i in unmatched_pool if strack_pool[i].time_since_update == 1]
-        iou_matrix = self._biou_matrix(remaining_tracked, low_boxes, self.iou_second)
+        iou_matrix = self._biou_matrix(remaining_tracked, low_boxes, self.iou_second, predicted_state_boxes)
         matched, _, unmatched_low = self._get_associated_indices(iou_matrix, self.minimum_iou_threshold_second_assoc)
 
         for row, col in matched:
@@ -289,7 +307,7 @@ class CBIoUTracker(BoTSORTTracker):
         if len(unconfirmed_tracks) > 0 and len(unmatched_high_list) > 0:
             uh_boxes = high_boxes[unmatched_high_list]
             uh_scores = high_scores[unmatched_high_list]
-            iou_matrix = self._biou_matrix(unconfirmed_tracks, uh_boxes, self.iou_first)
+            iou_matrix = self._biou_matrix(unconfirmed_tracks, uh_boxes, self.iou_first, predicted_state_boxes)
             iou_matrix = _fuse_score(self.iou_first.normalize_for_fusion(iou_matrix), uh_scores)
             matched_uc, unmatched_uc_indices, remaining_uh = self._get_associated_indices(
                 iou_matrix, self.minimum_iou_threshold_unconfirmed_assoc

--- a/src/trackers/core/cbiou/tracker.py
+++ b/src/trackers/core/cbiou/tracker.py
@@ -160,11 +160,23 @@ class CBIoUTracker(BoTSORTTracker):
             tracklet_boxes_by_id: Mapping from ``id(track)`` to the track's
                 predicted state bbox, computed once per ``update()`` and reused
                 across association stages to avoid recomputing ``get_state_bbox``.
+
+        Raises:
+            KeyError: If a tracklet passed in is absent from ``tracklet_boxes_by_id``
+                — an internal-invariant violation, since the map is built from
+                ``self.tracks`` and every tracklet here is drawn from it.
         """
         if len(tracklets) == 0:
             track_boxes = np.empty((0, 4))
         else:
-            track_boxes = np.array([tracklet_boxes_by_id[id(t)] for t in tracklets])
+            try:
+                track_boxes = np.array([tracklet_boxes_by_id[id(t)] for t in tracklets])
+            except KeyError as exc:
+                raise KeyError(
+                    f"tracklet id {exc.args[0]} missing from the per-frame decode-once box cache; "
+                    "tracklet_boxes_by_id must contain every tracklet passed to this helper "
+                    "(it is built from self.tracks once per update())"
+                ) from exc
         return iou.compute(track_boxes, boxes)
 
     def update(

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -808,11 +808,23 @@ class McByteTracker(BaseTracker):
             tracklet_boxes_by_id: Mapping from ``id(track)`` to the track's
                 predicted state bbox, computed once per ``update()`` and reused
                 across association stages to avoid recomputing ``get_state_bbox``.
+
+        Raises:
+            KeyError: If a tracklet passed in is absent from ``tracklet_boxes_by_id``
+                — an internal-invariant violation, since the map is built from
+                ``self.tracks`` and every tracklet here is drawn from it.
         """
         if len(tracklets) == 0:
             tracklet_boxes = np.empty((0, 4))
         else:
-            tracklet_boxes = np.array([tracklet_boxes_by_id[id(tracklet)] for tracklet in tracklets])
+            try:
+                tracklet_boxes = np.array([tracklet_boxes_by_id[id(tracklet)] for tracklet in tracklets])
+            except KeyError as exc:
+                raise KeyError(
+                    f"tracklet id {exc.args[0]} missing from the per-frame decode-once box cache; "
+                    "tracklet_boxes_by_id must contain every tracklet passed to this helper "
+                    "(it is built from self.tracks once per update())"
+                ) from exc
         return self.iou.compute(tracklet_boxes, detections)
 
     def _get_mask_conditioned_associated_indices(

--- a/tests/core/test_botsort_tracker.py
+++ b/tests/core/test_botsort_tracker.py
@@ -227,3 +227,19 @@ def test_get_iou_matrix_reads_cache_without_decoding(monkeypatch: pytest.MonkeyP
 
     assert result.shape == (1, 1)
     assert result[0, 0] == pytest.approx(1.0)
+
+
+def test_get_iou_matrix_raises_contextual_error_on_cache_miss() -> None:
+    """_get_iou_matrix raises a contextual KeyError when a tracklet is absent from the cache.
+
+    The decode-once map must contain every tracklet passed to the helper (it is
+    built from ``self.tracks`` once per ``update()``). A miss is an internal-invariant
+    violation; the helper surfaces it with a message naming the cache contract rather
+    than a bare ``KeyError: <id int>``.
+    """
+    tracker = BoTSORTTracker(enable_cmc=False)
+    tracklet = BoTSORTTracklet(np.array([0.0, 0.0, 10.0, 10.0]))
+    detections = np.array([[0.0, 0.0, 10.0, 10.0]])
+
+    with pytest.raises(KeyError, match="decode-once box cache"):
+        tracker._get_iou_matrix([tracklet], detections, {})

--- a/tests/core/test_botsort_tracker.py
+++ b/tests/core/test_botsort_tracker.py
@@ -20,6 +20,7 @@ import pytest
 import supervision as sv
 
 from trackers.core.botsort.tracker import BoTSORTTracker
+from trackers.core.botsort.tracklet import BoTSORTTracklet
 from trackers.utils.state_representations import (
     BaseStateEstimator,
     XCYCSRStateEstimator,
@@ -202,3 +203,27 @@ class TestBoTSORTTrackerCMC:
 
         assert tracker.cmc is not None
         assert not tracker.cmc._initialized, "CMC must be uninitialized after tracker reset"
+
+
+def test_get_iou_matrix_reads_cache_without_decoding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_get_iou_matrix reads predicted boxes from the per-frame cache, never re-decoding.
+
+    P4-2 decode-once: each tracklet's box is decoded a single time per ``update()``
+    and passed to all three association stages via a map keyed by ``id()``. The
+    helper must read that map and never call ``get_state_bbox`` itself — doing so
+    would reintroduce the per-stage redundant decode the cache exists to remove.
+    """
+    tracker = BoTSORTTracker(enable_cmc=False)
+    tracklet = BoTSORTTracklet(np.array([0.0, 0.0, 10.0, 10.0]))
+
+    def _fail() -> np.ndarray:
+        raise AssertionError("get_state_bbox must not be called; boxes come from the cache")
+
+    monkeypatch.setattr(tracklet, "get_state_bbox", _fail)
+    cached_box = np.array([5.0, 5.0, 15.0, 15.0])
+    detections = np.array([[5.0, 5.0, 15.0, 15.0]])  # identical to the cached box -> IoU 1.0
+
+    result = tracker._get_iou_matrix([tracklet], detections, {id(tracklet): cached_box})
+
+    assert result.shape == (1, 1)
+    assert result[0, 0] == pytest.approx(1.0)

--- a/tests/core/test_cbiou_tracker.py
+++ b/tests/core/test_cbiou_tracker.py
@@ -22,6 +22,7 @@ import pytest
 import supervision as sv
 
 from trackers.core.botsort.tracker import BoTSORTTracker
+from trackers.core.botsort.tracklet import BoTSORTTracklet
 from trackers.core.cbiou.tracker import CBIoUTracker
 from trackers.utils.iou import BIoU
 
@@ -376,3 +377,27 @@ class TestCBIoUStickyMaturity:
         assert track_a_id in remaining_ids
         assert -1 not in remaining_ids
         assert len(tracker.tracks) == 1
+
+
+def test_biou_matrix_reads_cache_without_decoding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_biou_matrix reads predicted boxes from the per-frame cache, never re-decoding.
+
+    P4-2 decode-once: each tracklet's box is decoded a single time per ``update()``
+    and passed to all three association stages via a map keyed by ``id()``. The
+    helper must read that map and never call ``get_state_bbox`` itself — doing so
+    would reintroduce the per-stage redundant decode the cache exists to remove.
+    """
+    tracker = CBIoUTracker()
+    tracklet = BoTSORTTracklet(np.array([0.0, 0.0, 10.0, 10.0]))
+
+    def _fail() -> np.ndarray:
+        raise AssertionError("get_state_bbox must not be called; boxes come from the cache")
+
+    monkeypatch.setattr(tracklet, "get_state_bbox", _fail)
+    cached_box = np.array([5.0, 5.0, 15.0, 15.0])
+    boxes = np.array([[5.0, 5.0, 15.0, 15.0]])  # identical to the cached box -> IoU 1.0
+
+    result = tracker._biou_matrix([tracklet], boxes, BIoU(buffer_ratio=0.0), {id(tracklet): cached_box})
+
+    assert result.shape == (1, 1)
+    assert result[0, 0] == pytest.approx(1.0)

--- a/tests/core/test_cbiou_tracker.py
+++ b/tests/core/test_cbiou_tracker.py
@@ -401,3 +401,19 @@ def test_biou_matrix_reads_cache_without_decoding(monkeypatch: pytest.MonkeyPatc
 
     assert result.shape == (1, 1)
     assert result[0, 0] == pytest.approx(1.0)
+
+
+def test_biou_matrix_raises_contextual_error_on_cache_miss() -> None:
+    """_biou_matrix raises a contextual KeyError when a tracklet is absent from the cache.
+
+    The decode-once map must contain every tracklet passed to the helper (it is
+    built from ``self.tracks`` once per ``update()``). A miss is an internal-invariant
+    violation; the helper surfaces it with a message naming the cache contract rather
+    than a bare ``KeyError: <id int>``.
+    """
+    tracker = CBIoUTracker()
+    tracklet = BoTSORTTracklet(np.array([0.0, 0.0, 10.0, 10.0]))
+    boxes = np.array([[0.0, 0.0, 10.0, 10.0]])
+
+    with pytest.raises(KeyError, match="decode-once box cache"):
+        tracker._biou_matrix([tracklet], boxes, BIoU(buffer_ratio=0.0), {})

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -662,3 +662,19 @@ def test_mcbyte_rejects_unused_mask_config() -> None:
             enable_mask_manager=False,
             mask_config=McByteMaskConfig(),
         )
+
+
+def test_get_iou_matrix_raises_contextual_error_on_cache_miss() -> None:
+    """_get_iou_matrix raises a contextual KeyError when a tracklet is absent from the cache.
+
+    The decode-once map must contain every tracklet passed to the helper (it is
+    built from ``self.tracks`` once per ``update()``). A miss is an internal-invariant
+    violation; the helper surfaces it with a message naming the cache contract rather
+    than a bare ``KeyError: <id int>``.
+    """
+    tracker = McByteTracker(enable_cmc=False, enable_mask_manager=False)
+    tracklet = McByteTracklet(initial_bbox=np.array([0.0, 0.0, 10.0, 10.0], dtype=np.float32))
+    detections = np.array([[0.0, 0.0, 10.0, 10.0]])
+
+    with pytest.raises(KeyError, match="decode-once box cache"):
+        tracker._get_iou_matrix([tracklet], detections, {})


### PR DESCRIPTION
BoTSORT and CBIoU re-decoded each tracklet's predicted box via get_state_bbox() in every association stage (up to 3x/frame). Decode once per update() into an id()-keyed map built after predict/CMC and reuse it across all three stages, matching the existing McByte idiom.

Bit-identical: a track matched in an earlier stage leaves the pool before later stages, BoTSORT CMC is applied before the map is built, and get_state_bbox is a pure decode of unchanged state. Add a decode-once contract test per tracker (get_state_bbox must not be called; boxes come from the cache).
