### PR TITLE
fix(mcbyte): advance the miss clocks from the predict timing

### DIFF
--- a/docs/learn/dynamic-frame-rate.md
+++ b/docs/learn/dynamic-frame-rate.md
@@ -1,6 +1,6 @@
 ---
 title: Dynamic Frame Rate — Variable-Gap Tracking | Trackers
-description: Track with irregular frame timing by passing timestamps to tracker.update(). Scale Kalman prediction and lost-track pruning to real wall-clock gaps on SORT, ByteTrack, OC-SORT, BoT-SORT, and C-BIoU.
+description: Track with irregular frame timing by passing timestamps to tracker.update(). Scale Kalman prediction and lost-track pruning to real wall-clock gaps on SORT, ByteTrack, OC-SORT, BoT-SORT, C-BIoU, and McByte.
 ---
 
 # Dynamic Frame Rate
@@ -39,7 +39,7 @@ Turn on timestamps when the **capture-time gap** between two `update()` calls is
 
 Stick with the default when you process **every** frame in order at a steady rate. A normal `VideoCapture` loop that reads all frames does not need timestamps.
 
-`SORTTracker`, `ByteTrackTracker`, `OCSORTTracker`, `BoTSORTTracker`, and `CBIoUTracker` all accept `timestamp` on `update()`.
+`SORTTracker`, `ByteTrackTracker`, `OCSORTTracker`, `BoTSORTTracker`, `CBIoUTracker`, and `McByteTracker` all accept `timestamp` on `update()`.
 
 ---
 
@@ -117,6 +117,8 @@ Call **`tracker.reset()`** when you switch videos so the last timestamp does not
 **`frame_rate` should match your reference timeline.** If the file is 24 FPS but you set `frame_rate=30`, each step over-predicts motion. Same parameter already mattered for threshold scaling in fixed mode; it matters more when gaps are measured in seconds.
 
 **OC-SORT:** ORU still steps in frame units, not wall-clock gaps.
+
+**McByte:** the optional mask pipeline (`enable_mask_manager=True`) still propagates one step per `update()` call; timestamps scale Kalman prediction and lost-track pruning, not mask propagation.
 
 ---
 

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------
 
 import logging
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -388,6 +389,7 @@ class McByteTracker(BaseTracker):
         # populated when the threshold exceeds 1.
         self._mask_pending_ages: dict[int, int] = {}
         self._consecutive_mask_failures: int = 0
+        self._warned_mask_manager_dynamic_rate = False
 
     def update(
         self,
@@ -455,6 +457,17 @@ class McByteTracker(BaseTracker):
             # output so masks stay in lockstep with the state used here.
             pass
         elif self.mask_manager is not None and current_frame is not None:
+            if timing.uses_elapsed_time and not self._warned_mask_manager_dynamic_rate:
+                warnings.warn(
+                    "enable_mask_manager=True with timestamp-based (dynamic-rate) "
+                    "updates: the mask pipeline advances one step per update() call "
+                    "regardless of elapsed time, while Kalman prediction and "
+                    "lost-track pruning scale by timestamp. Mask propagation can "
+                    "drift out of sync with track state across timestamp gaps.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                self._warned_mask_manager_dynamic_rate = True
             self._last_mask_output = self._run_mask_manager(self.mask_manager, current_frame)
         else:
             self._last_mask_output = None

--- a/src/trackers/core/mcbyte/tracklet.py
+++ b/src/trackers/core/mcbyte/tracklet.py
@@ -188,24 +188,24 @@ class McByteTracklet(BaseTracklet):
         self.state_estimator.update(bbox)
         self._clamp_state_bbox()
         self.time_since_update = 0
+        self.time_since_update_seconds = 0.0
         self.number_of_successful_updates += 1
 
     def predict(self, timing: PredictTiming = FIXED_RATE_TIMING) -> np.ndarray:
-        """Predict the next bounding-box position.
+        """Predict the next bounding-box position and advance the missed-frame clocks.
 
-        Increments ``time_since_update`` to track how many frames have
-        elapsed since the last matched measurement — this replaces the
-        ``update(None)`` call used in ByteTrack/SORT.
+        Advances ``time_since_update`` (and, in dynamic-rate mode,
+        ``time_since_update_seconds``) to track how long it has been since the
+        last matched measurement — this replaces the ``update(None)`` call used
+        in ByteTrack/SORT. Both clocks are advanced through
+        ``_advance_miss_clocks``, because ``time_since_update_seconds`` is the
+        counter ``within_lost_track_budget`` reads whenever a seconds budget is
+        in effect.
         """
-        # Accepted for compatibility with the current BaseTracklet interface.
-        # McByte currently does not distinguish prediction timing.
-        _ = timing
-
         self._refresh_noise_from_state()
-        self.state_estimator.predict()
+        self.state_estimator.predict(timing.frame_step)
         self._clamp_state_bbox()
-        self.age += 1
-        self.time_since_update += 1
+        self._advance_miss_clocks(timing)
         return self.state_estimator.state_to_bbox()
 
     def get_state_bbox(self) -> np.ndarray:

--- a/src/trackers/core/mcbyte/tracklet.py
+++ b/src/trackers/core/mcbyte/tracklet.py
@@ -203,7 +203,7 @@ class McByteTracklet(BaseTracklet):
         in effect.
         """
         self._refresh_noise_from_state()
-        self.state_estimator.predict(timing.frame_step)
+        self.state_estimator.predict(timing.frame_step, timing.frame_rate)
         self._clamp_state_bbox()
         self._advance_miss_clocks(timing)
         return self.state_estimator.state_to_bbox()

--- a/src/trackers/core/mcbyte/tracklet.py
+++ b/src/trackers/core/mcbyte/tracklet.py
@@ -201,6 +201,9 @@ class McByteTracklet(BaseTracklet):
         ``_advance_miss_clocks``, because ``time_since_update_seconds`` is the
         counter ``within_lost_track_budget`` reads whenever a seconds budget is
         in effect.
+
+        Returns:
+            Predicted bounding box ``[x1, y1, x2, y2]``.
         """
         self._refresh_noise_from_state()
         self.state_estimator.predict(timing.frame_step, timing.frame_rate)

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from types import ModuleType
 
 import numpy as np
@@ -183,6 +184,49 @@ def test_mcbyte_does_not_advance_masks_on_duplicate_timestamp() -> None:
 
     # No extra mask-backend step on the duplicate frame.
     assert len(mask_manager.calls) == 1
+
+
+def test_mcbyte_warns_once_for_mask_manager_with_dynamic_rate_timestamps() -> None:
+    """enable_mask_manager + dynamic-rate timestamps warns once, not on every call.
+
+    The mask backend advances one step per update() call regardless of
+    elapsed time, while Kalman prediction and pruning scale by timestamp —
+    a desync that grows with gap size. Disclosed in docs; this warning
+    surfaces it at runtime too.
+    """
+    mask_manager = SpyMaskManager()
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=False,
+        mask_manager=mask_manager,  # type: ignore[arg-type]
+        minimum_consecutive_frames=1,
+    )
+    frame = _make_frame()
+
+    with pytest.warns(UserWarning, match="dynamic-rate"):
+        tracker.update(_detection((100.0, 100.0, 200.0, 200.0)), frame, timestamp=0.0)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tracker.update(_detection((100.0, 100.0, 200.0, 200.0)), frame, timestamp=1.0 / 30.0)
+    assert not any("dynamic-rate" in str(w.message) for w in caught)
+
+
+def test_mcbyte_does_not_warn_for_mask_manager_without_timestamps() -> None:
+    """Fixed-rate calls (no timestamp) never trigger the dynamic-rate mask warning."""
+    mask_manager = SpyMaskManager()
+    tracker = McByteTracker(
+        enable_cmc=False,
+        enable_mask_manager=False,
+        mask_manager=mask_manager,  # type: ignore[arg-type]
+        minimum_consecutive_frames=1,
+    )
+    frame = _make_frame()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tracker.update(_detection((100.0, 100.0, 200.0, 200.0)), frame)
+    assert not any("dynamic-rate" in str(w.message) for w in caught)
 
 
 def test_mcbyte_rejects_high_conf_threshold_at_or_below_discard_floor() -> None:

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -754,3 +754,40 @@ def test_get_iou_matrix_raises_contextual_error_on_cache_miss() -> None:
 
     with pytest.raises(KeyError, match="decode-once box cache"):
         tracker._get_iou_matrix([tracklet], detections, {})
+
+
+def test_mcbyte_update_resets_the_seconds_clock() -> None:
+    """A re-match clears the seconds clock, so a second miss starts from zero."""
+    tracker = McByteTracker(enable_cmc=False)
+    box = (100.0, 100.0, 150.0, 200.0)
+    for i in range(6):
+        tracker.update(_detection(box), timestamp=i / 30.0)
+    for i in range(6, 12):
+        tracker.update(sv.Detections.empty(), timestamp=i / 30.0)
+    assert tracker.tracks[0].time_since_update_seconds > 0.0
+
+    tracker.update(_detection(box), timestamp=12 / 30.0)
+    assert tracker.tracks[0].time_since_update_seconds == 0.0
+
+    # Second occurrence: the clock has to advance again, not stay pinned.
+    tracker.update(sv.Detections.empty(), timestamp=13 / 30.0)
+    assert tracker.tracks[0].time_since_update_seconds > 0.0
+
+
+def test_mcbyte_tracklet_list_does_not_grow_without_bound_in_timestamp_mode() -> None:
+    """Objects that appear once and leave must not accumulate as live tracklets."""
+    tracker = McByteTracker(enable_cmc=False)
+    frame_index = 0
+    peak = 0
+    for k in range(12):
+        x = 40.0 + (k % 4) * 200.0
+        y = 40.0 + (k // 4) * 200.0
+        for _ in range(8):
+            tracker.update(_detection((x, y, x + 60.0, y + 80.0)), timestamp=frame_index / 30.0)
+            frame_index += 1
+        for _ in range(4):
+            tracker.update(sv.Detections.empty(), timestamp=frame_index / 30.0)
+            frame_index += 1
+        peak = max(peak, len(tracker.tracks))
+
+    assert peak <= 4, f"tracklet list grew to {peak} for 12 objects seen one at a time"

--- a/tests/core/test_timestamp_plumbing.py
+++ b/tests/core/test_timestamp_plumbing.py
@@ -31,6 +31,7 @@ from trackers.core.ocsort.tracklet import OCSORTTracklet
 from trackers.core.sort.tracker import SORTTracker
 from trackers.core.sort.tracklet import SORTTracklet
 from trackers.utils.base_tracklet import BaseTracklet
+from trackers.utils.predict_timing import PredictTiming
 from trackers.utils.state_representations import XCYCSRStateEstimator
 
 TIMESTAMP_AWARE_TRACKERS: list[Any] = [
@@ -550,6 +551,32 @@ def test_same_process_noise_at_reference_fps(
     dynamic = _process_noise_after_a_few_frames(tracker_cls, tracklet_cls, extra_kwargs, clock=clock)
 
     np.testing.assert_array_equal(dynamic, fixed)
+
+
+def test_mcbyte_predict_forwards_frame_rate_for_mid_band_gap() -> None:
+    """McByte's ``predict()`` must forward ``frame_rate`` for a mid-band gap.
+
+    ``frame_step=1.15`` sits outside the fixed 0.1 frame-unit fallback
+    tolerance but inside the fps-scaled ``0.004 * frame_rate`` band at 60 FPS
+    (0.24) — the exact divergence zone a dropped ``frame_rate`` falls out of.
+
+    Asserted directly on the tracklet, not through ``McByteTracker.update()``:
+    McByte's ``update()`` unconditionally recalibrates ``Q`` from the current
+    bbox scale via ``_refresh_noise_from_state``, which overwrites whatever
+    ``predict()`` computed before the next frame — the only place this
+    regression is observable is the tracklet's state right after ``predict()``.
+    """
+    box = np.array([100.0, 100.0, 150.0, 200.0], dtype=np.float32)
+    nominal = McByteTracklet(initial_bbox=box)
+    nominal.predict(PredictTiming(frame_step=1.0, elapsed_seconds=1.0 / 60.0, frame_rate=60.0))
+
+    gapped = McByteTracklet(initial_bbox=box)
+    gapped.predict(PredictTiming(frame_step=1.15, elapsed_seconds=1.15 / 60.0, frame_rate=60.0))
+
+    np.testing.assert_array_equal(
+        np.asarray(gapped.state_estimator.kf.process_noise, dtype=np.float64),
+        np.asarray(nominal.state_estimator.kf.process_noise, dtype=np.float64),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_timestamp_plumbing.py
+++ b/tests/core/test_timestamp_plumbing.py
@@ -24,6 +24,8 @@ from trackers.core.botsort.tracklet import BoTSORTTracklet
 from trackers.core.bytetrack.tracker import ByteTrackTracker
 from trackers.core.bytetrack.tracklet import ByteTrackTracklet
 from trackers.core.cbiou.tracker import CBIoUTracker
+from trackers.core.mcbyte.tracker import McByteTracker
+from trackers.core.mcbyte.tracklet import McByteTracklet
 from trackers.core.ocsort.tracker import OCSORTTracker
 from trackers.core.ocsort.tracklet import OCSORTTracklet
 from trackers.core.sort.tracker import SORTTracker
@@ -57,6 +59,12 @@ TIMESTAMP_AWARE_TRACKERS: list[Any] = [
         {"track_activation_threshold": 0.5},
         id="cbiou",
     ),
+    pytest.param(
+        McByteTracker,
+        McByteTracklet,
+        {"enable_cmc": False, "track_activation_threshold": 0.5},
+        id="mcbyte",
+    ),
 ]
 
 PREDICT_TIMING_TRACKER: list[Any] = [
@@ -76,6 +84,12 @@ FRAME_BUDGET_TRACKERS: list[Any] = [
         BoTSORTTracklet,
         {"track_activation_threshold": 0.5},
         id="cbiou",
+    ),
+    pytest.param(
+        McByteTracker,
+        McByteTracklet,
+        {"enable_cmc": False, "track_activation_threshold": 0.5},
+        id="mcbyte",
     ),
 ]
 
@@ -500,6 +514,11 @@ def test_same_confirmation_pattern_at_reference_fps(
             CBIoUTracker,
             {"state_estimator_class": XCYCSRStateEstimator},
             id="cbiou-xcycsr",
+        ),
+        pytest.param(
+            McByteTracker,
+            {"state_estimator_class": XCYCSRStateEstimator, "enable_cmc": False},
+            id="mcbyte-xcycsr",
         ),
     ],
 )


### PR DESCRIPTION
`McByteTracklet.predict` takes a `PredictTiming` and ignores it:

```python
# src/trackers/core/mcbyte/tracklet.py
# Accepted for compatibility with the current BaseTracklet interface.
# McByte currently does not distinguish prediction timing.
_ = timing

self._refresh_noise_from_state()
self.state_estimator.predict()
self._clamp_state_bbox()
self.age += 1
self.time_since_update += 1
```

It is the only tracklet of the five that does not call `BaseTracklet._advance_miss_clocks`, and that method is the only place where `time_since_update_seconds` is incremented (`base_tracklet.py:53`). The other four tracklets all call it: `sort/tracklet.py:52`, `bytetrack/tracklet.py:56`, `botsort/tracklet.py:204`, `ocsort/tracklet.py:269`.

That counter is what the budget reads. `within_lost_track_budget` (`base_tracklet.py:83-85`) uses the seconds counter whenever a seconds budget exists, and ignores the frame count:

```python
if maximum_time_without_update is not None:
    return tracklet.time_since_update_seconds <= maximum_time_without_update
return tracklet.time_since_update <= maximum_frames_without_update
```

A seconds budget only exists in dynamic-rate mode — `mcbyte/tracker.py:480` builds it and `:656` passes it to `_get_alive_tracklets`. So with a timestamp the check is always `0.0 <= budget`, and **no confirmed McByte track ever expires**. `update()` also never cleared the seconds counter, unlike the other four (`botsort:191`, `bytetrack:37`, `ocsort:234`, `sort:37`).

## Measured

Defaults everywhere, `lost_track_buffer=30`, so dynamic mode allows 1.0 s. One object visible for 6 frames, then 300 empty frames, that is ten times the budget:

```
tracker      no timestamp   with timestamp   time_since_update_seconds
sort                    0                0
bytetrack               0                0
botsort                 0                0
ocsort                  0                0
mcbyte                  0                1                      0.0000
```

The unbounded growth comes from the same cause. 40 objects, each one visible 8 frames in its own part of the frame and then it never comes back:

```
tracker      after 5 objs   after 15   after 40   peak   after a further 10 s
sort                    3          3          3      3                     0
bytetrack               3          3          3      3                     0
botsort                 3          3          3      3                     0
ocsort                  3          3          3      3                     0
mcbyte                  5         15         40     40                    40
```

Every object that ever appeared stays in `self.tracks` for the rest of the run, so both the memory and the per-frame association cost grow with the length of the video. With this patch McByte peaks at 3 and ends at 0, same as the others.

## The fix

`predict` now goes through `_advance_miss_clocks(timing)` like the other tracklets, and forwards `frame_step` to the state estimator; `update` clears the seconds counter.

Both are no-ops without timestamps. `FIXED_RATE_TIMING.frame_step` is `1.0`, which is already the default of `BaseStateEstimator.predict`, and in fixed-rate mode `_advance_miss_clocks` zeroes the seconds counter instead of accumulating. I did not want to assume this, so I checked it: running McByte over 6 DanceTrack sequences with no timestamps gives byte-identical output before and after, 41415 rows.

## Tests

McByte is added to the parametrized timestamp contracts in `tests/core/test_timestamp_plumbing.py` — `TIMESTAMP_AWARE_TRACKERS`, `FRAME_BUDGET_TRACKERS`, and the XCYCSR shrinking-box NaN case — so the same lifecycle every other tracker passes now runs against it: 10 new parametrized cases. Two of them fail on `develop` and pass here: `test_timestamp_mode_accumulates_elapsed_seconds_on_miss[mcbyte]` and `test_time_pruning_removes_track_past_budget[mcbyte]`. McByte already passes the other eight.

Two McByte-specific tests in `tests/core/test_mcbyte_tracker.py` cover what the shared file does not: the seconds clock advancing again on a *second* miss after a re-match, and the tracklet list not growing without bound for objects seen once. Both also fail on `develop`.

`docs/learn/dynamic-frame-rate.md` now lists `McByteTracker` among the trackers that accept `timestamp` — it was the only one missing on that page, and with the old behaviour the omission was correct. The page also gets a caveat line next to the OC-SORT one: the optional mask pipeline still propagates one step per `update()` call, timestamps scale Kalman prediction and lost-track pruning only (`_run_mask_manager` receives the frame, not the timing).

Full suite green with the 12 new tests (and only those 4 flip from red on `develop`), accuracy gate 10 passed with the goldens untouched, ruff and mypy clean on the touched files.

## What this does not cover

McByte is not in `ALL_TRACKER_IDS`, so it has no golden accuracy numbers and the integration gate does not exercise it. The evidence above is what I could measure without one. Forwarding `frame_step` does change the extrapolation on a real gap in timestamp mode — the same behaviour the other four already have — but no golden covers it, so that is the part I would review with more care .. The mask-manager path (`enable_mask_manager=True`) is not exercised with timestamps by any test either; the default is off and nothing here touches it, and that is what the new docs caveat says.

This is independent of #531: both touch `docs/learn/dynamic-frame-rate.md` and `tests/core/test_timestamp_plumbing.py`, but in disjoint hunks, so they merge cleanly in either order.
