### PR TITLE
feat(mcbyte): defer short-lived mask creation

### DIFF
--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -221,18 +221,6 @@ class McByteTracker(BaseTracker):
             create a new tracklet.
         minimum_consecutive_frames: Number of successful tracklet updates
             required before assigning a confirmed non-negative tracker ID.
-        minimum_mask_creation_frames: Number of consecutive frames a confirmed
-            tracklet must remain visible in tracker output before its mask is
-            created (the SAM prompt plus Cutie ``add_masks``). This defers the
-            per-appearance mask encode for very-short-lived tracklets: those
-            that terminate before reaching the threshold never pay the encode,
-            at the cost of running IoU-only association for those tracklets
-            until their mask exists. Because mask conditioning is deferred, this
-            can alter tracking output and must be validated for CLEAR/HOTA/
-            Identity parity on the target workload. Use ``1`` to create masks on
-            a tracklet's first visible frame (the original immediate-creation
-            timing). Only affects the incremental add path after Cutie has been
-            initialized; the initial mask set is never deferred.
         minimum_iou_threshold_first_assoc: Minimum association similarity for
             matching high-confidence detections to confirmed and lost tracks.
             The default of ``0.1`` follows ByteTrack's deliberately low
@@ -280,6 +268,20 @@ class McByteTracker(BaseTracker):
         enable_isolated_mask_matching: Whether mask evidence may rescue an
             isolated candidate with positive IoU whose association similarity
             is below the normal stage threshold.
+        minimum_mask_creation_frames: Number of consecutive frames a confirmed
+            tracklet must remain visible in tracker output before its mask is
+            created (the SAM prompt plus Cutie ``add_masks``). This defers the
+            per-appearance mask encode for very-short-lived tracklets: those
+            that terminate before reaching the threshold never pay the encode,
+            at the cost of running IoU-only association for those tracklets
+            until their mask exists. Because mask conditioning is deferred, this
+            can alter tracking output and must be validated for CLEAR/HOTA/
+            Identity parity on the target workload. Use ``1`` to create masks on
+            a tracklet's first visible frame (the original immediate-creation
+            timing). A deferred tracklet is withheld from the mask pipeline
+            entirely, including Cutie's initial mask set: when every confirmed
+            tracklet is still inside its defer window the first masks are
+            produced only once at least one tracklet reaches the threshold.
     """
 
     tracker_id = "mcbyte"
@@ -290,7 +292,6 @@ class McByteTracker(BaseTracker):
         frame_rate: float = 30.0,
         track_activation_threshold: float = 0.7,
         minimum_consecutive_frames: int = 2,
-        minimum_mask_creation_frames: int = 3,
         minimum_iou_threshold_first_assoc: float = 0.1,
         minimum_iou_threshold_second_assoc: float = 0.5,
         minimum_iou_threshold_unconfirmed_assoc: float = 0.3,
@@ -308,6 +309,7 @@ class McByteTracker(BaseTracker):
         minimum_mask_coverage: float = MINIMUM_MASK_COVERAGE,
         minimum_mask_fill_ratio: float = MINIMUM_MASK_FILL_RATIO,
         enable_isolated_mask_matching: bool = False,
+        minimum_mask_creation_frames: int = 3,
     ) -> None:
         # Calculate maximum frames without update based on lost_track_buffer and
         # frame_rate. This scales the buffer based on the frame rate to ensure

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -221,6 +221,18 @@ class McByteTracker(BaseTracker):
             create a new tracklet.
         minimum_consecutive_frames: Number of successful tracklet updates
             required before assigning a confirmed non-negative tracker ID.
+        minimum_mask_creation_frames: Number of consecutive frames a confirmed
+            tracklet must remain visible in tracker output before its mask is
+            created (the SAM prompt plus Cutie ``add_masks``). This defers the
+            per-appearance mask encode for very-short-lived tracklets: those
+            that terminate before reaching the threshold never pay the encode,
+            at the cost of running IoU-only association for those tracklets
+            until their mask exists. Because mask conditioning is deferred, this
+            can alter tracking output and must be validated for CLEAR/HOTA/
+            Identity parity on the target workload. Use ``1`` to create masks on
+            a tracklet's first visible frame (the original immediate-creation
+            timing). Only affects the incremental add path after Cutie has been
+            initialized; the initial mask set is never deferred.
         minimum_iou_threshold_first_assoc: Minimum association similarity for
             matching high-confidence detections to confirmed and lost tracks.
             The default of ``0.1`` follows ByteTrack's deliberately low
@@ -278,6 +290,7 @@ class McByteTracker(BaseTracker):
         frame_rate: float = 30.0,
         track_activation_threshold: float = 0.7,
         minimum_consecutive_frames: int = 2,
+        minimum_mask_creation_frames: int = 3,
         minimum_iou_threshold_first_assoc: float = 0.1,
         minimum_iou_threshold_second_assoc: float = 0.5,
         minimum_iou_threshold_unconfirmed_assoc: float = 0.3,
@@ -305,6 +318,12 @@ class McByteTracker(BaseTracker):
         )
         self.maximum_time_without_update: float = lost_track_buffer / 30.0
         self.minimum_consecutive_frames = minimum_consecutive_frames
+        if minimum_mask_creation_frames < 1:
+            raise ValueError(
+                "minimum_mask_creation_frames must be at least 1 "
+                f"(1 creates masks immediately). Got {minimum_mask_creation_frames}."
+            )
+        self.minimum_mask_creation_frames = minimum_mask_creation_frames
         self.minimum_iou_threshold_first_assoc = minimum_iou_threshold_first_assoc
         self.minimum_iou_threshold_second_assoc = minimum_iou_threshold_second_assoc
         self.minimum_iou_threshold_unconfirmed_assoc = minimum_iou_threshold_unconfirmed_assoc
@@ -362,6 +381,10 @@ class McByteTracker(BaseTracker):
         self._previous_new_tracklets: list[TrackletSnapshot] = []
         self._previous_removed_tracklet_ids: list[int] = []
         self._mask_tracklet_ids: set[int] = set()
+        # Consecutive-visible-frame counts for confirmed tracklets that are
+        # awaiting mask creation under ``minimum_mask_creation_frames``. Only
+        # populated when the threshold exceeds 1.
+        self._mask_pending_ages: dict[int, int] = {}
         self._consecutive_mask_failures: int = 0
 
     def update(
@@ -770,11 +793,10 @@ class McByteTracker(BaseTracker):
         removed_tracklet_id_set = set(removed_tracklet_ids)
         self._mask_tracklet_ids -= removed_tracklet_id_set
 
-        # Find current visible tracklets that do not yet have masks.
-        # These will be passed to SAM/Cutie on the next frame.
-        new_tracklets = [
-            tracklet for tracklet in current_tracklets if tracklet.tracker_id not in self._mask_tracklet_ids
-        ]
+        # Find current visible tracklets that do not yet have masks and have
+        # been visible long enough to warrant a mask. These will be passed to
+        # SAM/Cutie on the next frame.
+        new_tracklets = self._collect_new_masked_tracklets(current_tracklets)
 
         # Mark those new tracklets as now mask-managed, so if they disappear temporarily
         # and later reappear, they are not treated as new again.
@@ -785,10 +807,68 @@ class McByteTracker(BaseTracker):
         self._previous_new_tracklets = new_tracklets
         self._previous_removed_tracklet_ids = removed_tracklet_ids
 
-        # Stores the current frame and current visible tracklets
-        # as “previous” inputs for the next frame.
+        # Stores the current frame and current visible tracklets as “previous”
+        # inputs for the next frame. Only mask-eligible tracklets (already masked
+        # or promoted this frame) are exposed to the mask manager: tracklets
+        # still inside their ``minimum_mask_creation_frames`` defer window must
+        # be invisible to the pipeline so they are neither masked at Cutie
+        # initialization nor double-added once they cross the threshold. With
+        # ``minimum_mask_creation_frames == 1`` every visible tracklet is
+        # eligible immediately, so this equals ``current_tracklets``.
         self._previous_frame = frame
-        self._previous_tracklets = current_tracklets
+        if self.minimum_mask_creation_frames <= 1:
+            self._previous_tracklets = current_tracklets
+        else:
+            self._previous_tracklets = [
+                tracklet for tracklet in current_tracklets if tracklet.tracker_id in self._mask_tracklet_ids
+            ]
+
+    def _collect_new_masked_tracklets(
+        self,
+        current_tracklets: list[TrackletSnapshot],
+    ) -> list[TrackletSnapshot]:
+        """Select not-yet-masked tracklets ready for mask creation next frame.
+
+        A confirmed tracklet becomes eligible for mask creation only after it has
+        appeared in tracker output for ``minimum_mask_creation_frames`` consecutive
+        frames. Very-short-lived tracklets that terminate before reaching the
+        threshold are never handed to SAM/Cutie, saving the per-appearance mask
+        encode. A tracklet that disappears before reaching the threshold restarts
+        its count if it later reappears, so only stably visible tracklets are
+        masked. With ``minimum_mask_creation_frames == 1`` every not-yet-masked
+        tracklet is returned on its first visible frame, matching the original
+        immediate-creation timing.
+
+        Args:
+            current_tracklets: Tracklet snapshots visible in the current tracker
+                output (already filtered to valid, non-negative tracker IDs).
+
+        Returns:
+            Snapshots whose masks should be created on the next frame.
+        """
+        already_masked = self._mask_tracklet_ids
+        if self.minimum_mask_creation_frames <= 1:
+            return [tracklet for tracklet in current_tracklets if tracklet.tracker_id not in already_masked]
+
+        current_ids = {tracklet.tracker_id for tracklet in current_tracklets}
+        # Drop ages for tracklets no longer visible so a reappearing tracklet
+        # must again accumulate consecutive visible frames before it is masked.
+        self._mask_pending_ages = {
+            tracker_id: age for tracker_id, age in self._mask_pending_ages.items() if tracker_id in current_ids
+        }
+
+        new_tracklets: list[TrackletSnapshot] = []
+        for tracklet in current_tracklets:
+            tracker_id = tracklet.tracker_id
+            if tracker_id in already_masked:
+                continue
+            age = self._mask_pending_ages.get(tracker_id, 0) + 1
+            if age >= self.minimum_mask_creation_frames:
+                new_tracklets.append(tracklet)
+                self._mask_pending_ages.pop(tracker_id, None)
+            else:
+                self._mask_pending_ages[tracker_id] = age
+        return new_tracklets
 
     def _get_iou_matrix(
         self,
@@ -1025,6 +1105,7 @@ class McByteTracker(BaseTracker):
         self._previous_new_tracklets = []
         self._previous_removed_tracklet_ids = []
         self._mask_tracklet_ids = set()
+        self._mask_pending_ages = {}
         self._consecutive_mask_failures = 0
 
     def apply_cmc_batch(self, H: np.ndarray | None) -> None:

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -196,6 +196,7 @@ def test_mcbyte_reset_clears_mask_state() -> None:
         enable_cmc=False,
         mask_manager=_dummy_mask_manager(),
         minimum_consecutive_frames=1,
+        minimum_mask_creation_frames=1,
     )
 
     frame = _make_frame()
@@ -236,6 +237,7 @@ def test_mcbyte_passes_new_tracklets_to_mask_manager_on_next_frame() -> None:
         enable_mask_manager=False,
         mask_manager=mask_manager,  # type: ignore[arg-type]
         minimum_consecutive_frames=1,
+        minimum_mask_creation_frames=1,
     )
 
     frame = _make_frame()
@@ -270,6 +272,7 @@ def test_mcbyte_mask_lifecycle_keeps_missing_tracklet_until_explicit_removal() -
         enable_cmc=False,
         mask_manager=_dummy_mask_manager(),
         minimum_consecutive_frames=1,
+        minimum_mask_creation_frames=1,
     )
 
     frame = _make_frame()
@@ -310,6 +313,79 @@ def test_mcbyte_mask_lifecycle_keeps_missing_tracklet_until_explicit_removal() -
     assert tracker._previous_new_tracklets == []
     assert tracker._previous_removed_tracklet_ids == [7]
     assert tracker._mask_tracklet_ids == set()
+
+
+def _visible_single_tracklet(tracker_id: int = 7) -> sv.Detections:
+    """One confirmed detection with the given tracker ID."""
+    result = sv.Detections(xyxy=np.array([[10.0, 20.0, 30.0, 40.0]], dtype=np.float32))
+    result.tracker_id = np.array([tracker_id], dtype=int)
+    return result
+
+
+def test_mcbyte_defers_mask_creation_until_minimum_frames() -> None:
+    """A confirmed tracklet is masked only after minimum_mask_creation_frames consecutive visible frames."""
+    tracker = McByteTracker(
+        enable_cmc=False,
+        mask_manager=_dummy_mask_manager(),
+        minimum_consecutive_frames=1,
+        minimum_mask_creation_frames=3,
+    )
+    frame = _make_frame()
+    visible_result = _visible_single_tracklet(7)
+
+    tracker._store_previous_mask_inputs(frame=frame, detections=visible_result, removed_tracklet_ids=[])
+    assert tracker._previous_new_tracklets == []
+    assert tracker._mask_tracklet_ids == set()
+    assert tracker._mask_pending_ages == {7: 1}
+    # A deferred tracklet is invisible to the mask pipeline (not init-masked).
+    assert tracker._previous_tracklets == []
+
+    tracker._store_previous_mask_inputs(frame=frame, detections=visible_result, removed_tracklet_ids=[])
+    assert tracker._previous_new_tracklets == []
+    assert tracker._mask_tracklet_ids == set()
+    assert tracker._mask_pending_ages == {7: 2}
+    assert tracker._previous_tracklets == []
+
+    tracker._store_previous_mask_inputs(frame=frame, detections=visible_result, removed_tracklet_ids=[])
+    assert [snapshot.tracker_id for snapshot in tracker._previous_new_tracklets] == [7]
+    assert tracker._mask_tracklet_ids == {7}
+    assert tracker._mask_pending_ages == {}
+    # Once promoted, the tracklet is exposed to the mask pipeline.
+    assert [snapshot.tracker_id for snapshot in tracker._previous_tracklets] == [7]
+
+
+def test_mcbyte_defer_restarts_when_tracklet_disappears_before_threshold() -> None:
+    """A tracklet that vanishes before the threshold restarts its visible-frame count on reappearance."""
+    tracker = McByteTracker(
+        enable_cmc=False,
+        mask_manager=_dummy_mask_manager(),
+        minimum_consecutive_frames=1,
+        minimum_mask_creation_frames=3,
+    )
+    frame = _make_frame()
+    visible_result = _visible_single_tracklet(7)
+    empty_result = sv.Detections.empty()
+    empty_result.tracker_id = np.array([], dtype=int)
+
+    tracker._store_previous_mask_inputs(frame=frame, detections=visible_result, removed_tracklet_ids=[])
+    tracker._store_previous_mask_inputs(frame=frame, detections=visible_result, removed_tracklet_ids=[])
+    assert tracker._mask_pending_ages == {7: 2}
+
+    # Tracklet not visible this frame: its pending count is dropped.
+    tracker._store_previous_mask_inputs(frame=frame, detections=empty_result, removed_tracklet_ids=[])
+    assert tracker._mask_pending_ages == {}
+
+    # Reappearing tracklet must accumulate the full window again before masking.
+    tracker._store_previous_mask_inputs(frame=frame, detections=visible_result, removed_tracklet_ids=[])
+    assert tracker._previous_new_tracklets == []
+    assert tracker._mask_tracklet_ids == set()
+    assert tracker._mask_pending_ages == {7: 1}
+
+
+def test_mcbyte_rejects_minimum_mask_creation_frames_below_one() -> None:
+    """minimum_mask_creation_frames below 1 is rejected: 1 already means immediate creation."""
+    with pytest.raises(ValueError, match="minimum_mask_creation_frames must be at least 1"):
+        McByteTracker(enable_cmc=False, enable_mask_manager=False, minimum_mask_creation_frames=0)
 
 
 def test_mcbyte_mask_conditioned_association_combines_locked_and_reduced_matches() -> None:


### PR DESCRIPTION
Add McByteTracker.minimum_mask_creation_frames (default 3): a confirmed tracklet is handed to SAM/Cutie only after it has been visible in tracker output for that many consecutive frames. Very-short-lived tracklets that terminate first never pay the appearance encode; value 1 restores the original immediate-creation timing (bit-identical default path).

Track per-id consecutive-visible counts in _mask_pending_ages via the new _collect_new_masked_tracklets helper; a reappearing tracklet restarts its count. Filter deferred tracklets out of the previous_tracklets handed to the mask manager so they are invisible to Cutie initialization as well as the add path, preventing a double-add of a later-promoted tracklet. Clear _mask_pending_ages on reset and reject minimum_mask_creation_frames below 1.

Pin the immediate-creation behavior tests to minimum_mask_creation_frames=1 and add coverage for deferral, restart-on-disappearance, and the guard.
