### PR TITLE
releasing `2.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [2.6.0] — 2026-07-08
+## [2.6.0] — 2026-08-03
 
 ### 🚀 Added
 
-- **Optional `timestamp=` on `BaseTracker.update()`** — all five trackers convert elapsed wall-clock seconds into Kalman frame units and prune lost tracks on a seconds budget when timestamps are supplied; omitting `timestamp` preserves fixed-rate behaviour ([#446](https://github.com/roboflow/trackers/pull/446)).
+- **`McByteTracker`** — new mask-conditioned ByteTrack tracker combining mask-conditioned association with SAM box-mask generation and Cutie mask propagation; exported from `trackers` (`McByteMaskConfig` also exported) and CLI-discoverable. New `trackers[mask]` extra installs `torch`, `torchvision`, `rf-segment-anything`, and `rf-cutie[inference]` (`rf-cutie` now ships on PyPI instead of git). Device selection defaults to `"auto"` (CUDA → MPS → CPU); Cutie streaming behaviour is tunable via `cutie_max_internal_size` (480), `cutie_mem_every` (10), and `cutie_use_long_term` (`True`), with `cutie_channels_last` / `cutie_compile` and AMP left off by default; `minimum_mask_creation_frames` (3) defers SAM/Cutie encoding for short-lived tracklets. Frames are expected in **RGB** (`BaseTracker`'s other trackers expect BGR). Mask checkpoints load with `weights_only=True` (CWE-502 guard, never shipped unsafe) ([#388](https://github.com/roboflow/trackers/pull/388), [#418](https://github.com/roboflow/trackers/pull/418), [#441](https://github.com/roboflow/trackers/pull/441), [#452](https://github.com/roboflow/trackers/pull/452), [#459](https://github.com/roboflow/trackers/pull/459), [#481](https://github.com/roboflow/trackers/pull/481), [#491](https://github.com/roboflow/trackers/pull/491), [#508](https://github.com/roboflow/trackers/pull/508), [#513](https://github.com/roboflow/trackers/pull/513), [#519](https://github.com/roboflow/trackers/pull/519), [#520](https://github.com/roboflow/trackers/pull/520), [#521](https://github.com/roboflow/trackers/pull/521), [#522](https://github.com/roboflow/trackers/pull/522), [#523](https://github.com/roboflow/trackers/pull/523), [#524](https://github.com/roboflow/trackers/pull/524), [#525](https://github.com/roboflow/trackers/pull/525), [#526](https://github.com/roboflow/trackers/pull/526), [#529](https://github.com/roboflow/trackers/pull/529), [#532](https://github.com/roboflow/trackers/pull/532)).
+- **Optional `timestamp=` on `BaseTracker.update()`** — all six trackers convert elapsed wall-clock seconds into Kalman frame units and prune lost tracks on a seconds budget when timestamps are supplied; omitting `timestamp` preserves fixed-rate behaviour ([#446](https://github.com/roboflow/trackers/pull/446)).
 - **`KalmanMotionModel`** in `trackers.utils.motion_models` — supplies the Kalman `F` and `Q` for a given `frame_step`; `F` is a trivial constant-velocity matrix (`constant_velocity_F`) while `ScalableProcessNoise` holds the tuned `Q`, used at the nominal step and DWNA-scaled on timestamp gaps.
 
 ### ⚠️ Breaking Changes
 
-- **Invalid lost-track buffer settings now raise `ValueError`** — `lost_track_buffer` must be non-negative and `frame_rate` must be finite and positive for `SORTTracker`, `ByteTrackTracker`, `OCSORTTracker`, and `BoTSORTTracker`. Explicit `lost_track_buffer=0` remains valid and means no missed-frame grace period; negative buffers and invalid frame rates previously initialized but produced nonsensical lifecycle behavior ([#420](https://github.com/roboflow/trackers/pull/420)).
+- **Invalid lost-track buffer settings now raise `ValueError`** — `lost_track_buffer` must be non-negative and `frame_rate` must be finite and positive for `SORTTracker`, `ByteTrackTracker`, `OCSORTTracker`, `BoTSORTTracker`, and `CBIoUTracker` (which forwards its constructor args to `BoTSORTTracker`). Explicit `lost_track_buffer=0` remains valid and means no missed-frame grace period; negative buffers and invalid frame rates previously initialized but produced nonsensical lifecycle behavior ([#420](https://github.com/roboflow/trackers/pull/420)).
 - **Confirmed tracks now survive one additional missed frame** — all trackers changed from exclusive (`time_since_update < maximum_frames_without_update`) to inclusive (`<=`) boundary semantics to match OC-SORT's previous behavior. Users comparing metric results across this version should expect small IDSW/HOTA shifts ([#420](https://github.com/roboflow/trackers/pull/420)).
+
+### 🌱 Changed
+
+- **Improved tracker performance** (bit-identical output) — CMC's sparse optical-flow status-mask filtering vectorized (~24x faster for that operation); `KalmanMotionModel` now caches its transition/noise matrices and defers DWNA calibration (~38% lower BoT-SORT/CBIoU predict cost); predicted boxes cached across association stages in BoT-SORT/CBIoU; Kalman-state-estimator copies trimmed and OC-SORT association hygiene improved ([#522](https://github.com/roboflow/trackers/pull/522), [#527](https://github.com/roboflow/trackers/pull/527), [#528](https://github.com/roboflow/trackers/pull/528)).
+- Direct dependency constraint `pydeprecate>=0.7.0` raised to `>=0.8.0`; build backend migrated from `hatchling` to `setuptools` (`src`-layout discovery + `py.typed` support) ([#492](https://github.com/roboflow/trackers/pull/492)).
 
 ### 🔧 Fixed
 
 - **Positive low-FPS lost-track buffers no longer collapse to zero frames** — all trackers now scale positive `lost_track_buffer` values with `ceil(...)` and keep confirmed tracks alive through exactly the scaled number of missed frames, matching OC-SORT's previous inclusive boundary semantics ([#420](https://github.com/roboflow/trackers/pull/420)).
+- **BoT-SORT / CBIoU: instant-activated first-frame tracks no longer dropped on a single miss** — sticky maturity now triggers once a real `tracker_id` is assigned (`tracker_id != -1`), matching ByteTrack; fixes a default-config ID switch when a frame-1 object is missed once ([#478](https://github.com/roboflow/trackers/pull/478) BoT-SORT, [#504](https://github.com/roboflow/trackers/pull/504) CBIoU).
+- **ByteTrack / BoT-SORT / CBIoU now return unmatched detections between the two confidence thresholds** — detections below `track_activation_threshold` but above `high_conf_det_threshold` are now emitted with `tracker_id=-1` instead of silently dropped, matching the documented `update()` contract. Output-contract change: callers may now see additional `tracker_id == -1` rows ([#475](https://github.com/roboflow/trackers/pull/475)).
+- **Signed IoU variants clamped to `[0, 1]` before score fusion** — the CIoU floor (~-1.5 from the aspect penalty) no longer produces negative fused similarities; the clamp is a no-op for GIoU/DIoU ([#476](https://github.com/roboflow/trackers/pull/476)).
+- **OC-SORT: Kalman scale kept positive across frame-step gaps** — `clamp_velocity` no longer allows scale to collapse negative over long timestamp gaps ([#509](https://github.com/roboflow/trackers/pull/509)).
+- **CMC: handle mid-stream frame-resolution changes in optical-flow motion estimation** — adds a re-sync/resize path when the input resolution changes between frames ([#505](https://github.com/roboflow/trackers/pull/505)).
+- **CMC: fixed `cv2.resize` crash on tiny downscaled images** — dimensions are now clamped to `max(1, ...)`, covering 1x1, 1x3, and 3x1 edge cases ([#488](https://github.com/roboflow/trackers/pull/488)).
+- **`xcycsr_to_xyxy`: prevent zero-division on zero-aspect boxes** — an `r1 != 0` guard now yields height `0` instead of `inf` ([#485](https://github.com/roboflow/trackers/pull/485)).
+- **Video output resized on mid-stream resolution change** — `VideoOutput` now resizes frames to match the writer's configured size (`INTER_AREA` on downscale only) ([#514](https://github.com/roboflow/trackers/pull/514)).
+- **Package builds fixed for `src` layout** — corrected `setuptools` package discovery and typed-package (`py.typed`) support, plus release CI artifact handling and publish triggers ([#492](https://github.com/roboflow/trackers/pull/492)).
+
+### 🔒 Security
+
+- **Hardened ZIP extraction against Zip Slip / path traversal (CWE-22)** — archive members with absolute paths, traversal segments, empty names, or Windows-style backslash paths are now rejected; validated archives are contained so they cannot write outside the destination directory, including path-swap protection ([#495](https://github.com/roboflow/trackers/pull/495)).
 
 ## [2.5.0] — 2026-06-22
 


### PR DESCRIPTION
# v2.6.0: McByte and dynamic frame rate

## 📋 Summary

trackers v2.6.0 adds `McByteTracker`, a new mask-conditioned tracker that extends BoT-SORT-style
association with SAM/Cutie temporal segmentation masks as an extra matching cue. It also adds
dynamic frame rate support (`timestamp=` on `update()`) for all six trackers, tightens
track-lifecycle validation with two breaking changes, fixes nine correctness bugs, and hardens ZIP
extraction against path traversal (CWE-22).

## ✨ Spotlights / highlights

### McByteTracker

```python
from trackers import McByteTracker

tracker = McByteTracker()
```

Mask-conditioned association via SAM (box→mask) + Cutie (temporal mask propagation), opt-in via
`pip install trackers[mask]`. Default `enable_mask_manager=False` runs ByteTrack-parity with no
extra weights required.

### Dynamic frame rate via `timestamp=`

```python
tracker.update(detections, frame, timestamp=frame_wallclock_seconds)
```

Elapsed wall-clock seconds convert into Kalman frame units; omitting `timestamp` preserves the
existing fixed-rate behavior.

### Breaking: stricter lifecycle validation

```python
# Before: silently accepted
tracker = SORTTracker(lost_track_buffer=-1)

# After: raises ValueError
tracker = SORTTracker(lost_track_buffer=-1)
# ValueError: lost_track_buffer must be greater than or equal to 0
```

### Tracker performance improvements

CMC's sparse optical-flow status filter is now vectorized (~24x on that op); `KalmanMotionModel`
caches transition/noise matrices and defers DWNA calibration (~38% lower BoT-SORT/CBIoU predict
cost).

### Security: hardened ZIP extraction

Dataset-download ZIP extraction rejects archive members with absolute paths, traversal segments,
or Windows backslash paths (Zip Slip / CWE-22).

## 🔄 Migration guide

### Breaking changes

#### `lost_track_buffer` / `frame_rate` now validated

`SORTTracker`, `ByteTrackTracker`, `OCSORTTracker`, `BoTSORTTracker`, and `CBIoUTracker` (which
forwards its constructor args to `BoTSORTTracker`) now raise `ValueError` at construction if
`lost_track_buffer` is negative or `frame_rate` is not finite and positive.

```python
# Before (v2.5.0) — silently accepted
tracker = SORTTracker(lost_track_buffer=-1)

# After (v2.6.0) — raises immediately
tracker = SORTTracker(lost_track_buffer=-1)
# ValueError: lost_track_buffer must be greater than or equal to 0
```

`lost_track_buffer=0` remains valid (no missed-frame grace period).

#### Missed-frame boundary is now inclusive

Confirmed tracks now survive one additional missed frame — comparison changed from
`time_since_update < maximum_frames_without_update` to `time_since_update <= maximum_frames_without_update` (the frame-rate-scaled form of `lost_track_buffer`), matching
OC-SORT's prior behavior. Expect small IDSW/HOTA shifts when comparing metrics across versions.

### Behavior changes (non-breaking)

#### Unmatched sub-activation-threshold detections are now emitted

`ByteTrackTracker`, `BoTSORTTracker`, and `CBIoUTracker.update()` now return detections between
the two confidence thresholds (below `track_activation_threshold` but above
`high_conf_det_threshold`) with `tracker_id=-1` instead of dropping them.

```python
result = tracker.update(detections)
matched = result[result.tracker_id != -1]
```

## 📝 Notable changes

### 🚀 Added

- **`McByteTracker`** — mask-conditioned tracker combining SAM box-mask generation and Cutie mask
    propagation with BoT-SORT-style association; exported from `trackers` along with
    `McByteMaskConfig`. New `trackers[mask]` extra (`torch`, `torchvision`, `rf-segment-anything`,
    `rf-cutie[inference]`; `rf-cutie` now ships on PyPI instead of git). Device selection defaults to
    `"auto"` (CUDA → MPS → CPU). Frames are expected in **RGB** (other trackers expect BGR).
    (#388, #418, #441, #452, #459, #481, #491, #508, #513, #519–#526, #529, #532)
- **Optional `timestamp=` on `BaseTracker.update()`** — all six trackers convert elapsed
    wall-clock seconds into Kalman frame units and prune lost tracks on a seconds budget. (#446)
- **`KalmanMotionModel`** in `trackers.utils.motion_models` — supplies Kalman `F`/`Q` for a given
    `frame_step`.

### ⚠️ Breaking Changes

- **Invalid lost-track buffer settings now raise `ValueError`** — `lost_track_buffer` must be
    non-negative and `frame_rate` finite and positive across all five classic trackers (SORT,
    ByteTrack, OC-SORT, BoT-SORT, CBIoU). (#420)
- **Confirmed tracks now survive one additional missed frame** — boundary changed from exclusive
    to inclusive to match OC-SORT. (#420)

### 🌱 Changed

- **Improved tracker performance** (bit-identical output) — CMC status-filter vectorized (~24x),
    `KalmanMotionModel` caches matrices (~38% lower BoT-SORT/CBIoU predict cost), predicted boxes
    cached across association stages, KF-copy trimming. (#522, #527, #528)
- Build backend migrated `hatchling` → `setuptools` (`src`-layout + `py.typed`); direct dependency
    constraint `pydeprecate>=0.7.0` raised to `>=0.8.0`. (#492)

### 🔧 Fixed

- Positive low-FPS lost-track buffers no longer collapse to zero frames. (#420)
- BoT-SORT/CBIoU: instant-activated first-frame tracks no longer dropped on a single miss.
    (#478, #504)
- ByteTrack/BoT-SORT/CBIoU now return unmatched detections between the two confidence thresholds
    instead of silently dropping them. (#475)
- Signed IoU variants (CIoU/DIoU/GIoU) clamped to `[0, 1]` before score fusion. (#476)
- OC-SORT: Kalman scale kept positive across frame-step gaps. (#509)
- CMC: handle mid-stream frame-resolution changes in optical-flow motion estimation. (#505)
- CMC: fixed `cv2.resize` crash on tiny downscaled images. (#488)
- `xcycsr_to_xyxy`: prevent zero-division on zero-aspect boxes. (#485)
- Video output resized on mid-stream resolution change. (#514)
- Package builds fixed for `src` layout. (#492)

### 🔒 Security

- Hardened ZIP extraction against Zip Slip / path traversal (CWE-22). (#495)

---

## 🏆 Contributors

- **Agis Kounelis** (@kounelisagis) — ByteTrack fix: return unmatched detections between the two
    confidence thresholds instead of dropping them.
- **Alexander Bodner** (@AlexBodner) — dynamic frame-rate integration.
- **Christoph Deil** (@cdeil) — unified lost-track buffer semantics across all trackers.
- **Jesús Royeth** (@JESUSROYETH) — McByte miss-clock timing, video output resize fix, OC-SORT
    Kalman scale fix.
- **Jirka Borovec** (@Borda) — McByte MPS device support + Cutie streaming config, mask-pipeline
    public API export, package build/publish fix.
- **Ruben** (@RubenHaisma) — BoT-SORT instant-activated track fix, IoU signed-variant fusion clamp.
- **S B Pranay** (@pranaysb) — CMC resize-crash fix, `xcycsr_to_xyxy` zero-division fix.
- **Tomasz Stańczyk** (@tstanczyk95, [LinkedIn](https://www.linkedin.com/in/tomasz-stanczyk/)) —
    McByte tracker end-to-end: skeleton, dynamic Cutie mask lifecycle management, mask-conditioned
    association.

---

https://github.com/user-attachments/assets/ff04f0f2-fff1-4c38-8754-05a55c6b1e56

https://github.com/user-attachments/assets/e2683415-f4b7-4862-8e60-8cd2431d19dd

https://github.com/user-attachments/assets/5bc6c821-bfff-464e-aa5c-cde6b562ce2a

---

**Full changelog**: https://github.com/roboflow/trackers/compare/2.5.0...2.6.0
