### PR TITLE
fix(motion): keep the tuned Q at a near-nominal frame step

### DIFF
--- a/docs/learn/dynamic-frame-rate.md
+++ b/docs/learn/dynamic-frame-rate.md
@@ -57,7 +57,7 @@ Stick with the default when you process **every** frame in order at a steady rat
 
 Set **`frame_rate`** on the tracker in both modes. In fixed mode it scales the frame budget above. When you pass `timestamp`, it also turns elapsed seconds into Kalman frame units (`elapsed_seconds × frame_rate`).
 
-If the video is actually steady 25 FPS and you pass timestamps every frame, `frame_step` stays at `1.0` for Kalman purposes — dynamic mode lines up with fixed mode. It lands *near* `1.0` rather than on it, because `frame_step` comes out of a subtraction: a float clock is off by ~1e-12, `cv2.CAP_PROP_POS_MSEC` rounds to whole milliseconds (up to 4% at 60 FPS), and capture jitter of a couple of milliseconds reaches ~10%. Anything within 10% of `1.0` counts as one nominal frame and runs the same process noise as fixed mode.
+If the video is actually steady 25 FPS and you pass timestamps every frame, `frame_step` stays at `1.0` for Kalman purposes — dynamic mode lines up with fixed mode. It lands *near* `1.0` rather than on it, because `frame_step` comes out of a subtraction: a float clock is off by ~1e-12, `cv2.CAP_PROP_POS_MSEC` rounds to whole milliseconds, and capture jitter adds a couple more. The tolerance around `1.0` is a fixed **~4 ms of wall-clock slack**, scaled by your tracker's `frame_rate` into frame units — that keeps the tolerance the same physical size at any FPS, rather than a fixed percentage of a frame. A step within that budget counts as one nominal frame and runs the same process noise as fixed mode.
 
 Two differences remain. `frame_step` still scales the transition matrix, so a clock reporting 1.02 frames does extrapolate 2% further — sub-pixel in practice. And lost-track pruning is not symmetric: dynamic mode drops time-expired tracks *before* association, fixed mode enforces its frame budget *after*, so a track whose budget runs out on the step where a detection would have re-matched it survives in fixed mode and not in dynamic mode.
 
@@ -68,7 +68,7 @@ Two differences remain. `frame_step` still scales the transition matrix, so a cl
 On each predict, the filter adjusts how far it extrapolates and how uncertain it is:
 
 - **Position** moves with constant velocity, scaled by the difference in timestamps scaled by the previous frame rate (`frame_step`).
-- **Process noise** grows on longer gaps so the box does not stay artificially tight. Within 10% of `frame_step = 1.0` you get the same as with default usage. On bigger steps the library rescales noise the way a constant-velocity model expects (stronger growth on position than velocity), instead of naively multiplying a one-frame matrix by Δt.
+- **Process noise** grows on longer gaps so the box does not stay artificially tight. Within the ~4 ms wall-clock tolerance of `frame_step = 1.0` (see above) you get the same as with default usage. On bigger steps the library rescales noise the way a constant-velocity model expects (stronger growth on position than velocity), instead of naively multiplying a one-frame matrix by Δt.
 - **Scale velocity** is frozen if the projected area over the gap would go non-positive.
 
 ---

--- a/docs/learn/dynamic-frame-rate.md
+++ b/docs/learn/dynamic-frame-rate.md
@@ -57,7 +57,9 @@ Stick with the default when you process **every** frame in order at a steady rat
 
 Set **`frame_rate`** on the tracker in both modes. In fixed mode it scales the frame budget above. When you pass `timestamp`, it also turns elapsed seconds into Kalman frame units (`elapsed_seconds × frame_rate`).
 
-If the video is actually steady 25 FPS and you pass timestamps every frame, `frame_step` stays `1.0` — dynamic mode lines up with fixed mode.
+If the video is actually steady 25 FPS and you pass timestamps every frame, `frame_step` stays at `1.0` for Kalman purposes — dynamic mode lines up with fixed mode. It lands *near* `1.0` rather than on it, because `frame_step` comes out of a subtraction: a float clock is off by ~1e-12, `cv2.CAP_PROP_POS_MSEC` rounds to whole milliseconds (up to 4% at 60 FPS), and capture jitter of a couple of milliseconds reaches ~10%. Anything within 10% of `1.0` counts as one nominal frame and runs the same process noise as fixed mode.
+
+Two differences remain. `frame_step` still scales the transition matrix, so a clock reporting 1.02 frames does extrapolate 2% further — sub-pixel in practice. And lost-track pruning is not symmetric: dynamic mode drops time-expired tracks *before* association, fixed mode enforces its frame budget *after*, so a track whose budget runs out on the step where a detection would have re-matched it survives in fixed mode and not in dynamic mode.
 
 ---
 
@@ -66,7 +68,7 @@ If the video is actually steady 25 FPS and you pass timestamps every frame, `fra
 On each predict, the filter adjusts how far it extrapolates and how uncertain it is:
 
 - **Position** moves with constant velocity, scaled by the difference in timestamps scaled by the previous frame rate (`frame_step`).
-- **Process noise** grows on longer gaps so the box does not stay artificially tight. At `frame_step = 1.0` you get the same as with default usage. On bigger steps the library rescales noise the way a constant-velocity model expects (stronger growth on position than velocity), instead of naively multiplying a one-frame matrix by Δt.
+- **Process noise** grows on longer gaps so the box does not stay artificially tight. Within 10% of `frame_step = 1.0` you get the same as with default usage. On bigger steps the library rescales noise the way a constant-velocity model expects (stronger growth on position than velocity), instead of naively multiplying a one-frame matrix by Δt.
 - **Scale velocity** is frozen if the projected area over the gap would go non-positive.
 
 ---

--- a/src/trackers/core/base.py
+++ b/src/trackers/core/base.py
@@ -480,6 +480,7 @@ class BaseTracker(ABC):
             return PredictTiming(
                 frame_step=elapsed * self._frame_rate,
                 elapsed_seconds=elapsed,
+                frame_rate=self._frame_rate,
             )
 
         if timestamp < last:
@@ -505,6 +506,7 @@ class BaseTracker(ABC):
         return PredictTiming(
             frame_step=elapsed * self._frame_rate,
             elapsed_seconds=elapsed,
+            frame_rate=self._frame_rate,
         )
 
     def _detections_for_skipped_update(self, detections: sv.Detections) -> sv.Detections:

--- a/src/trackers/core/botsort/tracklet.py
+++ b/src/trackers/core/botsort/tracklet.py
@@ -199,7 +199,7 @@ class BoTSORTTracklet(BaseTracklet):
         ``update(None)`` call used in ByteTrack/SORT.
         """
         self._refresh_noise_from_state()
-        self.state_estimator.predict(timing.frame_step)
+        self.state_estimator.predict(timing.frame_step, timing.frame_rate)
         self._clamp_state_bbox()
         self._advance_miss_clocks(timing)
         return self.state_estimator.state_to_bbox()

--- a/src/trackers/core/bytetrack/tracklet.py
+++ b/src/trackers/core/bytetrack/tracklet.py
@@ -49,7 +49,7 @@ class ByteTrackTracklet(BaseTracklet):
         Returns:
             Predicted bounding box `[x1, y1, x2, y2]`.
         """
-        self.state_estimator.predict(timing.frame_step)
+        self.state_estimator.predict(timing.frame_step, timing.frame_rate)
 
         if self.time_since_update > 0:
             self.number_of_successful_consecutive_updates = 0

--- a/src/trackers/core/ocsort/tracklet.py
+++ b/src/trackers/core/ocsort/tracklet.py
@@ -261,7 +261,7 @@ class OCSORTTracklet(BaseTracklet):
             self._freeze()
             self._observed = False
 
-        self.state_estimator.predict(timing.frame_step)
+        self.state_estimator.predict(timing.frame_step, timing.frame_rate)
 
         if self.time_since_update > 0:
             self.number_of_successful_consecutive_updates = 0

--- a/src/trackers/core/sort/tracklet.py
+++ b/src/trackers/core/sort/tracklet.py
@@ -48,7 +48,7 @@ class SORTTracklet(BaseTracklet):
         Returns:
             Predicted bounding box `[x1, y1, x2, y2]`.
         """
-        self.state_estimator.predict(timing.frame_step)
+        self.state_estimator.predict(timing.frame_step, timing.frame_rate)
         self._advance_miss_clocks(timing)
         return self.state_estimator.state_to_bbox()
 

--- a/src/trackers/utils/motion_models.py
+++ b/src/trackers/utils/motion_models.py
@@ -18,15 +18,17 @@ that case; other values rescale ``F`` and ``Q`` for shorter or longer gaps.
 ``Q`` uses the standard constant-velocity + white-noise-acceleration (DWNA)
 layout for gaps (``frame_step > 1``) and shorter-than-nominal steps
 (``frame_step < 1``): velocity variance scales as ``Δt²``, position as ``Δt⁴``.
-At a *near-nominal* ``frame_step`` — within ``_NOMINAL_FRAME_STEP_TOLERANCE``
-of ``1.0`` — the original configured Q (set by ``_configure_noise`` via
-``set_kf_covariances``) is returned unchanged. This preserves the hand-tuned
-per-tracker noise, keeps backward compatibility when ``timestamp`` is omitted,
-and makes a timestamped stream at its nominal FPS behave like the fixed-rate
-one: ``frame_step`` is a product of a subtraction, so it lands near ``1.0``
-without ever hitting it. Same block structure as
-``filterpy.common.discrete_white_noise`` — see the filterpy docs or source if
-you want the formulas side by side.
+At a *near-nominal* ``frame_step`` — within a tolerance band of ``1.0`` — the
+original configured Q (set by ``_configure_noise`` via ``set_kf_covariances``)
+is returned unchanged. This preserves the hand-tuned per-tracker noise, keeps
+backward compatibility when ``timestamp`` is omitted, and makes a timestamped
+stream at its nominal FPS behave like the fixed-rate one: ``frame_step`` is a
+product of a subtraction, so it lands near ``1.0`` without ever hitting it. The
+band's half-width is time-based (``_NOMINAL_FRAME_STEP_TOLERANCE_SECONDS *
+frame_rate``) so it stays fps-invariant; callers that do not supply a frame
+rate fall back to the fixed frame-unit band ``_NOMINAL_FRAME_STEP_TOLERANCE``.
+Same block structure as ``filterpy.common.discrete_white_noise`` — see the
+filterpy docs or source if you want the formulas side by side.
 """
 
 from __future__ import annotations
@@ -67,16 +69,38 @@ def constant_velocity_transition_matrix(
     return mtx
 
 
-_NOMINAL_FRAME_STEP_TOLERANCE = 0.1
-"""Half-width of the band around ``frame_step = 1.0`` treated as one nominal frame.
+_NOMINAL_FRAME_STEP_TOLERANCE_SECONDS = 0.004
+"""Half-width, in **wall-clock seconds**, of the near-nominal ``frame_step`` band.
 
-``frame_step`` is ``(t - t_prev) * frame_rate``, so a stream running at its
-nominal FPS never lands on exactly ``1.0``: a float clock is off by ~1e-12, an
-integer-millisecond clock (``cv2.CAP_PROP_POS_MSEC``) by up to 4.1e-2 at 60 FPS,
-and capture jitter of a couple of milliseconds by ~1e-1. The smallest gap a
-caller can express is ``frame_step = 1.5``, i.e. a deviation of 5e-1, so this
-band separates "one nominal frame" from "a real gap" with an order of magnitude
-of headroom on either side.
+This is the primary tolerance. ``build_Q`` multiplies it by the tracker's
+``frame_rate`` to get the band half-width in frame units, so the band absorbs a
+*fixed* amount of physical clock error regardless of FPS. That is what keeps the
+band fps-invariant: the physical error measured in frame units grows with FPS,
+and so does the band, so their ratio is constant. The 4 ms budget is derived
+from the two physical error sources a timestamped-but-nominal stream carries:
+
+- **Millisecond-clock rounding.** ``cv2.CAP_PROP_POS_MSEC`` quantises every
+  timestamp to whole milliseconds; ``frame_step`` is the difference of two such
+  timestamps, so its rounding error is bounded by ±1 ms in wall-clock seconds,
+  independent of FPS (≈4.1e-2 frame units at 60 FPS).
+- **Capture jitter.** Real cameras do not expose frames at perfectly even
+  intervals; a couple of milliseconds is typical, so ~2 ms is assumed.
+
+The worst-case sum is ~3 ms; ``0.004`` s (4 ms) covers it with ~33 % headroom.
+"""
+
+_NOMINAL_FRAME_STEP_TOLERANCE = 0.1
+"""Fallback half-width, in **frame units**, used when no ``frame_rate`` is given.
+
+``build_Q`` uses this fixed band only when a caller does not supply a frame
+rate — e.g. OC-SORT's ORU sub-step replay, which walks the virtual trajectory
+in frame counts, not wall-clock seconds. Because it is fixed in frame units
+while the physical clock error *in frame units* grows with FPS, this band
+absorbs ``0.1 / frame_rate`` seconds of error: ~3.3 ms at 30 FPS but only ~2 ms
+by 50 FPS (bare capture jitter, no rounding margin), and less above that. So
+this fallback path has a practical fps ceiling around ~50 FPS — an honest limit
+of the fallback only; the primary time-based path
+(``_NOMINAL_FRAME_STEP_TOLERANCE_SECONDS``) has no such ceiling.
 """
 
 
@@ -90,12 +114,14 @@ class ScalableProcessNoise:
     acceleration variance ``sigma_a2`` from that reference ``Q`` and stores the
     DWNA-at-1 layout as ``baseline_Q``.
 
-    Within ``_NOMINAL_FRAME_STEP_TOLERANCE`` of ``frame_step = 1.0``,
-    ``build_Q`` returns the original configured Q stored in ``baseline_Q`` —
-    preserving hand-tuned per-tracker noise and backward compatibility. Outside
-    that band the step is a real gap and DWNA scaling is applied: smaller steps
-    shrink uncertainty; larger steps grow it. Frozen entries (e.g. aspect ratio
-    in XCYCSR) stay at the values from ``_configure_noise()``.
+    Within a near-nominal band of ``frame_step = 1.0``, ``build_Q`` returns the
+    original configured Q stored in ``baseline_Q`` — preserving hand-tuned
+    per-tracker noise and backward compatibility. The band half-width is
+    time-based when a ``frame_rate`` is supplied (fps-invariant) and falls back
+    to a fixed frame-unit width otherwise; see ``build_Q``. Outside that band
+    the step is a real gap and DWNA scaling is applied: smaller steps shrink
+    uncertainty; larger steps grow it. Frozen entries (e.g. aspect ratio in
+    XCYCSR) stay at the values from ``_configure_noise()``.
     """
 
     dim_x: int
@@ -143,37 +169,64 @@ class ScalableProcessNoise:
         self.extra_q_diagonal = np.diag(Q).astype(np.float64).copy()
         self._needs_calibration = False
 
-    def build_Q(self, frame_step: float) -> NDArray[np.float64]:
+    def build_Q(self, frame_step: float, frame_rate: float | None = None) -> NDArray[np.float64]:
         """Return process noise Q scaled for the given frame step.
 
-        Within ``_NOMINAL_FRAME_STEP_TOLERANCE`` of ``1.0`` the step counts as
-        one nominal frame and the configured Q (``baseline_Q``) is returned
-        unchanged, preserving hand-tuned noise. Outside that band the step is a
-        real gap and the DWNA formula is applied via ``_dwna``.
+        Within a near-nominal band of ``1.0`` the step counts as one nominal
+        frame and the configured Q (``baseline_Q``) is returned unchanged,
+        preserving hand-tuned noise. Outside that band the step is a real gap
+        and the DWNA formula is applied via ``_dwna``.
 
-        The tolerance is what makes dynamic-rate mode line up with fixed-rate
-        mode. ``frame_step`` comes from ``(t - t_prev) * frame_rate``, so a
-        stream at its nominal FPS lands *near* ``1.0``, never on it; an exact
-        comparison sent every such step down the gap path, where ``_dwna``
-        rebuilds Q from the velocity diagonal alone and drops the configured
-        position noise.
+        The band is what makes dynamic-rate mode line up with fixed-rate mode.
+        ``frame_step`` comes from ``(t - t_prev) * frame_rate``, so a stream at
+        its nominal FPS lands *near* ``1.0``, never on it; an exact comparison
+        would send every such step down the gap path, where ``_dwna`` rebuilds Q
+        from the velocity diagonal alone and drops the configured position noise.
+
+        The band half-width adapts to ``frame_rate`` so it stays fps-invariant.
+        The physical error a nominal stream carries (ms-clock rounding, capture
+        jitter) is bounded in *wall-clock seconds*, but expressed in *frame
+        units* it grows with FPS, so a fixed frame-unit band would break at high
+        FPS. Multiplying a seconds budget by ``frame_rate`` makes the error and
+        the band scale together:
+
+        - ``frame_rate`` given (the normal tracker path):
+          ``tolerance = _NOMINAL_FRAME_STEP_TOLERANCE_SECONDS * frame_rate`` —
+          4 ms of wall-clock slack at any FPS.
+        - ``frame_rate`` absent (e.g. OC-SORT ORU sub-steps, which are frame-unit
+          replay steps): the fixed fallback ``_NOMINAL_FRAME_STEP_TOLERANCE``
+          (0.1 frame units), whose own ~50 FPS ceiling is documented on that
+          constant.
+
+        The band is symmetric in ``frame_step``, but the DWNA growth it forgoes
+        is not: treating ``1.0 + tol`` as nominal skips ``(1 + tol)**4``
+        position-variance growth while ``1.0 - tol`` skips ``(1 - tol)**4``
+        shrink, so the upper edge is marginally worse-behaved than the lower —
+        immaterial this close to ``1.0``.
 
         What this does **not** cover: capture jitter wider than the tolerance
         still takes the gap path, and lost-track pruning remains asymmetric
-        between the two modes (``BaseTracker._prune_lost_tracks`` runs before
-        association in dynamic-rate mode, while the fixed-rate frame budget is
-        enforced after it), so the two modes can still differ by one
+        between the two modes (dynamic-rate mode drops time-expired tracks
+        before association, while fixed-rate mode enforces its frame budget
+        after association), so the two modes can still differ by one
         ``lost_track_buffer`` frame.
 
         Args:
-            frame_step: Elapsed time in frame units; a value within
-                ``_NOMINAL_FRAME_STEP_TOLERANCE`` of ``1.0`` returns
-                ``baseline_Q`` unchanged.
+            frame_step: Elapsed time in frame units; a value within the
+                near-nominal band of ``1.0`` returns ``baseline_Q`` unchanged.
+            frame_rate: Tracker reference FPS. When given (and positive) the band
+                half-width is ``_NOMINAL_FRAME_STEP_TOLERANCE_SECONDS *
+                frame_rate`` frame units, keeping it fps-invariant. When ``None``
+                the fixed fallback ``_NOMINAL_FRAME_STEP_TOLERANCE`` is used.
 
         Returns:
             Process noise matrix of shape ``(dim_x, dim_x)``.
         """
-        if abs(frame_step - 1.0) <= _NOMINAL_FRAME_STEP_TOLERANCE:
+        if frame_rate is not None and frame_rate > 0:
+            tolerance = _NOMINAL_FRAME_STEP_TOLERANCE_SECONDS * frame_rate
+        else:
+            tolerance = _NOMINAL_FRAME_STEP_TOLERANCE
+        if abs(frame_step - 1.0) <= tolerance:
             return self.baseline_Q.copy()
         self._ensure_calibrated()
         return self._dwna(frame_step)
@@ -269,7 +322,7 @@ class KalmanMotionModel:
         self.process_noise.calibrate(process_noise)
         self._cached_process_noise = None
 
-    def apply(self, kf: KalmanFilter, frame_step: float) -> None:
+    def apply(self, kf: KalmanFilter, frame_step: float, frame_rate: float | None = None) -> None:
         """Set transition_matrix and Q on a Kalman filter for the given frame step.
 
         Both matrices are cached to avoid redundant computation. The transition
@@ -277,10 +330,23 @@ class KalmanMotionModel:
         invalidated by ``calibrate_from_process_noise`` and rebuilt from the
         current reference on the next call.
 
+        The transition-matrix cache key stays keyed on ``frame_step`` alone and
+        is compared exactly (``frame_step != self.cached_step``). Unlike Q's
+        near-nominal band, this exactness is intentional: the cache key is a
+        memoization key, and ``F`` genuinely varies with the precise
+        ``frame_step`` (the coupling term is set to it directly), so an exact
+        key is correct — a near-nominal ``frame_step`` only costs a cache miss,
+        never a wrong matrix. ``frame_rate`` is constant per tracker instance,
+        not a per-call variable, so it does not enter the cache key.
+
         Args:
             kf: ``KalmanFilter`` to update in-place.
             frame_step: Elapsed time in frame units for this predict step.
                 Use ``1.0`` for a single nominal frame; larger values for gaps.
+            frame_rate: Tracker reference FPS, forwarded to
+                ``ScalableProcessNoise.build_Q`` to keep the near-nominal Q band
+                fps-invariant. ``None`` (fixed-rate mode or unavailable) selects
+                the fixed frame-unit fallback band.
         """
         if frame_step != self.cached_step or self._cached_transition_mtx is None:
             self._cached_transition_mtx = constant_velocity_transition_matrix(
@@ -289,7 +355,7 @@ class KalmanMotionModel:
             self.cached_step = frame_step
             self._cached_process_noise = None
         if self._cached_process_noise is None:
-            self._cached_process_noise = self.process_noise.build_Q(frame_step)
+            self._cached_process_noise = self.process_noise.build_Q(frame_step, frame_rate)
         kf.transition_mtx = self._cached_transition_mtx
         kf.process_noise = self._cached_process_noise
 

--- a/src/trackers/utils/motion_models.py
+++ b/src/trackers/utils/motion_models.py
@@ -18,10 +18,13 @@ that case; other values rescale ``F`` and ``Q`` for shorter or longer gaps.
 ``Q`` uses the standard constant-velocity + white-noise-acceleration (DWNA)
 layout for gaps (``frame_step > 1``) and shorter-than-nominal steps
 (``frame_step < 1``): velocity variance scales as ``Δt²``, position as ``Δt⁴``.
-At ``frame_step == 1.0`` the original configured Q (set by ``_configure_noise``
-via ``set_kf_covariances``) is returned unchanged — this preserves the
-hand-tuned per-tracker noise and ensures backward compatibility when
-``timestamp`` is omitted. Same block structure as
+At a *near-nominal* ``frame_step`` — within ``_NOMINAL_FRAME_STEP_TOLERANCE``
+of ``1.0`` — the original configured Q (set by ``_configure_noise`` via
+``set_kf_covariances``) is returned unchanged. This preserves the hand-tuned
+per-tracker noise, keeps backward compatibility when ``timestamp`` is omitted,
+and makes a timestamped stream at its nominal FPS behave like the fixed-rate
+one: ``frame_step`` is a product of a subtraction, so it lands near ``1.0``
+without ever hitting it. Same block structure as
 ``filterpy.common.discrete_white_noise`` — see the filterpy docs or source if
 you want the formulas side by side.
 """
@@ -64,6 +67,19 @@ def constant_velocity_transition_matrix(
     return mtx
 
 
+_NOMINAL_FRAME_STEP_TOLERANCE = 0.1
+"""Half-width of the band around ``frame_step = 1.0`` treated as one nominal frame.
+
+``frame_step`` is ``(t - t_prev) * frame_rate``, so a stream running at its
+nominal FPS never lands on exactly ``1.0``: a float clock is off by ~1e-12, an
+integer-millisecond clock (``cv2.CAP_PROP_POS_MSEC``) by up to 4.1e-2 at 60 FPS,
+and capture jitter of a couple of milliseconds by ~1e-1. The smallest gap a
+caller can express is ``frame_step = 1.5``, i.e. a deviation of 5e-1, so this
+band separates "one nominal frame" from "a real gap" with an order of magnitude
+of headroom on either side.
+"""
+
+
 @dataclass
 class ScalableProcessNoise:
     """Store the tracker's one-frame ``Q`` and scale it for any gap.
@@ -74,12 +90,12 @@ class ScalableProcessNoise:
     acceleration variance ``sigma_a2`` from that reference ``Q`` and stores the
     DWNA-at-1 layout as ``baseline_Q``.
 
-    At ``frame_step == 1.0``, ``build_Q`` returns the original configured Q
-    stored in ``baseline_Q`` — preserving hand-tuned per-tracker noise and
-    backward compatibility. For other frame steps, DWNA scaling is applied:
-    smaller steps (``frame_step < 1``) shrink uncertainty; larger steps
-    (``frame_step > 1``) grow it. Frozen entries (e.g. aspect ratio in XCYCSR)
-    stay at the values from ``_configure_noise()``.
+    Within ``_NOMINAL_FRAME_STEP_TOLERANCE`` of ``frame_step = 1.0``,
+    ``build_Q`` returns the original configured Q stored in ``baseline_Q`` —
+    preserving hand-tuned per-tracker noise and backward compatibility. Outside
+    that band the step is a real gap and DWNA scaling is applied: smaller steps
+    shrink uncertainty; larger steps grow it. Frozen entries (e.g. aspect ratio
+    in XCYCSR) stay at the values from ``_configure_noise()``.
     """
 
     dim_x: int
@@ -130,19 +146,34 @@ class ScalableProcessNoise:
     def build_Q(self, frame_step: float) -> NDArray[np.float64]:
         """Return process noise Q scaled for the given frame step.
 
-        At ``frame_step == 1.0`` the original configured Q (``baseline_Q``) is
-        returned unchanged to preserve hand-tuned noise and backward
-        compatibility. For any other step the DWNA formula is applied via
-        ``_dwna``.
+        Within ``_NOMINAL_FRAME_STEP_TOLERANCE`` of ``1.0`` the step counts as
+        one nominal frame and the configured Q (``baseline_Q``) is returned
+        unchanged, preserving hand-tuned noise. Outside that band the step is a
+        real gap and the DWNA formula is applied via ``_dwna``.
+
+        The tolerance is what makes dynamic-rate mode line up with fixed-rate
+        mode. ``frame_step`` comes from ``(t - t_prev) * frame_rate``, so a
+        stream at its nominal FPS lands *near* ``1.0``, never on it; an exact
+        comparison sent every such step down the gap path, where ``_dwna``
+        rebuilds Q from the velocity diagonal alone and drops the configured
+        position noise.
+
+        What this does **not** cover: capture jitter wider than the tolerance
+        still takes the gap path, and lost-track pruning remains asymmetric
+        between the two modes (``BaseTracker._prune_lost_tracks`` runs before
+        association in dynamic-rate mode, while the fixed-rate frame budget is
+        enforced after it), so the two modes can still differ by one
+        ``lost_track_buffer`` frame.
 
         Args:
-            frame_step: Elapsed time in frame units; ``1.0`` returns
-                ``baseline_Q`` exactly.
+            frame_step: Elapsed time in frame units; a value within
+                ``_NOMINAL_FRAME_STEP_TOLERANCE`` of ``1.0`` returns
+                ``baseline_Q`` unchanged.
 
         Returns:
             Process noise matrix of shape ``(dim_x, dim_x)``.
         """
-        if frame_step == 1.0:
+        if abs(frame_step - 1.0) <= _NOMINAL_FRAME_STEP_TOLERANCE:
             return self.baseline_Q.copy()
         self._ensure_calibrated()
         return self._dwna(frame_step)

--- a/src/trackers/utils/motion_models.py
+++ b/src/trackers/utils/motion_models.py
@@ -69,39 +69,18 @@ def constant_velocity_transition_matrix(
     return mtx
 
 
+# Half-width, in wall-clock seconds, of the near-nominal frame_step band.
+# build_Q multiplies this by frame_rate to get the frame-unit half-width, so
+# the band absorbs a fixed physical-clock-error budget at any FPS. 4ms covers
+# the two error sources: ms-clock rounding (bounded ~1ms) + capture jitter
+# (~2ms), with ~33% headroom on the ~3ms worst-case sum.
 _NOMINAL_FRAME_STEP_TOLERANCE_SECONDS = 0.004
-"""Half-width, in **wall-clock seconds**, of the near-nominal ``frame_step`` band.
 
-This is the primary tolerance. ``build_Q`` multiplies it by the tracker's
-``frame_rate`` to get the band half-width in frame units, so the band absorbs a
-*fixed* amount of physical clock error regardless of FPS. That is what keeps the
-band fps-invariant: the physical error measured in frame units grows with FPS,
-and so does the band, so their ratio is constant. The 4 ms budget is derived
-from the two physical error sources a timestamped-but-nominal stream carries:
-
-- **Millisecond-clock rounding.** ``cv2.CAP_PROP_POS_MSEC`` quantises every
-  timestamp to whole milliseconds; ``frame_step`` is the difference of two such
-  timestamps, so its rounding error is bounded by ±1 ms in wall-clock seconds,
-  independent of FPS (≈4.1e-2 frame units at 60 FPS).
-- **Capture jitter.** Real cameras do not expose frames at perfectly even
-  intervals; a couple of milliseconds is typical, so ~2 ms is assumed.
-
-The worst-case sum is ~3 ms; ``0.004`` s (4 ms) covers it with ~33 % headroom.
-"""
-
+# Fallback half-width, in frame units, used when no frame_rate is given (e.g.
+# OC-SORT's ORU sub-step replay, which is frame-unit not wall-clock). Fixed in
+# frame units while the physical error it absorbs grows with FPS, so this path
+# has a practical ~50fps ceiling; the time-based tolerance above has none.
 _NOMINAL_FRAME_STEP_TOLERANCE = 0.1
-"""Fallback half-width, in **frame units**, used when no ``frame_rate`` is given.
-
-``build_Q`` uses this fixed band only when a caller does not supply a frame
-rate — e.g. OC-SORT's ORU sub-step replay, which walks the virtual trajectory
-in frame counts, not wall-clock seconds. Because it is fixed in frame units
-while the physical clock error *in frame units* grows with FPS, this band
-absorbs ``0.1 / frame_rate`` seconds of error: ~3.3 ms at 30 FPS but only ~2 ms
-by 50 FPS (bare capture jitter, no rounding margin), and less above that. So
-this fallback path has a practical fps ceiling around ~50 FPS — an honest limit
-of the fallback only; the primary time-based path
-(``_NOMINAL_FRAME_STEP_TOLERANCE_SECONDS``) has no such ceiling.
-"""
 
 
 @dataclass

--- a/src/trackers/utils/predict_timing.py
+++ b/src/trackers/utils/predict_timing.py
@@ -29,11 +29,17 @@ class PredictTiming:
             was passed); non-``None`` in dynamic-rate mode.
         skip_update (bool): When ``True`` the caller should skip the entire
             measurement update step (e.g. backwards or non-finite timestamp).
+        frame_rate (float | None): The tracker's configured reference FPS, used
+            to make the near-nominal Kalman-``Q`` tolerance fps-invariant (the
+            band half-width scales as ``seconds_tolerance * frame_rate``).
+            ``None`` in fixed-rate mode or when the frame rate is unavailable,
+            in which case the Kalman layer falls back to a fixed frame-unit band.
     """
 
     frame_step: float
     elapsed_seconds: float | None
     skip_update: bool = False
+    frame_rate: float | None = None
 
     @property
     def skip_predict(self) -> bool:

--- a/src/trackers/utils/state_representations.py
+++ b/src/trackers/utils/state_representations.py
@@ -143,16 +143,20 @@ class BaseStateEstimator(ABC):
                 by `frame_step`, not by a single nominal frame.
         """
 
-    def predict(self, frame_step: float = 1.0) -> None:
+    def predict(self, frame_step: float = 1.0, frame_rate: float | None = None) -> None:
         """Predict one Kalman step, scaling F and Q by frame_step.
 
         Args:
             frame_step: Elapsed time in frame units; ``1.0`` = one nominal
                 frame. Pass a larger value after a gap between updates so the
                 filter extrapolates further and widens process noise accordingly.
+            frame_rate: Tracker reference FPS, forwarded to the motion model so
+                the near-nominal process-noise band stays fps-invariant. ``None``
+                (fixed-rate mode or unavailable) selects the fixed frame-unit
+                fallback band.
         """
         self.clamp_velocity(frame_step)
-        self.motion.apply(self.kf, frame_step)
+        self.motion.apply(self.kf, frame_step, frame_rate)
         self.kf.predict()
 
     def update(self, bbox: np.ndarray | None) -> None:

--- a/tests/core/test_timestamp_plumbing.py
+++ b/tests/core/test_timestamp_plumbing.py
@@ -477,6 +477,67 @@ def test_same_confirmation_pattern_at_reference_fps(
     assert fixed_pattern == dynamic_pattern
 
 
+def _process_noise_after_a_few_frames(
+    tracker_cls: type[BaseTracker],
+    tracklet_cls: type[BaseTracklet],
+    extra_kwargs: dict[str, Any],
+    *,
+    clock: str,
+    frame_rate: float = 30.0,
+) -> np.ndarray:
+    """Return the ``Q`` a tracklet ends up running with under the given clock."""
+    tracker = _make_timestamp_aware_tracker(
+        tracker_cls,
+        tracklet_cls,
+        extra_kwargs,
+        frame_rate=frame_rate,
+        lost_track_buffer=30,
+    )
+    for i in range(6):
+        if clock == "fixed":
+            timestamp = None
+        elif clock == "float":
+            timestamp = i / frame_rate
+        elif clock == "milliseconds":
+            # cv2.CAP_PROP_POS_MSEC reports whole milliseconds.
+            timestamp = round(i / frame_rate * 1000.0) / 1000.0
+        else:
+            raise ValueError(clock)
+        x = 100.0 + 6.0 * i
+        tracker.update(_make_detections([[x, 100.0, x + 50.0, 200.0]], [0.9]), timestamp=timestamp)
+    return np.asarray(tracker.tracks[0].state_estimator.kf.process_noise, dtype=np.float64).copy()
+
+
+@pytest.mark.parametrize("clock", ["float", "milliseconds"])
+@pytest.mark.parametrize(
+    "tracker_cls, tracklet_cls, extra_kwargs",
+    TIMESTAMP_AWARE_TRACKERS,
+)
+def test_same_process_noise_at_reference_fps(
+    tracker_cls: type[BaseTracker],
+    tracklet_cls: type[BaseTracklet],
+    extra_kwargs: dict[str, Any],
+    clock: str,
+) -> None:
+    """A steady stream at the reference FPS runs the tracker's configured ``Q``.
+
+    ``frame_step`` is ``(t - t_prev) * frame_rate``, which lands near ``1.0``
+    but never on it, so this is the case an exact ``== 1.0`` comparison misses:
+    every step took the gap path and ran a ``Q`` rebuilt from the velocity
+    diagonal instead of the configured one.
+
+    ``Q`` is asserted rather than the output boxes on purpose. ``Q`` does not
+    enter the predicted state (``x = F @ x``) — it enters the covariance, which
+    sets the Kalman gain, so its effect on the boxes only becomes measurable
+    once detections compete for association in a crowded scene. Asserting the
+    matrix keeps the regression observable in a unit test.
+    """
+    fixed = _process_noise_after_a_few_frames(tracker_cls, tracklet_cls, extra_kwargs, clock="fixed")
+    dynamic = _process_noise_after_a_few_frames(tracker_cls, tracklet_cls, extra_kwargs, clock=clock)
+
+    np.testing.assert_array_equal(dynamic, fixed)
+
+
 @pytest.mark.parametrize(
     ("tracker_cls", "extra_kwargs"),
     [

--- a/tests/utils/test_motion_models.py
+++ b/tests/utils/test_motion_models.py
@@ -8,11 +8,15 @@
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pytest
 
 from trackers.utils.kalman_filter import KalmanFilter
 from trackers.utils.motion_models import (
+    _NOMINAL_FRAME_STEP_TOLERANCE,
+    _NOMINAL_FRAME_STEP_TOLERANCE_SECONDS,
     KalmanMotionModel,
     ScalableProcessNoise,
     constant_velocity_transition_matrix,
@@ -133,6 +137,111 @@ def test_build_Q_returns_baseline_for_near_nominal_frame_step(frame_step: float)
     assert built.tobytes() == baseline.tobytes()
 
 
+FRAME_RATE_FOR_BOUNDARY_TEST = 60.0
+
+
+def _edge_step(tolerance: float, sign: float, *, included: bool) -> float:
+    """Return the float ``frame_step`` nearest ``1.0 + sign * tolerance``.
+
+    ``1.0 + tolerance`` is not itself guaranteed to satisfy
+    ``abs(frame_step - 1.0) <= tolerance`` in float64 (the same rounding trap
+    that makes the literal ``1.1`` land outside a ``0.1`` band): adding and then
+    subtracting ``1.0`` can round away from ``tolerance``. This walks the float
+    representable just past the raw sum back toward ``1.0`` until the actual
+    ``build_Q`` comparison would include it, so the probe matches the real
+    boundary of the implementation, not an algebraic approximation of it.
+
+    Args:
+        tolerance: Band half-width in frame units.
+        sign: ``1.0`` for the high edge, ``-1.0`` for the low edge.
+        included: If ``True``, return the last included step; if ``False``,
+            return the first excluded step just beyond it.
+
+    Returns:
+        The boundary ``frame_step`` value for the requested edge.
+    """
+    candidate = 1.0 + sign * tolerance
+    while abs(candidate - 1.0) > tolerance:
+        candidate = math.nextafter(candidate, 1.0)
+    return candidate if included else math.nextafter(candidate, sign * math.inf)
+
+
+@pytest.mark.parametrize(
+    "frame_step,expect_baseline",
+    [
+        pytest.param(
+            _edge_step(_NOMINAL_FRAME_STEP_TOLERANCE, 1.0, included=True),
+            True,
+            id="fallback-high-edge-included",
+        ),
+        pytest.param(
+            _edge_step(_NOMINAL_FRAME_STEP_TOLERANCE, 1.0, included=False),
+            False,
+            id="fallback-high-edge-excluded",
+        ),
+        pytest.param(
+            _edge_step(_NOMINAL_FRAME_STEP_TOLERANCE, -1.0, included=True),
+            True,
+            id="fallback-low-edge-included",
+        ),
+        pytest.param(
+            _edge_step(_NOMINAL_FRAME_STEP_TOLERANCE, -1.0, included=False),
+            False,
+            id="fallback-low-edge-excluded",
+        ),
+    ],
+)
+def test_build_Q_fallback_tolerance_boundary_without_frame_rate(frame_step: float, expect_baseline: bool) -> None:
+    """No ``frame_rate``: the fixed frame-unit band edge is inclusive at exactly the tolerance."""
+    baseline = np.diag([16.0, 81.0, 16.0, 81.0, 0.25, 1.2656, 0.25, 1.2656])
+    noise = _noise_8d(baseline)
+
+    built = noise.build_Q(frame_step)
+
+    is_baseline = built.tobytes() == baseline.tobytes()
+    assert is_baseline is expect_baseline, (
+        f"frame_step={frame_step!r} (no frame_rate) expected baseline={expect_baseline}"
+    )
+
+
+@pytest.mark.parametrize(
+    "frame_step,expect_baseline",
+    [
+        pytest.param(
+            _edge_step(_NOMINAL_FRAME_STEP_TOLERANCE_SECONDS * FRAME_RATE_FOR_BOUNDARY_TEST, 1.0, included=True),
+            True,
+            id="fps-invariant-high-edge-included",
+        ),
+        pytest.param(
+            _edge_step(_NOMINAL_FRAME_STEP_TOLERANCE_SECONDS * FRAME_RATE_FOR_BOUNDARY_TEST, 1.0, included=False),
+            False,
+            id="fps-invariant-high-edge-excluded",
+        ),
+        pytest.param(
+            _edge_step(_NOMINAL_FRAME_STEP_TOLERANCE_SECONDS * FRAME_RATE_FOR_BOUNDARY_TEST, -1.0, included=True),
+            True,
+            id="fps-invariant-low-edge-included",
+        ),
+        pytest.param(
+            _edge_step(_NOMINAL_FRAME_STEP_TOLERANCE_SECONDS * FRAME_RATE_FOR_BOUNDARY_TEST, -1.0, included=False),
+            False,
+            id="fps-invariant-low-edge-excluded",
+        ),
+    ],
+)
+def test_build_Q_fps_invariant_tolerance_boundary_with_frame_rate(frame_step: float, expect_baseline: bool) -> None:
+    """``frame_rate`` given: the fps-scaled band edge is inclusive at exactly ``tolerance * frame_rate``."""
+    baseline = np.diag([16.0, 81.0, 16.0, 81.0, 0.25, 1.2656, 0.25, 1.2656])
+    noise = _noise_8d(baseline)
+
+    built = noise.build_Q(frame_step, frame_rate=FRAME_RATE_FOR_BOUNDARY_TEST)
+
+    is_baseline = built.tobytes() == baseline.tobytes()
+    assert is_baseline is expect_baseline, (
+        f"frame_step={frame_step!r} frame_rate={FRAME_RATE_FOR_BOUNDARY_TEST} expected baseline={expect_baseline}"
+    )
+
+
 def test_build_Q_still_rescales_a_real_gap() -> None:
     """Steps outside the band keep the DWNA gap scaling untouched."""
     baseline = np.eye(8, dtype=np.float64) * 0.01
@@ -172,6 +281,61 @@ def test_build_Q_recalibrates_within_the_nominal_band() -> None:
     noise.calibrate(second)
 
     assert noise.build_Q(1.0 + 2.0e-2).tobytes() == second.tobytes()
+
+
+def test_build_Q_at_zero_frame_step_zeroes_kinematic_block_only() -> None:
+    """frame_step=0.0 sits outside both tolerance bands: the DWNA kinematic block collapses
+    to all-zero (dt2=dt3=dt4=0), but non-kinematic diagonal entries still come from the
+    one-frame reference Q — this is not a blanket all-zero matrix.
+    """
+    extra = np.ones(7, dtype=np.float64) * 0.01
+    extra[3] = 7.5
+    noise = ScalableProcessNoise(
+        dim_x=7,
+        pos_idx=POS_XCYCSR,
+        vel_idx=VEL_XCYCSR,
+        baseline_Q=np.diag(extra),
+        sigma_a2=np.ones(3, dtype=np.float64) * 0.01,
+        extra_q_diagonal=extra,
+    )
+
+    built = noise.build_Q(0.0)
+
+    kinematic_idx = np.array([*POS_XCYCSR, *VEL_XCYCSR])
+    kinematic_block = built[np.ix_(kinematic_idx, kinematic_idx)]
+    np.testing.assert_array_equal(kinematic_block, np.zeros((6, 6)))
+    assert built[3, 3] == pytest.approx(7.5), "non-kinematic diagonal must survive frame_step=0.0"
+
+
+def test_build_Q_at_negative_frame_step_documents_sign_inverted_dwna() -> None:
+    """frame_step=-1.0 is not degenerate like 0.0: dt2=1, dt3=-1, dt4=1 build a real,
+    non-zero, sign-inverted DWNA matrix. This pins current documented behavior rather than
+    guarding a bug — ``build_Q`` does not validate ``frame_step`` and no shipped tracker
+    calls it with a negative step.
+    """
+    extra = np.ones(7, dtype=np.float64) * 0.01
+    extra[3] = 7.5
+    sigma_a2 = np.ones(3, dtype=np.float64) * 0.01
+    noise = ScalableProcessNoise(
+        dim_x=7,
+        pos_idx=POS_XCYCSR,
+        vel_idx=VEL_XCYCSR,
+        baseline_Q=np.diag(extra),
+        sigma_a2=sigma_a2,
+        extra_q_diagonal=extra,
+    )
+    zero_case = noise.build_Q(0.0)
+
+    built = noise.build_Q(-1.0)
+
+    assert not np.array_equal(built, zero_case), "frame_step=-1.0 must not collapse like frame_step=0.0"
+    expected = np.zeros((7, 7), dtype=np.float64)
+    expected[POS_XCYCSR, POS_XCYCSR] = sigma_a2 * 1.0 / 4.0  # dt4 = (-1)**4 = 1
+    expected[POS_XCYCSR, VEL_XCYCSR] = sigma_a2 * -1.0 / 2.0  # dt3 = (-1)**3 = -1
+    expected[VEL_XCYCSR, POS_XCYCSR] = sigma_a2 * -1.0 / 2.0
+    expected[VEL_XCYCSR, VEL_XCYCSR] = sigma_a2 * 1.0  # dt2 = (-1)**2 = 1
+    expected[3, 3] = extra[3]
+    np.testing.assert_allclose(built, expected)
 
 
 def test_sync_preserves_configured_q_at_unit_frame_step() -> None:

--- a/tests/utils/test_motion_models.py
+++ b/tests/utils/test_motion_models.py
@@ -94,6 +94,86 @@ def test_build_Q_at_frame_step_1_returns_baseline() -> None:
     np.testing.assert_array_equal(q1, baseline)
 
 
+def _noise_8d(baseline: np.ndarray) -> ScalableProcessNoise:
+    return ScalableProcessNoise(
+        dim_x=8,
+        pos_idx=POS_4D,
+        vel_idx=VEL_4D,
+        baseline_Q=baseline.copy(),
+        sigma_a2=np.ones(4, dtype=np.float64) * 0.01,
+        extra_q_diagonal=np.diag(baseline).astype(np.float64).copy(),
+    )
+
+
+# Deviations a stream running at its nominal FPS actually produces. `frame_step`
+# is `(t - t_prev) * frame_rate`, so it lands near 1.0 and never on it.
+NEAR_NOMINAL_FRAME_STEPS = [
+    pytest.param(1.0 + 5e-13, id="float-clock"),
+    pytest.param(1.0 - 5e-13, id="float-clock-below"),
+    pytest.param(1.0 + 2.0e-2, id="millisecond-clock-30fps"),
+    pytest.param(1.0 + 4.1e-2, id="millisecond-clock-60fps"),
+    pytest.param(1.0 - 4.1e-2, id="millisecond-clock-60fps-below"),
+    pytest.param(1.0 + 1.0e-3, id="ntsc-29.97-declared-30"),
+]
+
+
+@pytest.mark.parametrize("frame_step", NEAR_NOMINAL_FRAME_STEPS)
+def test_build_Q_returns_baseline_for_near_nominal_frame_step(frame_step: float) -> None:
+    """A step off 1.0 by real clock error still counts as one nominal frame.
+
+    Compared bit for bit rather than with ``approx``: an approximate check would
+    pass on the rebuilt DWNA matrix this guards against, which differs from the
+    configured Q by two orders of magnitude on the position block.
+    """
+    baseline = np.diag([16.0, 81.0, 16.0, 81.0, 0.25, 1.2656, 0.25, 1.2656])
+    noise = _noise_8d(baseline)
+
+    built = noise.build_Q(frame_step)
+
+    assert built.tobytes() == baseline.tobytes()
+
+
+def test_build_Q_still_rescales_a_real_gap() -> None:
+    """Steps outside the band keep the DWNA gap scaling untouched."""
+    baseline = np.eye(8, dtype=np.float64) * 0.01
+    noise = _noise_8d(baseline)
+
+    for frame_step in (1.5, 2.0, 5.0, 15.0):
+        built = noise.build_Q(frame_step)
+        assert built.tobytes() != baseline.tobytes(), f"frame_step={frame_step} must take the gap path"
+
+    for p, v in zip(POS_4D, VEL_4D):
+        assert noise.build_Q(4.0)[v, v] == pytest.approx(noise.build_Q(2.0)[v, v] * 4.0)
+
+
+def test_build_Q_alternating_nominal_and_gap_steps_leaves_no_stale_state() -> None:
+    """Second occurrence and the return to the original state, not just the first transition."""
+    baseline = np.diag([16.0, 81.0, 16.0, 81.0, 0.25, 1.2656, 0.25, 1.2656])
+    noise = _noise_8d(baseline)
+
+    gap_first = noise.build_Q(3.0)
+    for _ in range(2):
+        assert noise.build_Q(1.0 + 2.0e-2).tobytes() == baseline.tobytes()
+        np.testing.assert_array_equal(noise.build_Q(3.0), gap_first)
+        assert noise.build_Q(1.0).tobytes() == baseline.tobytes()
+
+
+def test_build_Q_recalibrates_within_the_nominal_band() -> None:
+    """A near-nominal step returns the *current* reference, not a cached one.
+
+    BoT-SORT refreshes its scale-aware Q on every frame, so the band must track
+    ``calibrate`` rather than pin the matrix seen on the first call.
+    """
+    first = np.eye(8, dtype=np.float64) * 0.01
+    noise = _noise_8d(first)
+    assert noise.build_Q(1.0 + 2.0e-2).tobytes() == first.tobytes()
+
+    second = np.eye(8, dtype=np.float64) * 0.5
+    noise.calibrate(second)
+
+    assert noise.build_Q(1.0 + 2.0e-2).tobytes() == second.tobytes()
+
+
 def test_sync_preserves_configured_q_at_unit_frame_step() -> None:
     """At frame_step=1.0, kf.process_noise must equal the configured Q exactly (backward-compat gate)."""
     kf = KalmanFilter(dim_x=2, dim_z=1)


### PR DESCRIPTION
`ScalableProcessNoise.build_Q` decides whether a predict step is one nominal frame by comparing a float for exact equality:

```python
# src/trackers/utils/motion_models.py
if frame_step == 1.0:
    return self.baseline_Q.copy()
self._ensure_calibrated()
return self._dwna(frame_step)
```

`frame_step` comes out of `BaseTracker._predict_timing` as `(t - t_prev) * frame_rate`, so a stream running at its nominal FPS ends up near `1.0` but almost never exactly on it. Measured over 4000 steps at 24/25/29.97/30/50/60 FPS: a float clock is off by up to 8e-13, `cv2.CAP_PROP_POS_MSEC` by up to 4.1e-2 at 60 FPS (it reports whole milliseconds), and `time.time()` by 1.4e-5. So on an ordinary steady video, passing timestamps makes almost every step take the gap path.

That path is not equivalent. `_dwna` rebuilds `Q` from the velocity diagonal alone and drops the configured position noise, so the position block collapses: 4x for SORT and ByteTrack, 256x for BoT-SORT and C-BIoU, and 400x (40000x on the scale channel) for OC-SORT. The filter becomes over-confident, the predicted box lags, and association starts to fail.

The docs say the opposite — `docs/learn/dynamic-frame-rate.md` says "If the video is actually steady 25 FPS and you pass timestamps every frame, `frame_step` stays `1.0` — dynamic mode lines up with fixed mode" — and its own example is `cap.get(cv2.CAP_PROP_POS_MSEC) / 1000.0`, which is the worst clock of the three.

## Measured

DanceTrack, 25 sequences, same path as `tests/core/test_tracker_integration.py`: detections derived from GT, `_MOTOutput`, `evaluate_mot_sequences`. The run without timestamps reproduces `tests/data/tracker_expected_dancetrack.json` to within 0.0004 HOTA, so the harness is the same one the accuracy gate uses. Each cell is the delta against that tracker's own fixed-rate run.

```
                 timestamp = i/fps      = POS_MSEC/1000        29.97 declared as 30
                 before    after        before    after        before    after
sort             -0.381    +0.000       -0.168    +0.550       -0.287    +0.187
bytetrack        -0.327    -0.054       -0.300    +0.515       -0.332    +0.124
botsort          -4.245    -0.084       -4.229    -0.137       -4.226    -0.084
ocsort           -4.589    -0.134       -4.860    -0.113       -4.652    -0.098
cbiou            -4.235    -0.221       -4.304    -0.221       -4.098    -0.230

worst of the 15 cells:  -4.860 HOTA -> -0.230 HOTA
worst extra ID switches:  +236 -> +5
```

## The fix

Treat a frame step within 10% of `1.0` as one nominal frame:

```python
if abs(frame_step - 1.0) <= _NOMINAL_FRAME_STEP_TOLERANCE:
    return self.baseline_Q.copy()
```

The band comes from the numbers above. On one side, the worst deterministic clock error I measured is 4.1e-2, and capture jitter of a couple of milliseconds reaches ~1e-1 at 30 FPS. On the other, the smallest gap a caller can express is `frame_step = 1.5`, a deviation of 5e-1. So 1e-1 is an order of magnitude above the clocks and well below any real gap — real gaps keep the DWNA rescaling exactly as it is today.

I also considered rescaling `Q` continuously through `Δt = 1`. That one fixes the clocks too, but it changes what happens on genuine gaps, and I measured it: up to 4.0 HOTA lost on SportsMOT at `frame_step = 4`. This patch leaves every gap byte-identical to `develop`, which for a fix seemed the correct trade-off.

## Tests

`tests/utils/test_motion_models.py` covers `build_Q` directly: the six real clock deviations return `baseline_Q` compared byte for byte (an `approx` check would also pass with the rebuilt matrix, which is exactly what the test needs to catch), gaps still take the DWNA path, alternating nominal and gap steps leave no stale cache, and a re-`calibrate` inside the band returns the new reference — BoT-SORT refreshes its scale-aware `Q` every frame, so that one matters.

`tests/core/test_timestamp_plumbing.py` adds the end-to-end check across the five core trackers: a steady stream at the reference FPS must run the tracker's configured `Q`. That test asserts `Q` and not the output boxes on purpose. `Q` never enters the predicted state (`x = F @ x`), it enters the covariance, so its effect on the boxes only shows up once detections compete for association in a crowded scene — asserting the matrix keeps it observable in a unit test.

14 of the new tests fail on `develop` and pass here. Full suite 1086 passed / 2 skipped, accuracy gate 10 passed with the goldens untouched, ruff clean.

## What this does not cover

Capture jitter wider than the band still takes the gap path. Also, lost-track pruning stays asymmetric between the two modes — `BaseTracker._prune_lost_tracks` runs before association in dynamic-rate mode while the fixed-rate frame budget is enforced after it, so the two modes can still differ by one `lost_track_buffer` frame. That is the residual difference in the table above, between -0.05 and -0.23 HOTA. It is a separate change and I left it out, but I'm happy to follow up with it if you want.

There is a sibling of this bug that I did not touch, because it is not a correctness issue: `KalmanMotionModel.apply` (`motion_models.py:282`) caches the transition matrix behind `frame_step != self.cached_step`, the same exact float comparison. It always returns a correct matrix, it just never gets a cache hit under a real clock, so the per-tracklet saving that #522 added is lost in timestamp mode. That one can go in a separate PR if you think it is worth it.

I updated `docs/learn/dynamic-frame-rate.md` so the equivalence claim matches what the code does now, including both of those limits — let me know what you think ..
