### PR TITLE
chore(pre-commit): add `--wrap=no` to `mdformat` args in config

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,129 +2,81 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socioeconomic status,
-nationality, personal appearance, race, caste, color, religion, or sexual
-identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+Examples of behavior that contributes to a positive environment for our community include:
 
 - Demonstrating empathy and kindness toward other people
 - Being respectful of differing opinions, viewpoints, and experiences
 - Giving and gracefully accepting constructive feedback
-- Accepting responsibility and apologizing to those affected by our mistakes,
-    and learning from the experience
-- Focusing on what is best not just for us as individuals, but for the overall
-    community
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery, and sexual attention or advances of
-    any kind
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or email address,
-    without their explicit permission
-- Other conduct which could reasonably be considered inappropriate in a
-    professional setting
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-community-reports@roboflow.com.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at community-reports@roboflow.com.
 
 All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series of
-actions.
+**Community Impact**: A violation through a single incident or series of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or permanent
-ban.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior, harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within the
-community.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][mozilla coc].
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla coc].
 
-For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][faq]. Translations are available at
-[https://www.contributor-covenant.org/translations][translations].
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][faq]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
 
 [faq]: https://www.contributor-covenant.org/faq
 [homepage]: https://www.contributor-covenant.org

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,6 @@
 # GitHub Copilot Instructions — Roboflow Trackers
 
-Roboflow Trackers is a Python library for multi-object tracking (MOT). It provides clean-room
-implementations of SORT, ByteTrack, and OC-SORT that plug into any detection model via the
-`supervision` library.
+Roboflow Trackers is a Python library for multi-object tracking (MOT). It provides clean-room implementations of SORT, ByteTrack, and OC-SORT that plug into any detection model via the `supervision` library.
 
 ## Installation
 
@@ -59,8 +57,7 @@ trackers/
 
 ## Detection Format
 
-Input: `supervision.Detections` with `.xyxy` bounding boxes.
-Output: same `supervision.Detections` with `.tracker_id` populated.
+Input: `supervision.Detections` with `.xyxy` bounding boxes. Output: same `supervision.Detections` with `.tracker_id` populated.
 
 Internal state uses `xcycsr` (center-x, center-y, area, aspect ratio) for Kalman filter.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,7 +57,8 @@ trackers/
 
 ## Detection Format
 
-Input: `supervision.Detections` with `.xyxy` bounding boxes. Output: same `supervision.Detections` with `.tracker_id` populated.
+- Input: `supervision.Detections` with `.xyxy` bounding boxes.
+- Output: same `supervision.Detections` with `.tracker_id` populated.
 
 Internal state uses `xcycsr` (center-x, center-y, area, aspect ratio) for Kalman filter.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         additional_dependencies:
           - "mdformat-mkdocs[recommended]>=2.1.0"
           - "mdformat-ruff"
-        args: ["--number"]
+        args: ["--number", "--wrap=no"]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3

--- a/README.md
+++ b/README.md
@@ -3,12 +3,7 @@
     <h1>trackers</h1>
     <p>Plug-and-play multi-object tracking for any detection model.</p>
 
-[![version](https://badge.fury.io/py/trackers.svg)](https://badge.fury.io/py/trackers)
-[![downloads](https://img.shields.io/pypi/dm/trackers)](https://pypistats.org/packages/trackers)
-[![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/trackers/blob/release/stable/LICENSE.md)
-[![python-version](https://img.shields.io/pypi/pyversions/trackers)](https://badge.fury.io/py/trackers)
-[![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-track-objects-with-bytetrack-tracker.ipynb)
-[![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
+[![version](https://badge.fury.io/py/trackers.svg)](https://badge.fury.io/py/trackers) [![downloads](https://img.shields.io/pypi/dm/trackers)](https://pypistats.org/packages/trackers) [![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/trackers/blob/release/stable/LICENSE.md) [![python-version](https://img.shields.io/pypi/pyversions/trackers)](https://badge.fury.io/py/trackers) [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-track-objects-with-bytetrack-tracker.ipynb) [![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -201,33 +201,20 @@ Try trackers in your browser with our [Hugging Face Playground](https://huggingf
 
 **What is multi-object tracking and how does it differ from object detection?**
 
-Object detection finds and classifies objects in a single image frame. Multi-object tracking
-assigns a persistent ID to each detected object across video frames, maintaining continuity
-through occlusions, re-entries, and camera motion. Trackers use a detect-then-track approach:
-a detector runs on each frame, and the tracker links detections across time using motion
-models and spatial matching.
+Object detection finds and classifies objects in a single image frame. Multi-object tracking assigns a persistent ID to each detected object across video frames, maintaining continuity through occlusions, re-entries, and camera motion. Trackers use a detect-then-track approach: a detector runs on each frame, and the tracker links detections across time using motion models and spatial matching.
 
 **Which tracker should I use?**
 
-Start with ByteTrack — out of the box, it performs best across two out of four benchmarks in our evaluation and
-handles variable-confidence detectors well, while providing real time latency. Use SORT if speed or device constraints require the lightest possible tracker. Use OC-SORT when camera motion is significant or objects follow
-non-linear paths. See the [tracker comparison](trackers/comparison.md) for benchmark scores.
+Start with ByteTrack — out of the box, it performs best across two out of four benchmarks in our evaluation and handles variable-confidence detectors well, while providing real time latency. Use SORT if speed or device constraints require the lightest possible tracker. Use OC-SORT when camera motion is significant or objects follow non-linear paths. See the [tracker comparison](trackers/comparison.md) for benchmark scores.
 
 **Do I need a specific detector?**
 
-No. Roboflow Trackers works with any detector that outputs `supervision.Detections` objects.
-The library ships example pipelines using RF-DETR but is compatible with YOLO, Detectron2,
-and any custom model. The tracker never inspects the detection model directly.
+No. Roboflow Trackers works with any detector that outputs `supervision.Detections` objects. The library ships example pipelines using RF-DETR but is compatible with YOLO, Detectron2, and any custom model. The tracker never inspects the detection model directly.
 
 **What MOT datasets does the library support?**
 
-MOT17 and SportsMOT are supported for download and evaluation. Use
-`trackers download <dataset>` to pull frames, annotations, and pre-computed
-detections in one command. DanceTrack and SoccerNet-tracking support is coming soon.
-See the [download guide](learn/download.md) for asset options.
+MOT17 and SportsMOT are supported for download and evaluation. Use `trackers download <dataset>` to pull frames, annotations, and pre-computed detections in one command. DanceTrack and SoccerNet-tracking support is coming soon. See the [download guide](learn/download.md) for asset options.
 
 **How do I evaluate my tracker?**
 
-Run `trackers eval` against a directory of ground-truth MOT-format text files. The evaluation
-pipeline computes HOTA, IDF1, and MOTA and prints a per-sequence and combined score table.
-See the [evaluation guide](learn/evaluate.md) for the full workflow.
+Run `trackers eval` against a directory of ground-truth MOT-format text files. The evaluation pipeline computes HOTA, IDF1, and MOTA and prints a per-sequence and combined score table. See the [evaluation guide](learn/evaluate.md) for the full workflow.

--- a/docs/learn/cli-migration.md
+++ b/docs/learn/cli-migration.md
@@ -5,20 +5,13 @@ description: Migrate Trackers CLI commands from the legacy argparse interface to
 
 # CLI Migration Guide
 
-The CLI now groups `track` options by responsibility. The new dotted arguments
-map directly to the option dataclasses used by `track`, and are also available
-in YAML configuration files.
+The CLI now groups `track` options by responsibility. The new dotted arguments map directly to the option dataclasses used by `track`, and are also available in YAML configuration files.
 
-Semantic legacy spellings remain available during the transition. Each use
-emits a `FutureWarning` with the replacement. Do not combine a legacy argument
-and its replacement in one command; the CLI rejects that ambiguity. Develop's
-`--no-boxes` and `--no-ids` still work and map to `--show.no_boxes` and
-`--show.no_ids`. Each warning names the release that removes it: 2.10.0.
+Semantic legacy spellings remain available during the transition. Each use emits a `FutureWarning` with the replacement. Do not combine a legacy argument and its replacement in one command; the CLI rejects that ambiguity. Develop's `--no-boxes` and `--no-ids` still work and map to `--show.no_boxes` and `--show.no_ids`. Each warning names the release that removes it: 2.10.0.
 
 ## Track command
 
-Use dotted paths for grouped detection, filtering, output, visualization, and
-tracker options. `--display` remains ungrouped.
+Use dotted paths for grouped detection, filtering, output, visualization, and tracker options. `--display` remains ungrouped.
 
 ```text
 trackers track \
@@ -32,28 +25,13 @@ trackers track \
     --show.no_boxes
 ```
 
-Every boolean option is a pair: `--show.boxes` turns it on, `--show.no_boxes`
-turns it off, and `--show.boxes false` or `--show.boxes=false` spell the same
-thing explicitly. The negation sits on the field rather than the group, so it
-stays readable for any group name — `--detection.no_fast`, never
-`--no_detection.fast`. Repeating both halves is allowed; the last one wins. A
-`--config` file keeps one plain boolean key per field, and a command-line flag
-always overrides it.
+Every boolean option is a pair: `--show.boxes` turns it on, `--show.no_boxes` turns it off, and `--show.boxes false` or `--show.boxes=false` spell the same thing explicitly. The negation sits on the field rather than the group, so it stays readable for any group name — `--detection.no_fast`, never `--no_detection.fast`. Repeating both halves is allowed; the last one wins. A `--config` file keeps one plain boolean key per field, and a command-line flag always overrides it.
 
-This covers ungrouped options too — `--display` / `--no_display`,
-`--no_enqueue_defaults` on `tune`, `--no_list_available` on `download`.
+This covers ungrouped options too — `--display` / `--no_display`, `--no_enqueue_defaults` on `tune`, `--no_list_available` on `download`.
 
-The algorithm and its parameters share one group, mirroring `--detection.model`
-and the rest of the detection options. `--tracker sort` is shorthand for
-`--tracker.name sort`; both spellings are supported and neither warns.
+The algorithm and its parameters share one group, mirroring `--detection.model` and the rest of the detection options. `--tracker sort` is shorthand for `--tracker.name sort`; both spellings are supported and neither warns.
 
-Tracker parameters are the exception: they default to `None`, meaning "leave the
-tracker's own default alone", so they take an explicit value and have no
-negative half. Develop's bare `--tracker.enable_cmc` flag turned camera motion
-compensation **off**, since the parameter itself defaults to `True`, so the bare
-spelling still maps to `--tracker.enable_cmc=false` and warns. Prefer
-`--tracker.enable_cmc true` or `--tracker.enable_cmc false`; they say what they
-do. The same applies to `--tracker.instant_first_frame_activation`.
+Tracker parameters are the exception: they default to `None`, meaning "leave the tracker's own default alone", so they take an explicit value and have no negative half. Develop's bare `--tracker.enable_cmc` flag turned camera motion compensation **off**, since the parameter itself defaults to `True`, so the bare spelling still maps to `--tracker.enable_cmc=false` and warns. Prefer `--tracker.enable_cmc true` or `--tracker.enable_cmc false`; they say what they do. The same applies to `--tracker.instant_first_frame_activation`.
 
 As in develop, specify either a model or a precomputed MOT file, not both.
 
@@ -85,11 +63,7 @@ As in develop, specify either a model or a precomputed MOT file, not both.
 
 ### List-valued filters
 
-`--filters.classes` and `--filters.track_ids` take lists, matching the
-list-valued `--metrics` and `--columns` options of `eval` and `tune`. Bracket
-shorthand needs no quoting, so `--filters.classes [person,car]`,
-`--filters.classes [0,2]`, and the mixed `--filters.classes [person,2]` all
-work. Comma-separated strings remain available as a warning-emitting alias.
+`--filters.classes` and `--filters.track_ids` take lists, matching the list-valued `--metrics` and `--columns` options of `eval` and `tune`. Bracket shorthand needs no quoting, so `--filters.classes [person,car]`, `--filters.classes [0,2]`, and the mixed `--filters.classes [person,2]` all work. Comma-separated strings remain available as a warning-emitting alias.
 
 | Legacy value form              | Current value form               |
 | ------------------------------ | -------------------------------- |
@@ -98,11 +72,7 @@ work. Comma-separated strings remain available as a warning-emitting alias.
 
 ### Abbreviated tracker parameters
 
-Tracker parameter names abbreviate their standard leading token on the command
-line: `minimum_` becomes `min_` and `maximum_` becomes `max_`. Domain words such
-as `threshold` stay spelled out. Every develop parameter path whose spelling did
-not change keeps working as-is, without a warning; the unabbreviated paths remain
-as warning-emitting aliases.
+Tracker parameter names abbreviate their standard leading token on the command line: `minimum_` becomes `min_` and `maximum_` becomes `max_`. Domain words such as `threshold` stay spelled out. Every develop parameter path whose spelling did not change keeps working as-is, without a warning; the unabbreviated paths remain as warning-emitting aliases.
 
 | Legacy argument                                     | Current argument                                |
 | --------------------------------------------------- | ----------------------------------------------- |
@@ -113,38 +83,19 @@ as warning-emitting aliases.
 | `--tracker.minimum_iou_threshold_unconfirmed_assoc` | `--tracker.min_iou_threshold_unconfirmed_assoc` |
 | `--tracker.iou`                                     | `--tracker.iou_variant`                         |
 
-These short forms are **CLI aliases only**. The Python constructor keywords are
-unchanged, so `ByteTrackTracker(minimum_iou_threshold=0.3)` stays correct, and
-so do `tune --fixed_params`, each tracker's `search_space` keys, and the
-"Valid parameters" list printed on a `search_space` error. A consequence worth
-knowing: `tune` reports the long parameter names, so its output cannot be
-pasted verbatim into a `track` command — abbreviate the leading `minimum_` or
-`maximum_` token first.
+These short forms are **CLI aliases only**. The Python constructor keywords are unchanged, so `ByteTrackTracker(minimum_iou_threshold=0.3)` stays correct, and so do `tune --fixed_params`, each tracker's `search_space` keys, and the "Valid parameters" list printed on a `search_space` error. A consequence worth knowing: `tune` reports the long parameter names, so its output cannot be pasted verbatim into a `track` command — abbreviate the leading `minimum_` or `maximum_` token first.
 
 ## Hyphens and underscores
 
-Interchangeable in every option name, on every command, without a warning. Only
-the name is rewritten: each `-` after the leading `--` becomes `_`, and values
-are left alone, so `--detection.model rfdetr-base` and
-`--source my-dir/clip.mp4` keep their hyphens. This covers dotted paths and
-negations alike — `--show.no-ids`, `--tracker.min-iou-threshold` and
-`--no-display` all reach the parser as their underscore spellings. The canonical
-documentation spelling uses underscores.
+Interchangeable in every option name, on every command, without a warning. Only the name is rewritten: each `-` after the leading `--` becomes `_`, and values are left alone, so `--detection.model rfdetr-base` and `--source my-dir/clip.mp4` keep their hyphens. This covers dotted paths and negations alike — `--show.no-ids`, `--tracker.min-iou-threshold` and `--no-display` all reach the parser as their underscore spellings. The canonical documentation spelling uses underscores.
 
 Anything after a bare `--` is passed through untouched.
 
-This holds for the deprecated spellings in the tables below too, so a develop
-command ports without also having to guess which separator each option wanted:
-`--no-boxes` and `--no_boxes` resolve alike, as do `--mot-output` and
-`--mot_output`, `--track-ids` and `--track_ids`. `--help` lists the underscore
-spelling.
+This holds for the deprecated spellings in the tables below too, so a develop command ports without also having to guess which separator each option wanted: `--no-boxes` and `--no_boxes` resolve alike, as do `--mot-output` and `--mot_output`, `--track-ids` and `--track_ids`. `--help` lists the underscore spelling.
 
 ## `eval` prediction inputs
 
-`--tracker` names the tracking algorithm in `track` and `tune`. In `eval` it
-meant something else entirely — a file of results that algorithm had already
-produced. Both prediction inputs are renamed so one option name no longer
-carries two meanings:
+`--tracker` names the tracking algorithm in `track` and `tune`. In `eval` it meant something else entirely — a file of results that algorithm had already produced. Both prediction inputs are renamed so one option name no longer carries two meanings:
 
 | Legacy argument | Current argument    |
 | --------------- | ------------------- |
@@ -193,8 +144,7 @@ trackers download --name mot17 --cache_dir .cache
 
 ## YAML configuration
 
-The same nesting is used in `--config` files. Command-line values override
-configuration values.
+The same nesting is used in `--config` files. Command-line values override configuration values.
 
 ```yaml
 source: source.mp4

--- a/docs/learn/iou.md
+++ b/docs/learn/iou.md
@@ -4,8 +4,7 @@ description: Learn IoU, GIoU, DIoU, CIoU, and BIoU for object tracking associati
 
 # IoU API
 
-IoU variants are pluggable similarity metrics used during detection-to-track
-association. You pass one of these classes to a tracker via the `iou` argument.
+IoU variants are pluggable similarity metrics used during detection-to-track association. You pass one of these classes to a tracker via the `iou` argument.
 
 **What you'll learn:**
 
@@ -54,9 +53,7 @@ tracker = SORTTracker(
 
 - \( \mathrm{GIoU} = \mathrm{IoU} - \frac{|C \setminus (A \cup B)|}{|C|} \)
 - \( \mathrm{DIoU} = \mathrm{IoU} - \frac{d^2}{c^2 + \epsilon} \)
-- \( \mathrm{CIoU} = \mathrm{DIoU} - \alpha v \), where
-    \( v = \frac{4}{\pi^2}\left(\arctan\frac{w_A}{h_A} - \arctan\frac{w_B}{h_B}\right)^2 \)
-    and \( \alpha = \frac{v}{1 - \mathrm{IoU} + v + \epsilon} \)
+- \( \mathrm{CIoU} = \mathrm{DIoU} - \alpha v \), where \( v = \frac{4}{\pi^2}\left(\arctan\frac{w_A}{h_A} - \arctan\frac{w_B}{h_B}\right)^2 \) and \( \alpha = \frac{v}{1 - \mathrm{IoU} + v + \epsilon} \)
 
 ## IoU
 
@@ -103,8 +100,7 @@ Set `minimum_iou_threshold` based on the score range of your chosen metric.
 
 ## GIoU
 
-**Generalised IoU** ([Rezatofighi et al., 2019](https://arxiv.org/abs/1902.09630)) — penalises the gap inside the
-smallest enclosing box `C` that neither `A` nor `B` fills.
+**Generalised IoU** ([Rezatofighi et al., 2019](https://arxiv.org/abs/1902.09630)) — penalises the gap inside the smallest enclosing box `C` that neither `A` nor `B` fills.
 
 \[
 \mathrm{GIoU}(A, B) = \mathrm{IoU} - \frac{|C \setminus (A \cup B)|}{|C|}
@@ -114,9 +110,7 @@ smallest enclosing box `C` that neither `A` nor `B` fills.
   <img src="../../assets/IoU%20variants/GIoU%20visualization.png" alt="GIoU visualization" loading="lazy" decoding="async"/>
 </figure>
 
-When boxes do not overlap at all, IoU is flat at `0`, but the penalty term still
-changes as boxes move closer or farther apart, giving the tracker a meaningful
-signal based on distances, sizes and shapes.
+When boxes do not overlap at all, IoU is flat at `0`, but the penalty term still changes as boxes move closer or farther apart, giving the tracker a meaningful signal based on distances, sizes and shapes.
 
 ```python
 from trackers import OCSORTTracker
@@ -133,11 +127,7 @@ tracker = OCSORTTracker(iou=GIoU(), minimum_iou_threshold=-0.3)
 | Best IoU  |    73.07 |          — |
 | Best GIoU |    89.31 | **+16.24** |
 
-Left: IoU. Right: GIoU. Camera movements can introduce unexpected displacement,
-producing ID switches with IoU-based association. GIoU still provides a signal when
-there is no overlap by considering enclosing-box geometry, which helps preserve
-tracks that IoU would otherwise confuse or lose due to direction changes and
-non-linear motion (for example, tracks `5`, `12` on the left vs `13` on the right).
+Left: IoU. Right: GIoU. Camera movements can introduce unexpected displacement, producing ID switches with IoU-based association. GIoU still provides a signal when there is no overlap by considering enclosing-box geometry, which helps preserve tracks that IoU would otherwise confuse or lose due to direction changes and non-linear motion (for example, tracks `5`, `12` on the left vs `13` on the right).
 
 <video width="100%" controls muted loop>
   <source src="https://github.com/user-attachments/assets/dd38120d-ebbe-4705-8140-fcf24bc8ce99" type="video/mp4">
@@ -147,8 +137,7 @@ non-linear motion (for example, tracks `5`, `12` on the left vs `13` on the righ
 
 ## DIoU
 
-**Distance IoU** ([Zheng et al., 2019](https://arxiv.org/abs/1911.08287)) — adds a centre-distance penalty to IoU,
-normalised by the enclosing box diagonal.
+**Distance IoU** ([Zheng et al., 2019](https://arxiv.org/abs/1911.08287)) — adds a centre-distance penalty to IoU, normalised by the enclosing box diagonal.
 
 \[
 \mathrm{DIoU}(A, B) = \mathrm{IoU} - \frac{d^2}{c^2 + \epsilon}
@@ -158,9 +147,7 @@ normalised by the enclosing box diagonal.
   <img src="../../assets/IoU%20variants/DIoU%20visualization.png" alt="DIoU visualization" loading="lazy" decoding="async"/>
 </figure>
 
-where `d` is the Euclidean distance between box centres and `c` is the diagonal of
-the smallest enclosing rectangle. This encourages centre alignment independently of
-aspect ratio and tends to produce smoother associations in fast-motion sequences.
+where `d` is the Euclidean distance between box centres and `c` is the diagonal of the smallest enclosing rectangle. This encourages centre alignment independently of aspect ratio and tends to produce smoother associations in fast-motion sequences.
 
 ```python
 from trackers import OCSORTTracker
@@ -176,10 +163,7 @@ tracker = OCSORTTracker(iou=DIoU(), minimum_iou_threshold=-0.3)
 | Best IoU  |    73.07 |          — |
 | Best DIoU |    86.53 | **+13.46** |
 
-Left: IoU. Right: DIoU. Highly non-linear motion can make IoU drop to zero,
-causing the Kalman prediction to attach to another object and produce an ID switch.
-The centre-distance term keeps the score smoother and preserves IDs more often
-(for example, tracks `3–5`).
+Left: IoU. Right: DIoU. Highly non-linear motion can make IoU drop to zero, causing the Kalman prediction to attach to another object and produce an ID switch. The centre-distance term keeps the score smoother and preserves IDs more often (for example, tracks `3–5`).
 
 <video width="100%" controls muted loop>
   <source src="https://github.com/user-attachments/assets/011f6cfa-a2be-4109-8326-a98bcae4ed93" type="video/mp4">
@@ -189,8 +173,7 @@ The centre-distance term keeps the score smoother and preserves IDs more often
 
 ## CIoU
 
-**Complete IoU** ([Zheng et al., 2019](https://arxiv.org/abs/1911.08287)) — extends DIoU with a penalty for aspect-ratio
-mismatch between the two boxes.
+**Complete IoU** ([Zheng et al., 2019](https://arxiv.org/abs/1911.08287)) — extends DIoU with a penalty for aspect-ratio mismatch between the two boxes.
 
 \[
 \mathrm{CIoU}(A, B) = \mathrm{DIoU} - \alpha v
@@ -205,8 +188,7 @@ v = \frac{4}{\pi^2}\!\left(\arctan\frac{w_A}{h_A} - \arctan\frac{w_B}{h_B}\right
   <img src="../../assets/IoU%20variants/CIoU%20visualization.png" alt="CIoU visualization" loading="lazy" decoding="async"/>
 </figure>
 
-`v` measures aspect-ratio divergence; `α` scales it so the penalty is low when IoU
-is already high. On tracking benchmarks CIoU and DIoU behave similarly.
+`v` measures aspect-ratio divergence; `α` scales it so the penalty is low when IoU is already high. On tracking benchmarks CIoU and DIoU behave similarly.
 
 ```python
 from trackers import OCSORTTracker
@@ -232,8 +214,7 @@ Left: IoU. Right: CIoU. In this example, CIoU is capable of perfectly keeping th
 
 ## BIoU
 
-**Buffered IoU** ([Yang et al., 2022](https://arxiv.org/abs/2211.14317)) — expands each box by a relative margin `r`
-before computing standard IoU. Let `w = x2 − x1`, `h = y2 − y1`:
+**Buffered IoU** ([Yang et al., 2022](https://arxiv.org/abs/2211.14317)) — expands each box by a relative margin `r` before computing standard IoU. Let `w = x2 − x1`, `h = y2 − y1`:
 
 \[
 A^r = (x_1 - rw,\; y_1 - rh,\; x_2 + rw,\; y_2 + rh)
@@ -247,9 +228,7 @@ A^r = (x_1 - rw,\; y_1 - rh,\; x_2 + rw,\; y_2 + rh)
   <img src="../../assets/IoU%20variants/BIoU%20visualization.png" alt="BIoU visualization" loading="lazy" decoding="async"/>
 </figure>
 
-`r = 0` recovers plain IoU exactly. Enlarging boxes creates artificial overlap for
-objects that are geometrically close, which is useful when detections are very small
-or objects move fast enough so that consecutive boxes miss each other entirely.
+`r = 0` recovers plain IoU exactly. Enlarging boxes creates artificial overlap for objects that are geometrically close, which is useful when detections are very small or objects move fast enough so that consecutive boxes miss each other entirely.
 
 ```python
 from trackers import SORTTracker
@@ -265,9 +244,7 @@ tracker = SORTTracker(iou=BIoU(buffer_ratio=0.15), minimum_iou_threshold=0.3)
 | Best IoU  |    80.54 |         — |
 | Best BIoU |    88.00 | **+7.46** |
 
-Left: IoU. Right: BIoU. Notice how ID switches happen when fast players
-temporarily produce non-overlapping boxes between frames. The buffer closes
-that gap and keeps the same ID. (e.g. tracks 7 and 8).
+Left: IoU. Right: BIoU. Notice how ID switches happen when fast players temporarily produce non-overlapping boxes between frames. The buffer closes that gap and keeps the same ID. (e.g. tracks 7 and 8).
 
 <video width="100%" controls muted loop>
   <source src="https://github.com/user-attachments/assets/9a74a27b-0470-4cd8-b545-0507a0d2b053" type="video/mp4">
@@ -277,9 +254,7 @@ that gap and keeps the same ID. (e.g. tracks 7 and 8).
 
 ## IoU Variant Performance Across Benchmarks
 
-We evaluate how much each variant changes performance across datasets.
-For each `(dataset, tracker)` pair, we keep the `state_estimator` with the highest **IoU HOTA** on the evaluation split, then report mean
-`ΔHOTA = HOTA(variant) − HOTA(IoU)` over trackers (same split; thresholds tuned per experiment).
+We evaluate how much each variant changes performance across datasets. For each `(dataset, tracker)` pair, we keep the `state_estimator` with the highest **IoU HOTA** on the evaluation split, then report mean `ΔHOTA = HOTA(variant) − HOTA(IoU)` over trackers (same split; thresholds tuned per experiment).
 
 For more information on the datasets, see: [dataset comparison](../trackers/comparison.md).
 
@@ -306,27 +281,16 @@ For more information on the datasets, see: [dataset comparison](../trackers/comp
 | DanceTrack val |         50.27 |   **−0.80** |   **−0.34** |   **+0.05** |   **+0.15** |
 | SoccerNet test |         83.21 |   **+1.57** |   **+2.82** |   **+2.76** |   **+1.41** |
 
-Over SportsMOT and SoccerNet, all IoU variants outperform standard IoU, with DIoU
-and CIoU strongest on SoccerNet and DIoU slightly ahead of CIoU on SportsMOT. In
-MOT17, standard IoU is best by a small margin (DIoU and CIoU are similar). On
-DanceTrack, GIoU and DIoU underperform IoU, while CIoU and BIoU perform slightly better.
+Over SportsMOT and SoccerNet, all IoU variants outperform standard IoU, with DIoU and CIoU strongest on SoccerNet and DIoU slightly ahead of CIoU on SportsMOT. In MOT17, standard IoU is best by a small margin (DIoU and CIoU are similar). On DanceTrack, GIoU and DIoU underperform IoU, while CIoU and BIoU perform slightly better.
 
-These experiments suggest IoU variants provide task-dependent gains, with larger
-improvements on sports datasets. We hypothesize detection quality plays a major role:
-SoccerNet uses perfect detections, and SportsMOT detections come from a strong
-detector, and both show the largest improvements. To test this, we run an additional
-experiment using ground-truth boxes from MOT17 and SportsMOT as tracker detections.
+These experiments suggest IoU variants provide task-dependent gains, with larger improvements on sports datasets. We hypothesize detection quality plays a major role: SoccerNet uses perfect detections, and SportsMOT detections come from a strong detector, and both show the largest improvements. To test this, we run an additional experiment using ground-truth boxes from MOT17 and SportsMOT as tracker detections.
 
 | Dataset (GT-as-det) | IoU mean HOTA | GIoU mean Δ | DIoU mean Δ | CIoU mean Δ | BIoU mean Δ |
 | :------------------ | ------------: | ----------: | ----------: | ----------: | ----------: |
 | MOT17 val           |         97.17 |   **−0.05** |   **−0.07** |   **−0.05** |   **+0.31** |
 | SportsMOT val       |         87.18 |   **+0.47** |   **+1.09** |   **+1.06** |   **+0.46** |
 
-With ground-truth detections, mean ΔHOTA increases for three of four variants on
-SportsMOT compared to YOLOX detections. On MOT17, gaps narrow overall: GIoU moves
-closer to IoU, DIoU and CIoU remain slightly below IoU, and BIoU becomes positive on
-average. This is consistent with cleaner inputs: Kalman predictions align better
-with detections, so richer association signals can help more.
+With ground-truth detections, mean ΔHOTA increases for three of four variants on SportsMOT compared to YOLOX detections. On MOT17, gaps narrow overall: GIoU moves closer to IoU, DIoU and CIoU remain slightly below IoU, and BIoU becomes positive on average. This is consistent with cleaner inputs: Kalman predictions align better with detections, so richer association signals can help more.
 
 ---
 

--- a/docs/learn/tune.md
+++ b/docs/learn/tune.md
@@ -32,17 +32,11 @@ For more options, see the [install guide](install.md).
 
 The tuner needs matching MOT files for ground truth and detections.
 
-By default, the **first trial** evaluates a baseline parameter set before Optuna
-samples further combinations. That trial counts toward `--n-trials` / `n_trials`.
-Set `enqueue_defaults=False` on `Tuner` to disable this behavior.
+By default, the **first trial** evaluates a baseline parameter set before Optuna samples further combinations. That trial counts toward `--n-trials` / `n_trials`. Set `enqueue_defaults=False` on `Tuner` to disable this behavior.
 
-For each `search_space` key, the baseline uses the tracker's default
-when it lies within the search space.
+For each `search_space` key, the baseline uses the tracker's default when it lies within the search space.
 
-Options that are not tuned (or differ from `__init__`) are set with
-`fixed_params` on `Tuner`. They apply to every trial, including the baseline,
-override the same key in `search_space` if present, and are returned from
-`run()` merged into the best parameter dict.
+Options that are not tuned (or differ from `__init__`) are set with `fixed_params` on `Tuner`. They apply to every trial, including the baseline, override the same key in `search_space` if present, and are returned from `run()` merged into the best parameter dict.
 
 === "Python"
 
@@ -79,9 +73,7 @@ override the same key in `search_space` if present, and are returned from
         --fixed_params '{"enable_cmc": false}'
     ```
 
-Images are read from `{images_dir}/{sequence}/img1/` using MOT-style stems:
-6-digit (`000001.jpg`, MOT17/SportsMOT) or 8-digit (`00000001.jpg`, DanceTrack),
-plus common extensions (`.jpg`, `.png`, …).
+Images are read from `{images_dir}/{sequence}/img1/` using MOT-style stems: 6-digit (`000001.jpg`, MOT17/SportsMOT) or 8-digit (`00000001.jpg`, DanceTrack), plus common extensions (`.jpg`, `.png`, …).
 
 ```text
 data

--- a/docs/trackers/bytetrack.md
+++ b/docs/trackers/bytetrack.md
@@ -50,8 +50,7 @@ ByteTrack builds on the same Kalman filter and Hungarian algorithm framework as 
 
 !!! warning "Frame input is ignored by ByteTrack"
 
-    `ByteTrackTracker.update()` accepts `frame` for API consistency with other trackers, but ByteTrack does not use image/frame pixels.
-    If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
+    `ByteTrackTracker.update()` accepts `frame` for API consistency with other trackers, but ByteTrack does not use image/frame pixels. If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
 
 ## Run on video, webcam, or RTSP stream
 

--- a/docs/trackers/cbiou.md
+++ b/docs/trackers/cbiou.md
@@ -53,8 +53,7 @@ C-BIoU keeps the [ByteTrack](bytetrack.md)-style association pipeline used in [B
 
 !!! warning "Frame input is ignored by C-BIoU"
 
-    `CBIoUTracker.update()` accepts `frame` for API consistency with other trackers, but C-BIoU does not use image/frame pixels.
-    If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
+    `CBIoUTracker.update()` accepts `frame` for API consistency with other trackers, but C-BIoU does not use image/frame pixels. If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
 
 ## Run on video, webcam, or RTSP stream
 

--- a/docs/trackers/comparison.md
+++ b/docs/trackers/comparison.md
@@ -26,8 +26,7 @@ Pedestrian tracking with crowded scenes and frequent occlusions. Strongly tests 
 
 !!! info
 
-    Parameters were tuned on the validation set. Results are reported on the
-    test set via Codabench submission. Detections come from a YOLOX model.
+    Parameters were tuned on the validation set. Results are reported on the test set via Codabench submission. Detections come from a YOLOX model.
 
 === "Default"
 
@@ -112,8 +111,7 @@ Sports broadcast tracking with fast motion, camera pans, and similar-looking tar
 
 !!! info
 
-    Parameters were tuned on the validation set. Results are reported on the
-    test set via Codabench submission. Detections come from a YOLOX model.
+    Parameters were tuned on the validation set. Results are reported on the test set via Codabench submission. Detections come from a YOLOX model.
 
 === "Default"
 
@@ -198,9 +196,7 @@ Long sequences with dense interactions and partial occlusions. Tests long-term I
 
 !!! info
 
-    Parameters were tuned on the train set. Results are reported on the test
-    set. SoccerNet-tracking has no validation split. This dataset provides
-    oracle (ground-truth) detections.
+    Parameters were tuned on the train set. Results are reported on the test set. SoccerNet-tracking has no validation split. This dataset provides oracle (ground-truth) detections.
 
 === "Default"
 
@@ -276,10 +272,7 @@ Long sequences with dense interactions and partial occlusions. Tests long-term I
 
 !!! note "SoccerNet buffer ordering exception"
 
-    This config uses `buffer_ratio_first: 0.68 > buffer_ratio_second: 0.50`, which reverses
-    the general `b1 < b2` recommendation in the [C-BIoU docs](cbiou.md#buffer-ordering).
-    Optuna found this ordering yields higher HOTA on SoccerNet's dense, long-sequence scenarios.
-    On most other datasets the `b1 < b2` default applies.
+    This config uses `buffer_ratio_first: 0.68 > buffer_ratio_second: 0.50`, which reverses the general `b1 < b2` recommendation in the [C-BIoU docs](cbiou.md#buffer-ordering). Optuna found this ordering yields higher HOTA on SoccerNet's dense, long-sequence scenarios. On most other datasets the `b1 < b2` default applies.
 
 ## [DanceTrack](https://arxiv.org/abs/2111.14690)
 
@@ -292,9 +285,7 @@ Group dancing tracking with uniform appearance, diverse motions, and extreme art
 
 !!! info
 
-    Parameters were tuned on the validation set. Results are reported on the
-    test set via [Codabench](https://www.codabench.org/competitions/14885/) submission.
-    Detections come from a YOLOX model.
+    Parameters were tuned on the validation set. Results are reported on the test set via [Codabench](https://www.codabench.org/competitions/14885/) submission. Detections come from a YOLOX model.
 
 === "Default"
 
@@ -311,9 +302,7 @@ Group dancing tracking with uniform appearance, diverse motions, and extreme art
 
 === "Tuned"
 
-    Hyperparameter tuning, reporting the best tuned configuration per
-    tracker evaluated on the test set (tuning performed on the valid split;
-    if tuning did not outperform registry defaults, defaults are shown).
+    Hyperparameter tuning, reporting the best tuned configuration per tracker evaluated on the test set (tuning performed on the valid split; if tuning did not outperform registry defaults, defaults are shown).
 
     |  Tracker  |   HOTA   |   IDF1   |   MOTA   |
     | :-------: | :------: | :------: | :------: |
@@ -372,27 +361,17 @@ Group dancing tracking with uniform appearance, diverse motions, and extreme art
 
 !!! note "DanceTrack buffer ordering exception"
 
-    This config uses `buffer_ratio_first: 0.12 > buffer_ratio_second: 0.10`, which reverses
-    the general `b1 < b2` recommendation in the [C-BIoU docs](cbiou.md#buffer-ordering).
-    Optuna found this ordering on DanceTrack's validation split; the margin (0.02) is small
-    and the `b1 < b2` default applies on most other datasets.
+    This config uses `buffer_ratio_first: 0.12 > buffer_ratio_second: 0.10`, which reverses the general `b1 < b2` recommendation in the [C-BIoU docs](cbiou.md#buffer-ordering). Optuna found this ordering on DanceTrack's validation split; the margin (0.02) is small and the `b1 < b2` default applies on most other datasets.
 
 ## Methodology
 
 ### Detections
 
-Each dataset uses one of two detection sources: oracle detections (ground-truth
-bounding boxes provided by the dataset) or model detections (produced by a YOLOX
-detector following the ByteTrack procedure). The source is noted per dataset above.
+Each dataset uses one of two detection sources: oracle detections (ground-truth bounding boxes provided by the dataset) or model detections (produced by a YOLOX detector following the ByteTrack procedure). The source is noted per dataset above.
 
 ### Tuning
 
-Best parameters per tracker and dataset were found via grid search (SORT, ByteTrack,
-OC-SORT, BoT-SORT) or Optuna (`n_trials=100`, objective HOTA, trial 0 = defaults for
-C-BIoU), selecting the configuration with the highest HOTA on the tune split. McByte is
-not tuned here: defaults with mask-conditioned association enabled are reported, matching
-the [McByte](mcbyte.md) page (source: [PR #513](https://github.com/roboflow/trackers/pull/513)).
-Tuning and evaluation always use separate data splits to reflect real-world usage:
+Best parameters per tracker and dataset were found via grid search (SORT, ByteTrack, OC-SORT, BoT-SORT) or Optuna (`n_trials=100`, objective HOTA, trial 0 = defaults for C-BIoU), selecting the configuration with the highest HOTA on the tune split. McByte is not tuned here: defaults with mask-conditioned association enabled are reported, matching the [McByte](mcbyte.md) page (source: [PR #513](https://github.com/roboflow/trackers/pull/513)). Tuning and evaluation always use separate data splits to reflect real-world usage:
 
 - Train + validation + test: tune on validation, report on test.
 - Train + validation: tune on train, report on validation.
@@ -400,28 +379,13 @@ Tuning and evaluation always use separate data splits to reflect real-world usag
 
 ## When to Use Each Tracker
 
-**SORT** is the right choice when speed is the primary constraint and scenes are not heavily
-occluded. Its Kalman filter plus Hungarian matching runs at hundreds of frames per second and
-produces clean, easy-to-debug results. Use SORT as a baseline before adding more complex
-trackers, or when deploying on edge devices with tight compute budgets.
+**SORT** is the right choice when speed is the primary constraint and scenes are not heavily occluded. Its Kalman filter plus Hungarian matching runs at hundreds of frames per second and produces clean, easy-to-debug results. Use SORT as a baseline before adding more complex trackers, or when deploying on edge devices with tight compute budgets.
 
-**ByteTrack** is the default recommendation for most applications. It outperforms SORT on all
-four benchmarks by recovering low-confidence detections that SORT discards. The two-stage
-association adds almost no extra compute and consistently reduces missed tracks and identity
-switches. Use ByteTrack when your detector produces noisy or variable-confidence outputs —
-sports video, aerial footage, and crowded retail scenes all benefit.
+**ByteTrack** is the default recommendation for most applications. It outperforms SORT on all four benchmarks by recovering low-confidence detections that SORT discards. The two-stage association adds almost no extra compute and consistently reduces missed tracks and identity switches. Use ByteTrack when your detector produces noisy or variable-confidence outputs — sports video, aerial footage, and crowded retail scenes all benefit.
 
-**OC-SORT** is best when camera motion is significant or objects follow non-linear paths. Its
-observation-centric re-update mechanism and direction consistency cost reduce drift from the
-linear motion assumption. Use OC-SORT when SORT or ByteTrack loses tracks on fast turns,
-camera pans, or erratic motion — the benchmark edge on MOT17 reflects exactly
-these conditions.
+**OC-SORT** is best when camera motion is significant or objects follow non-linear paths. Its observation-centric re-update mechanism and direction consistency cost reduce drift from the linear motion assumption. Use OC-SORT when SORT or ByteTrack loses tracks on fast turns, camera pans, or erratic motion — the benchmark edge on MOT17 reflects exactly these conditions.
 
-**BoT-SORT** is the choice when camera ego-motion is strong and you need the most stable
-identities. It extends ByteTrack with camera motion compensation (CMC) and confidence-aware
-association, which reduces ID switches on panning or handheld footage. Use BoT-SORT for sports
-broadcasts, drone video, or any scene where the camera moves frequently. The CMC overhead is
-small relative to the detector, so the trade-off favors identity stability over raw speed.
+**BoT-SORT** is the choice when camera ego-motion is strong and you need the most stable identities. It extends ByteTrack with camera motion compensation (CMC) and confidence-aware association, which reduces ID switches on panning or handheld footage. Use BoT-SORT for sports broadcasts, drone video, or any scene where the camera moves frequently. The CMC overhead is small relative to the detector, so the trade-off favors identity stability over raw speed.
 
 **C-BIoU** targets fast or irregular motion when you want buffered, cascaded geometric matching without camera motion compensation. In these benchmarks it leads on SoccerNet when tuned, and reaches the highest tuned IDF1 and MOTA on DanceTrack among the motion-only trackers. Use C-BIoU when BoT-SORT-style association is a good fit but CMC is unavailable or harmful, or when plain IoU matching is too strict. See [C-BIoU](cbiou.md) for buffer scales **b1** and **b2**.
 
@@ -429,18 +393,8 @@ small relative to the detector, so the trade-off favors identity stability over 
 
 ## Metric Definitions
 
-**HOTA** (Higher Order Tracking Accuracy) — the primary benchmark metric. HOTA decomposes
-tracking quality into detection accuracy (DetA) and association accuracy (AssA), then takes
-their geometric mean. It weights identity consistency equally with detection recall and
-precision, unlike older metrics that under-penalize fragmented tracks. Higher HOTA indicates
-both good detection and stable long-term identity.
+**HOTA** (Higher Order Tracking Accuracy) — the primary benchmark metric. HOTA decomposes tracking quality into detection accuracy (DetA) and association accuracy (AssA), then takes their geometric mean. It weights identity consistency equally with detection recall and precision, unlike older metrics that under-penalize fragmented tracks. Higher HOTA indicates both good detection and stable long-term identity.
 
-**IDF1** (Identity F1) — measures how long the system correctly identifies each ground-truth
-object over its lifetime. IDF1 is the harmonic mean of identification precision and
-identification recall. High IDF1 means tracks stay on the correct identity; low IDF1 means
-frequent identity switches.
+**IDF1** (Identity F1) — measures how long the system correctly identifies each ground-truth object over its lifetime. IDF1 is the harmonic mean of identification precision and identification recall. High IDF1 means tracks stay on the correct identity; low IDF1 means frequent identity switches.
 
-**MOTA** (Multiple Object Tracking Accuracy) — combines the count of false positives, missed
-detections, and identity switches into a single score relative to the total number of
-ground-truth objects. MOTA is dominated by detection recall and precision; a detector with
-near-perfect recall produces high MOTA even when identity switches are frequent.
+**MOTA** (Multiple Object Tracking Accuracy) — combines the count of false positives, missed detections, and identity switches into a single score relative to the total number of ground-truth objects. MOTA is dominated by detection recall and precision; a detector with near-perfect recall produces high MOTA even when identity switches are frequent.

--- a/docs/trackers/ocsort.md
+++ b/docs/trackers/ocsort.md
@@ -8,10 +8,7 @@ description: OC-SORT (Observation-Centric SORT) enhances SORT with three mechani
 
 ## What is OC-SORT?
 
-OC-SORT remains Simple, Online, and Real-Time like ([SORT](sort.md)) but improves robustness during occlusion and non-linear motion.
-It recognizes limitations from SORT and the linear motion assumption of the Kalman filter, and adds three mechanisms to enhance tracking. These
-mechanisms help having better Kalman Filter parameters after an occlusion, add a term to the association process to incorporate how consistent is the direction with the new association with respect to the tracks' previous direction and add a second-stage association step between the last observation of unmatched tracks and the unmatched observations after the usual association to attempt to recover tracks that were lost
-due to object stopping or short-term occlusion.
+OC-SORT remains Simple, Online, and Real-Time like ([SORT](sort.md)) but improves robustness during occlusion and non-linear motion. It recognizes limitations from SORT and the linear motion assumption of the Kalman filter, and adds three mechanisms to enhance tracking. These mechanisms help having better Kalman Filter parameters after an occlusion, add a term to the association process to incorporate how consistent is the direction with the new association with respect to the tracks' previous direction and add a second-stage association step between the last observation of unmatched tracks and the unmatched observations after the usual association to attempt to recover tracks that were lost due to object stopping or short-term occlusion.
 
 ## How does OC-SORT compare to other trackers?
 
@@ -54,8 +51,7 @@ Together, these three mechanisms make OC-SORT effective for group dancing, sport
 
 !!! warning "Frame input is ignored by OC-SORT"
 
-    `OCSORTTracker.update()` accepts `frame` for API consistency with other trackers, but OC-SORT does not use image/frame pixels.
-    If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
+    `OCSORTTracker.update()` accepts `frame` for API consistency with other trackers, but OC-SORT does not use image/frame pixels. If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
 
 ## Run on video, webcam, or RTSP stream
 

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -49,13 +49,11 @@ SORT models each tracked object with a seven-dimensional state vector `[x, y, s,
 
 !!! warning "Frame input is ignored by SORT"
 
-    `SORTTracker.update()` accepts `frame` for API consistency with other trackers, but SORT does not use image/frame pixels.
-    If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
+    `SORTTracker.update()` accepts `frame` for API consistency with other trackers, but SORT does not use image/frame pixels. If you pass `frame` with a non-`None` value, the tracker emits a `UserWarning` and ignores it.
 
 !!! note "SORTTracker is not deprecated"
 
-    `SORTTracker` itself is not deprecated. Only the `tracker.trackers` attribute alias
-    is deprecated in favor of `tracker.tracks`.
+    `SORTTracker` itself is not deprecated. Only the `tracker.trackers` attribute alias is deprecated in favor of `tracker.tracks`.
 
 ## Run on video, webcam, or RTSP stream
 


### PR DESCRIPTION
This pull request makes a minor update to the pre-commit configuration for markdown formatting. The change disables line wrapping in the `mdformat` hook by adding the `--wrap=no` argument.

- [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L56-R56): Updated the `mdformat` hook to include `--wrap=no` in the arguments, preventing automatic line wrapping during formatting.