### PR TITLE
build(pre-commit): add docformatter hook, wrap docstrings at 120

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,6 @@ repos:
     hooks:
       - id: ruff-check
         args: [--fix]
-      - id: ruff-format
 
   - repo: https://github.com/PyCQA/docformatter
     rev: v1.7.8
@@ -52,6 +51,11 @@ repos:
         language_version: python3.10
         additional_dependencies: [tomli]
         args: ["--in-place"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.1
+    hooks:
+      - id: ruff-format
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,14 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.8
+    hooks:
+      - id: docformatter
+        language_version: python3.10
+        additional_dependencies: [tomli]
+        args: ["--in-place"]
+
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
     hooks:

--- a/docs/hooks/doctest_filter.py
+++ b/docs/hooks/doctest_filter.py
@@ -4,22 +4,19 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""
-MkDocs hook to strip doctest directives from rendered documentation.
+"""MkDocs hook to strip doctest directives from rendered documentation.
 
-Removes `# doctest: +SKIP`, `# doctest: +ELLIPSIS`, and similar directives
-from code blocks so they don't appear in the rendered docs.
+Removes `# doctest: +SKIP`, `# doctest: +ELLIPSIS`, and similar directives from code blocks so they don't appear in the
+rendered docs.
 """
 
 import re
 
 
 def on_page_content(html: str, **kwargs) -> str:
-    """
-    Process page HTML content to remove doctest directives.
+    """Process page HTML content to remove doctest directives.
 
-    This hook runs after markdown is converted to HTML, so we need to
-    handle HTML-encoded content within <code> blocks.
+    This hook runs after markdown is converted to HTML, so we need to handle HTML-encoded content within <code> blocks.
     """
     # Pattern to match doctest directives in code
     # Handles both plain text and HTML-encoded versions

--- a/docs/hooks/schema_inject.py
+++ b/docs/hooks/schema_inject.py
@@ -121,8 +121,8 @@ _BENCHMARK_DATASETS = [
 def _build_breadcrumbs(page, config, nav):  # type: ignore[no-untyped-def]
     """Build BreadcrumbList JSON-LD from navigation hierarchy.
 
-    Returns None if the page is at the root level (no meaningful breadcrumb)
-    or if the page is the homepage (to avoid "Home > Home > ..." duplication).
+    Returns None if the page is at the root level (no meaningful breadcrumb) or if the page is the homepage (to avoid
+    "Home > Home > ..." duplication).
     """
     # Skip breadcrumbs for the homepage to avoid "Home > Home > ..." duplication.
     if page.file.src_path == "index.md":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,10 @@ markers = [
     "integration: marks tests as integration tests (require external data download)",
 ]
 
+[tool.docformatter]
+wrap-summaries = 120
+wrap-descriptions = 120
+
 [tool.codespell]
 skip = "*.pth,*.svg"
 ignore-words-list = "mot"

--- a/src/trackers/cli/_annotate.py
+++ b/src/trackers/cli/_annotate.py
@@ -6,17 +6,14 @@
 
 """Drawing shared by every command that renders frames.
 
-Everything here delegates to ``supervision`` annotators rather than calling
-OpenCV directly. The library is already a hard dependency and already speaks
-:class:`sv.Detections`, so a bespoke box or mask drawer buys nothing but a
-second visual style to keep in sync.
+Everything here delegates to ``supervision`` annotators rather than calling OpenCV directly. The library is already a
+hard dependency and already speaks :class:`sv.Detections`, so a bespoke box or mask drawer buys nothing but a second
+visual style to keep in sync.
 
-One consequence worth stating: ``trackers track`` and ``trackers inspect`` now
-draw from the same palette, so a track ID keeps its colour whether you are
-watching a live run or inspecting one stage of the mask pipeline.
+One consequence worth stating: ``trackers track`` and ``trackers inspect`` now draw from the same palette, so a track ID
+keeps its colour whether you are watching a live run or inspecting one stage of the mask pipeline.
 
-Infrastructure module, not a command — see :mod:`trackers.cli` for the layout
-rule.
+Infrastructure module, not a command — see :mod:`trackers.cli` for the layout rule.
 """
 
 from __future__ import annotations
@@ -62,9 +59,8 @@ LIFECYCLE_TRACKED = 3
 LIFECYCLE_LABELS = ("new", "pending", "masked", "tracked")
 """Mask-lifecycle states, used as ``class_id`` so colour follows state not ID.
 
-Ground-truth replay knows whether a tracklet is newly visible, waiting for mask
-creation, already masked, or none of those. Encoding that as a class lets
-``supervision`` colour it, instead of a hand-rolled branch per state.
+Ground-truth replay knows whether a tracklet is newly visible, waiting for mask creation, already masked, or none of
+those. Encoding that as a class lets ``supervision`` colour it, instead of a hand-rolled branch per state.
 """
 
 _LIFECYCLE_PALETTE = sv.ColorPalette.from_hex(

--- a/src/trackers/cli/_detections.py
+++ b/src/trackers/cli/_detections.py
@@ -6,19 +6,15 @@
 
 """Detection-file reading shared by ``benchmark`` and ``inspect``.
 
-Both command groups replay pre-computed detections through a tracker, so both
-need the same parser, the same frame lookup, and the same frame loader. They had
-their own copies, which had already drifted apart in error wording and in the
-set of image extensions they accepted.
+Both command groups replay pre-computed detections through a tracker, so both need the same parser, the same frame
+lookup, and the same frame loader. They had their own copies, which had already drifted apart in error wording and in
+the set of image extensions they accepted.
 
-Not merged into :mod:`trackers.io.mot`: ``load_mot_file`` there returns
-evaluation-shaped ``_MOTFrameData`` — boxes as ``xywh``, plus the class and
-visibility columns that ground-truth filtering needs — and handles one layout.
-What these commands need is a detection record across two layouts. Same file
-extension, different contract.
+Not merged into :mod:`trackers.io.mot`: ``load_mot_file`` there returns evaluation-shaped ``_MOTFrameData`` — boxes as
+``xywh``, plus the class and visibility columns that ground-truth filtering needs — and handles one layout. What these
+commands need is a detection record across two layouts. Same file extension, different contract.
 
-Infrastructure module, not a command — see :mod:`trackers.cli` for the layout
-rule.
+Infrastructure module, not a command — see :mod:`trackers.cli` for the layout rule.
 """
 
 from __future__ import annotations
@@ -47,12 +43,10 @@ IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".bmp", ".webp")
 DetectionFileFormat = Literal["mot_tlwh", "mot", "xyxy"]
 """Detection-file column layout.
 
-``mot_tlwh`` (spelled ``mot`` by the benchmark datasets)
-    ``frame,id,left,top,width,height,confidence,...`` — the identity column is
-    ignored, since tracker identities are what these commands produce.
+``mot_tlwh`` (spelled ``mot`` by the benchmark datasets)     ``frame,id,left,top,width,height,confidence,...`` — the
+identity column is     ignored, since tracker identities are what these commands produce.
 
-``xyxy``
-    ``frame,x1,y1,x2,y2,confidence``
+``xyxy``     ``frame,x1,y1,x2,y2,confidence``
 """
 
 _FRAME_NUMBER_WIDTHS = (6, 8)

--- a/src/trackers/cli/_detections.py
+++ b/src/trackers/cli/_detections.py
@@ -43,10 +43,11 @@ IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".bmp", ".webp")
 DetectionFileFormat = Literal["mot_tlwh", "mot", "xyxy"]
 """Detection-file column layout.
 
-``mot_tlwh`` (spelled ``mot`` by the benchmark datasets)     ``frame,id,left,top,width,height,confidence,...`` — the
-identity column is     ignored, since tracker identities are what these commands produce.
-
-``xyxy``     ``frame,x1,y1,x2,y2,confidence``
+- ``mot_tlwh`` (spelled ``mot`` by the benchmark datasets):
+  ``frame,id,left,top,width,height,confidence,...`` — the identity column is
+  ignored, since tracker identities are what these commands produce.
+- ``xyxy``:
+  ``frame,x1,y1,x2,y2,confidence``
 """
 
 _FRAME_NUMBER_WIDTHS = (6, 8)

--- a/src/trackers/cli/_legacy.py
+++ b/src/trackers/cli/_legacy.py
@@ -6,18 +6,15 @@
 
 """Transitional CLI spellings, kept parsing until 2.10.0.
 
-Everything in this module exists to let a command written against the previous
-release keep working, with a ``FutureWarning`` naming its replacement. It is
-deliberately one file so the removal is a deletion rather than an archaeology
-exercise: at 2.10.0 this module goes, along with the ``_translate_legacy_args``
-call in :func:`trackers.cli.__main__.main`.
+Everything in this module exists to let a command written against the previous release keep working, with a
+``FutureWarning`` naming its replacement. It is deliberately one file so the removal is a deletion rather than an
+archaeology exercise: at 2.10.0 this module goes, along with the ``_translate_legacy_args`` call in
+:func:`trackers.cli.__main__.main`.
 
-TODO(v2.10): three passes in :func:`_translate_legacy_args` are NOT deprecations
-and must survive the deletion — the ``_normalise_option`` sweep that makes
-hyphens and underscores interchangeable, ``_expand_tracker_shorthand``, and
-``_translate_legacy_list_args`` which converts space-separated and ``=`` values
-to JSON lists. All three live in :mod:`trackers.cli._parser`; move the calls
-there rather than dropping them with this file.
+TODO(v2.10): three passes in :func:`_translate_legacy_args` are NOT deprecations and must survive the deletion — the
+``_normalise_option`` sweep that makes hyphens and underscores interchangeable, ``_expand_tracker_shorthand``, and
+``_translate_legacy_list_args`` which converts space-separated and ``=`` values to JSON lists. All three live in
+:mod:`trackers.cli._parser`; move the calls there rather than dropping them with this file.
 """
 
 from __future__ import annotations
@@ -208,8 +205,8 @@ def _warn_legacy_cli(message: str) -> None:
 def _translate_legacy_args(args: list[str]) -> list[str]:
     """Translate deprecated CLI spellings to their current argument paths.
 
-    The translator runs before jsonargparse sees argv, allowing legacy scalar
-    arguments to target fields in the track command's nested option dataclasses.
+    The translator runs before jsonargparse sees argv, allowing legacy scalar arguments to target fields in the track
+    command's nested option dataclasses.
     """
     subcommand_index = next((index for index, arg in enumerate(args) if arg in _SUBCOMMANDS), None)
     if subcommand_index is None:

--- a/src/trackers/cli/_parser.py
+++ b/src/trackers/cli/_parser.py
@@ -6,14 +6,12 @@
 
 """Parser conventions shared by every trackers command.
 
-Everything here is permanent: the option-name spelling rule, the boolean option
-pair, and the nested option groups of ``track``. The transitional rewrites that
-accept the previous release's spellings live in :mod:`trackers.cli._legacy`.
+Everything here is permanent: the option-name spelling rule, the boolean option pair, and the nested option groups of
+``track``. The transitional rewrites that accept the previous release's spellings live in :mod:`trackers.cli._legacy`.
 
-This module deliberately imports nothing from :mod:`trackers.cli.__main__`. The
-entry point imports every subcommand, so a subcommand reaching back for the
-shared parser through ``__main__`` would import a half-initialised module.
-Import from here instead.
+This module deliberately imports nothing from :mod:`trackers.cli.__main__`. The entry point imports every subcommand, so
+a subcommand reaching back for the shared parser through ``__main__`` would import a half-initialised module. Import
+from here instead.
 """
 
 from __future__ import annotations

--- a/src/trackers/cli/benchmark/__init__.py
+++ b/src/trackers/cli/benchmark/__init__.py
@@ -6,13 +6,11 @@
 
 """Trackers benchmarked by ``trackers benchmark``.
 
-Each key in :data:`BENCHMARK_COMMANDS` names a tracker run over a complete
-benchmark test set. Only McByte has a benchmark harness today; the group exists
-so the top-level CLI holds verbs alone.
+Each key in :data:`BENCHMARK_COMMANDS` names a tracker run over a complete benchmark test set. Only McByte has a
+benchmark harness today; the group exists so the top-level CLI holds verbs alone.
 
-These commands need the ``mask`` extra (``pip install 'trackers[mask]'``). The
-heavy imports are deferred into the command bodies so that importing the CLI
-stays cheap for everyone else.
+These commands need the ``mask`` extra (``pip install 'trackers[mask]'``). The heavy imports are deferred into the
+command bodies so that importing the CLI stays cheap for everyone else.
 """
 
 from trackers.cli.benchmark.mcbyte import benchmark_command

--- a/src/trackers/cli/benchmark/mcbyte.py
+++ b/src/trackers/cli/benchmark/mcbyte.py
@@ -169,12 +169,11 @@ class DatasetPaths:
 class DatasetConfig:
     """Dataset-specific paths and parsing behavior.
 
-    Each dataset defines where detections and frames are located,
-    how detections should be parsed,
-    and any dataset-specific conventions.
+    Each dataset defines where detections and frames are located, how detections should be parsed, and any dataset-
+    specific conventions.
 
-    The two roots default to ``None`` because no value can be right for every
-    machine; :func:`resolve_datasets` fills them from what the run supplied.
+    The two roots default to ``None`` because no value can be right for every machine; :func:`resolve_datasets` fills
+    them from what the run supplied.
     """
 
     name: str

--- a/src/trackers/cli/inspect/__init__.py
+++ b/src/trackers/cli/inspect/__init__.py
@@ -6,14 +6,12 @@
 
 """Components behind ``trackers inspect``.
 
-Each entry in :data:`INSPECT_COMPONENTS` names the thing it inspects, not the
-tracker that happens to use it. The mask stack (``sam``, ``cutie``,
-``mask-manager``) is tracker-agnostic and lives in :mod:`trackers.core.masks`;
-only ``mcbyte`` inspects a tracker.
+Each entry in :data:`INSPECT_COMPONENTS` names the thing it inspects, not the tracker that happens to use it. The mask
+stack (``sam``, ``cutie``, ``mask-manager``) is tracker-agnostic and lives in :mod:`trackers.core.masks`; only
+``mcbyte`` inspects a tracker.
 
-These commands need the ``mask`` extra (``pip install 'trackers[mask]'``). The
-heavy imports are deferred into the command bodies so that importing the CLI
-stays cheap for everyone else.
+These commands need the ``mask`` extra (``pip install 'trackers[mask]'``). The heavy imports are deferred into the
+command bodies so that importing the CLI stays cheap for everyone else.
 """
 
 from trackers.cli.inspect.cutie import cutie_inspection

--- a/src/trackers/cli/inspect/cutie.py
+++ b/src/trackers/cli/inspect/cutie.py
@@ -141,8 +141,8 @@ def group_add_events_by_next_frame(
 ) -> dict[str, list[AddMaskEvent]]:
     """Group add events by the frame they should be applied before.
 
-    The CLI frame is the frame where the box is valid. Internally, McByte-style
-    timing applies the mask on that frame, then propagates to the next frame.
+    The CLI frame is the frame where the box is valid. Internally, McByte-style timing applies the mask on that frame,
+    then propagates to the next frame.
     """
     filenames = [path.name for path in frame_paths]
     grouped: dict[str, list[AddMaskEvent]] = defaultdict(list)
@@ -170,9 +170,8 @@ def validate_lifecycle_events(
 ) -> None:
     """Validate that add/remove lifecycle events are compatible with the frame range.
 
-    Add events refer to the source frame where the box is valid and are internally
-    shifted to the next frame. Therefore, they cannot be scheduled on the last
-    selected frame. Remove events are applied before propagation to their target
+    Add events refer to the source frame where the box is valid and are internally shifted to the next frame. Therefore,
+    they cannot be scheduled on the last selected frame. Remove events are applied before propagation to their target
     frame, so they cannot be scheduled on the first selected frame.
     """
     filenames = [path.name for path in frame_paths]

--- a/src/trackers/cli/inspect/mask_manager.py
+++ b/src/trackers/cli/inspect/mask_manager.py
@@ -175,9 +175,8 @@ def group_add_events_by_source_frame(
 ) -> dict[str, list[AddTrackletEvent]]:
     """Group add events by the frame where new tracklets are created.
 
-    The grouped events are converted into ``previous_new_tracklets`` after the
-    MaskManager call for that frame. They are then consumed by MaskManager on
-    the next frame, matching the original McByte timing.
+    The grouped events are converted into ``previous_new_tracklets`` after the MaskManager call for that frame. They are
+    then consumed by MaskManager on the next frame, matching the original McByte timing.
     """
     filenames = [path.name for path in frame_paths]
     grouped: dict[str, list[AddTrackletEvent]] = defaultdict(list)
@@ -193,9 +192,8 @@ def group_add_events_by_source_frame(
 def group_remove_events(events: list[RemoveTrackletEvent]) -> dict[str, list[int]]:
     """Group remove events by the frame where tracklets are terminated.
 
-    The grouped events are converted into ``previous_removed_tracklet_ids`` after
-    the MaskManager call for that frame. They are then consumed by MaskManager on
-    the next frame, matching the original McByte timing.
+    The grouped events are converted into ``previous_removed_tracklet_ids`` after the MaskManager call for that frame.
+    They are then consumed by MaskManager on the next frame, matching the original McByte timing.
     """
     grouped: dict[str, list[int]] = defaultdict(list)
     for event in events:

--- a/src/trackers/cli/inspect/mcbyte.py
+++ b/src/trackers/cli/inspect/mcbyte.py
@@ -226,10 +226,9 @@ def prepare_run_directory(
 ) -> tuple[Path, Path]:
     """Create the output directory for one comparison mode.
 
-    ``output_root`` is a fresh run directory, so the mode directory starts empty
-    without deleting anything. Frames are named after the frame number, and a
-    shorter re-run into a populated directory would leave stale frames from a
-    longer previous run interleaved with the new ones.
+    ``output_root`` is a fresh run directory, so the mode directory starts empty without deleting anything. Frames are
+    named after the frame number, and a shorter re-run into a populated directory would leave stale frames from a longer
+    previous run interleaved with the new ones.
     """
     run_dir = output_root / mode_name
     frames_dir = run_dir / "frames"
@@ -357,8 +356,7 @@ def run_mode(
 ) -> None:
     """Run one McByte configuration over the requested inclusive frame range.
 
-    Tracking results are written in MOTChallenge format and one annotated image is
-    saved for every processed frame.
+    Tracking results are written in MOTChallenge format and one annotated image is saved for every processed frame.
     """
     use_masks = mode_name == "mask_conditioned"
 

--- a/src/trackers/core/base.py
+++ b/src/trackers/core/base.py
@@ -27,8 +27,7 @@ from trackers.utils.predict_timing import PredictTiming
 class ParameterInfo:
     """Holds metadata for a single tracker parameter.
 
-    Stores the type, default value, and description extracted from the
-    tracker's __init__ signature and docstring.
+    Stores the type, default value, and description extracted from the tracker's __init__ signature and docstring.
     """
 
     param_type: type
@@ -57,8 +56,7 @@ class TrackerParameters(dict[str, ParameterInfo]):
 class TrackerInfo:
     """Holds a tracker class and its extracted parameter metadata.
 
-    Used by the CLI to discover available trackers and their configurable
-    options without instantiating them.
+    Used by the CLI to discover available trackers and their configurable options without instantiating them.
     """
 
     tracker_class: type[BaseTracker]
@@ -373,8 +371,8 @@ class BaseTracker(ABC):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Register subclass in the tracker registry if it defines tracker_id.
 
-        Extracts parameter metadata from __init__ at class definition time.
-        Validates search_space (if present) against __init__ parameters.
+        Extracts parameter metadata from __init__ at class definition time. Validates search_space (if present) against
+        __init__ parameters.
         """
         super().__init_subclass__(**kwargs)
 
@@ -537,14 +535,13 @@ class BaseTracker(ABC):
     def _prune_lost_tracks(self, timing: PredictTiming) -> None:
         """Remove tracks that exceed their lost-track budget (ghost-ID prevention).
 
-        Applies a budget-only filter so immature tracks stay alive for matching.
-        Call after ``_predict_tracklets`` and before association.
+        Applies a budget-only filter so immature tracks stay alive for matching. Call after ``_predict_tracklets`` and
+        before association.
 
-        At fixed frame rate (no timestamps) this is a no-op — the frame-count
-        budget is enforced post-association, preserving the last-frame re-association
-        opportunity that the original trackers relied on.  In variable-FPS mode the
-        time budget can differ from the frame budget, so expired-by-time tracks are
-        removed here before they can be matched and revived with a stale ID.
+        At fixed frame rate (no timestamps) this is a no-op — the frame-count budget is enforced post-association,
+        preserving the last-frame re-association opportunity that the original trackers relied on.  In variable-FPS mode
+        the time budget can differ from the frame budget, so expired-by-time tracks are removed here before they can be
+        matched and revived with a stale ID.
         """
         budget = self._lost_track_time_budget(timing, self.maximum_time_without_update)
         if budget is None:

--- a/src/trackers/core/botsort/tracker.py
+++ b/src/trackers/core/botsort/tracker.py
@@ -24,8 +24,7 @@ from trackers.utils.state_representations import (
 
 
 class BoTSORTTracker(BaseTracker):
-    """
-    BoT-SORT-style multi-object tracker (IoU association + optional CMC).
+    """BoT-SORT-style multi-object tracker (IoU association + optional CMC).
 
     The tracker maintains a list of active tracks (Kalman-filter-based) and, for each
     frame, performs:
@@ -395,10 +394,8 @@ class BoTSORTTracker(BaseTracker):
         similarity_matrix: np.ndarray,
         min_similarity_thresh: float,
     ) -> tuple[list[tuple[int, int]], list[int], list[int]]:
-        """
-        Associate detections to tracks based on Similarity (IoU) using the
-        Jonker-Volgenant algorithm approach with no initialization instead of the
-        Hungarian algorithm as mentioned in the SORT paper, but it solves the
+        """Associate detections to tracks based on Similarity (IoU) using the Jonker-Volgenant algorithm approach with
+        no initialization instead of the Hungarian algorithm as mentioned in the SORT paper, but it solves the
         assignment problem in an optimal way.
 
         Args:
@@ -465,6 +462,7 @@ class BoTSORTTracker(BaseTracker):
 
     def reset(self) -> None:
         """Reset tracker state by clearing all tracks and resetting ID counter.
+
         Call this method when switching to a new video or scene.
         """
         self.tracks = []

--- a/src/trackers/core/botsort/tracklet.py
+++ b/src/trackers/core/botsort/tracklet.py
@@ -179,10 +179,8 @@ class BoTSORTTracklet(BaseTracklet):
     def update(self, bbox: np.ndarray) -> None:
         """Update tracklet with a new observation.
 
-        In the BoT-SORT flow **only matched tracks** call ``update(bbox)``
-        with an actual bounding box.  Unmatched tracks simply skip
-        ``update`` (their ``time_since_update`` is incremented in
-        ``predict`` instead).
+        In the BoT-SORT flow **only matched tracks** call ``update(bbox)`` with an actual bounding box.  Unmatched
+        tracks simply skip ``update`` (their ``time_since_update`` is incremented in ``predict`` instead).
         """
         self._refresh_noise_from_state()
         self.state_estimator.update(bbox)
@@ -194,9 +192,8 @@ class BoTSORTTracklet(BaseTracklet):
     def predict(self, timing: PredictTiming = FIXED_RATE_TIMING) -> np.ndarray:
         """Predict the next bounding-box position.
 
-        Increments ``time_since_update`` to track how many frames have
-        elapsed since the last matched measurement — this replaces the
-        ``update(None)`` call used in ByteTrack/SORT.
+        Increments ``time_since_update`` to track how many frames have elapsed since the last matched measurement — this
+        replaces the ``update(None)`` call used in ByteTrack/SORT.
         """
         self._refresh_noise_from_state()
         self.state_estimator.predict(timing.frame_step, timing.frame_rate)

--- a/src/trackers/core/botsort/utils.py
+++ b/src/trackers/core/botsort/utils.py
@@ -18,8 +18,7 @@ def get_alive_tracklets(
     maximum_frames_without_update: int,
     maximum_time_without_update: float | None = None,
 ) -> list[BoTSORTTracklet]:
-    """
-    Remove dead or immature lost tracklets and return alive ones.
+    """Remove dead or immature lost tracklets and return alive ones.
 
     A tracklet is kept if it is within ``maximum_frames_without_update`` **and**
     it satisfies at least one liveness condition:

--- a/src/trackers/core/bytetrack/tracker.py
+++ b/src/trackers/core/bytetrack/tracker.py
@@ -22,15 +22,13 @@ from trackers.utils.state_representations import (
 
 
 class ByteTrackTracker(BaseTracker):
-    """ByteTrack operates online by processing all detector outputs, categorizing them
-    by confidence thresholds to enable a two-stage association process. High-score boxes
-    are initially linked to tracklets via Kalman filter predictions and IoU-based
-    Hungarian matching, optionally enhanced with appearance features. Low-score boxes
-    follow in a secondary matching phase using pure motion similarity to revive occluded
-    tracks. Tracks without matches are kept briefly for potential re-association,
-    preventing premature termination. This inclusive approach addresses common pitfalls
-    in detection filtering, establishing ByteTrack as a flexible enhancer for existing
-    tracking frameworks.
+    """ByteTrack operates online by processing all detector outputs, categorizing them by confidence thresholds to
+    enable a two-stage association process. High-score boxes are initially linked to tracklets via Kalman filter
+    predictions and IoU-based Hungarian matching, optionally enhanced with appearance features. Low-score boxes follow
+    in a secondary matching phase using pure motion similarity to revive occluded tracks. Tracks without matches are
+    kept briefly for potential re-association, preventing premature termination. This inclusive approach addresses
+    common pitfalls in detection filtering, establishing ByteTrack as a flexible enhancer for existing tracking
+    frameworks.
 
     ByteTrack excels in dense environments, where its low-score recovery mechanism
     minimizes missed detections and enhances overall trajectory completeness. It
@@ -250,10 +248,8 @@ class ByteTrackTracker(BaseTracker):
         similarity_matrix: np.ndarray,
         min_similarity_thresh: float,
     ) -> tuple[list[tuple[int, int]], list[int], list[int]]:
-        """
-        Associate detections to tracks based on Similarity (IoU) using the
-        Jonker-Volgenant algorithm approach with no initialization instead of the
-        Hungarian algorithm as mentioned in the SORT paper, but it solves the
+        """Associate detections to tracks based on Similarity (IoU) using the Jonker-Volgenant algorithm approach with
+        no initialization instead of the Hungarian algorithm as mentioned in the SORT paper, but it solves the
         assignment problem in an optimal way.
 
         Args:
@@ -310,6 +306,7 @@ class ByteTrackTracker(BaseTracker):
 
     def reset(self) -> None:
         """Reset tracker state by clearing all tracks and resetting ID counter.
+
         Call this method when switching to a new video or scene.
         """
         self.tracks = []

--- a/src/trackers/core/bytetrack/utils.py
+++ b/src/trackers/core/bytetrack/utils.py
@@ -18,9 +18,8 @@ def _get_alive_tracklets(
     maximum_frames_without_update: int,
     maximum_time_without_update: float | None = None,
 ) -> list[T_ByteTrackTracklet]:
-    """
-    Remove dead or immature lost tracklets and return alive trackers
-    that are within the time/frame budget AND (mature OR just updated).
+    """Remove dead or immature lost tracklets and return alive trackers that are within the time/frame budget AND
+    (mature OR just updated).
 
     Note:
         Maturity is sticky: once a tracklet has reached

--- a/src/trackers/core/masks/cutie.py
+++ b/src/trackers/core/masks/cutie.py
@@ -26,9 +26,8 @@ CUTIE_RELEASE_URL = "https://github.com/hkchengrex/Cutie/releases/download/v1.0"
 class CutieAsset(Enum):
     """Known downloadable Cutie checkpoint assets.
 
-    Each member pairs a checkpoint filename with its expected MD5 checksum,
-    used to locate, download, and validate the default weights for a given
-    Cutie ``model_type``.
+    Each member pairs a checkpoint filename with its expected MD5 checksum, used to locate, download, and validate the
+    default weights for a given Cutie ``model_type``.
     """
 
     BASE_MEGA = (
@@ -83,7 +82,6 @@ def _ensure_weights_exist(
 
 def _get_cutie_package_dir(cutie_module: Any) -> Path:
     """Return the root directory of the installed Cutie package."""
-
     if getattr(cutie_module, "__file__", None) is not None:
         return Path(cutie_module.__file__).resolve().parent
 
@@ -145,9 +143,7 @@ def _image_to_torch(
     frame: np.ndarray,
     device: torch.device,
 ) -> torch.Tensor:
-    """Convert an RGB frame from ``(H, W, 3)`` NumPy format to ``(3, H, W)`` Cutie
-    tensor format.
-    """
+    """Convert an RGB frame from ``(H, W, 3)`` NumPy format to ``(3, H, W)`` Cutie tensor format."""
     # Normalize by dtype, not by pixel magnitude. A ``max() > 1`` heuristic
     # mis-scales a near-black uint8 frame whose brightest pixel is 0 or 1
     # (treated as already-normalized and left un-divided). An unsigned-integer
@@ -304,9 +300,9 @@ def _binary_masks_to_non_overlapping_torch(
 ) -> torch.Tensor:
     """Convert binary masks to non-overlapping Cutie mask channels.
 
-    Input masks have shape ``(N, H, W)``. If masks overlap, earlier masks keep
-    priority, matching the original McByte initialization behavior. The returned
-    tensor has shape ``(N, H, W)``, dtype ``float32``, and values ``0.0`` or ``1.0``.
+    Input masks have shape ``(N, H, W)``. If masks overlap, earlier masks keep priority, matching the original McByte
+    initialization behavior. The returned tensor has shape ``(N, H, W)``, dtype ``float32``, and values ``0.0`` or
+    ``1.0``.
     """
     # Coerce to bool for the same reason as _binary_masks_to_indexed_mask:
     # ``mask & ~occupied`` requires boolean arrays to act as set difference.
@@ -342,8 +338,8 @@ def _build_tracklet_object_dict(
 ) -> dict[int, int]:
     """Map tracklet IDs to Cutie object IDs.
 
-    Mask generators return local mask array indices starting from 0. Cutie uses
-    positive object IDs, with 0 reserved for background.
+    Mask generators return local mask array indices starting from 0. Cutie uses positive object IDs, with 0 reserved for
+    background.
     """
     return {tracklet_id: local_mask_index + 1 for tracklet_id, local_mask_index in tracklet_mask_dict.items()}
 
@@ -356,13 +352,11 @@ def _compute_mask_avg_prob_dict(
 ) -> dict[int, float]:
     """Compute average Cutie confidence for each predicted object region.
 
-    The input probability tensor has shape ``(num_objects + 1, H, W)``, where
-    channel 0 is background and channels ``1..num_objects`` follow Cutie's
-    current temporary object IDs. For each immutable object ID, confidence is
-    averaged over pixels where that object's current temporary ID wins the argmax
-    prediction. ``max_result`` optionally supplies a precomputed
-    ``torch.max(prob, dim=0)`` so callers that already reduced ``prob`` (for the
-    indexed mask) avoid a second full-resolution pass.
+    The input probability tensor has shape ``(num_objects + 1, H, W)``, where channel 0 is background and channels
+    ``1..num_objects`` follow Cutie's current temporary object IDs. For each immutable object ID, confidence is averaged
+    over pixels where that object's current temporary ID wins the argmax prediction. ``max_result`` optionally supplies
+    a precomputed ``torch.max(prob, dim=0)`` so callers that already reduced ``prob`` (for the indexed mask) avoid a
+    second full-resolution pass.
     """
     num_channels = int(prob.shape[0])
     if max_result is None:
@@ -763,11 +757,9 @@ class CutieMaskPropagator(MaskPropagator):
     ) -> Any:
         """Load Cutie Hydra config and inject runtime overrides.
 
-        Besides the selected weights path, streaming-oriented runtime options
-        (``max_internal_size``, ``mem_every``, ``use_long_term``) are written
-        into the top-level config. Non-``None`` top-level values survive
-        Cutie's ``get_dataset_cfg`` escalation and are read by
-        ``InferenceCore`` and ``MemoryManager`` at construction time.
+        Besides the selected weights path, streaming-oriented runtime options (``max_internal_size``, ``mem_every``,
+        ``use_long_term``) are written into the top-level config. Non-``None`` top-level values survive Cutie's
+        ``get_dataset_cfg`` escalation and are read by ``InferenceCore`` and ``MemoryManager`` at construction time.
         """
         try:
             from hydra import compose, initialize_config_dir
@@ -819,10 +811,9 @@ class CutieMaskPropagator(MaskPropagator):
     ) -> None:
         """Add externally generated masks to Cutie memory.
 
-        This method does not create masks itself. It receives masks through
-        ``MaskOutput``, for example from ``SAMBoxMaskGenerator``. The method assigns
-        new immutable Cutie object IDs, feeds the masks into Cutie memory on the
-        given reference frame, and updates the propagator's tracklet/object state.
+        This method does not create masks itself. It receives masks through ``MaskOutput``, for example from
+        ``SAMBoxMaskGenerator``. The method assigns new immutable Cutie object IDs, feeds the masks into Cutie memory on
+        the given reference frame, and updates the propagator's tracklet/object state.
         """
         if not self._initialized:
             raise RuntimeError(

--- a/src/trackers/core/masks/dummy.py
+++ b/src/trackers/core/masks/dummy.py
@@ -60,9 +60,8 @@ class DummyBoxMaskGenerator(MaskGenerator):
 class DummyIdentityMaskPropagator(MaskPropagator):
     """In-memory mask propagator used for lightweight MaskManager tests.
 
-    The propagator keeps the last initialized ``MaskOutput`` and returns copies
-    of it during propagation. It also supports simple add/remove lifecycle
-    operations so MaskManager tests can validate mask indexing without requiring
+    The propagator keeps the last initialized ``MaskOutput`` and returns copies of it during propagation. It also
+    supports simple add/remove lifecycle operations so MaskManager tests can validate mask indexing without requiring
     SAM, Cutie, checkpoints, or GPU.
     """
 

--- a/src/trackers/core/masks/sam.py
+++ b/src/trackers/core/masks/sam.py
@@ -203,9 +203,8 @@ class SAMBoxMaskGenerator(MaskGenerator):
     def _convert_masks(self, masks: Any) -> np.ndarray:
         """Convert SAM mask tensor to McByte mask format.
 
-        SAM returns masks with shape ``(N, C, H, W)``, where ``C`` is the number
-        of candidate masks per prompt. With ``multimask_output=False``, ``C`` is
-        expected to be 1. McByte keeps one binary mask per tracklet, so this method
+        SAM returns masks with shape ``(N, C, H, W)``, where ``C`` is the number of candidate masks per prompt. With
+        ``multimask_output=False``, ``C`` is expected to be 1. McByte keeps one binary mask per tracklet, so this method
         converts the tensor to a NumPy array with shape ``(N, H, W)``.
         """
         masks_np = masks.detach().cpu().numpy()

--- a/src/trackers/core/mcbyte/mask_association.py
+++ b/src/trackers/core/mcbyte/mask_association.py
@@ -88,9 +88,8 @@ def _get_clear_matches(
 ) -> list[tuple[int, int]]:
     """Return threshold-valid pairs that are unique in both row and column.
 
-    Eligibility is determined from the untouched similarity matrix. A pair is
-    clear when it is the only threshold-valid candidate for both its tracklet
-    row and its detection column.
+    Eligibility is determined from the untouched similarity matrix. A pair is clear when it is the only threshold-valid
+    candidate for both its tracklet row and its detection column.
     """
     eligible = similarity >= minimum_similarity
     row_candidate_counts = eligible.sum(axis=1)
@@ -135,9 +134,8 @@ def _get_ambiguous_candidate_matrix(
 ) -> np.ndarray:
     """Return eligible pairs belonging to an ambiguous row or column.
 
-    Ambiguity is always computed from the untouched base similarity matrix.
-    A pair is ambiguous when its tracklet has multiple eligible detections or
-    its detection has multiple eligible tracklets.
+    Ambiguity is always computed from the untouched base similarity matrix. A pair is ambiguous when its tracklet has
+    multiple eligible detections or its detection has multiple eligible tracklets.
     """
     eligible = similarity >= minimum_similarity
     ambiguous_rows = eligible.sum(axis=1) > 1
@@ -153,9 +151,8 @@ def _get_isolated_candidate_matrix(
 ) -> np.ndarray:
     """Return isolated positive-IoU pairs below the normal threshold.
 
-    A pair is isolated when it is the only positive-IoU edge in both its row
-    and its column. Isolation is based exclusively on raw IoU geometry, not on
-    score-fused similarity.
+    A pair is isolated when it is the only positive-IoU edge in both its row and its column. Isolation is based
+    exclusively on raw IoU geometry, not on score-fused similarity.
     """
     positive_iou = raw_iou_similarity > 0.0
     isolated_rows = positive_iou.sum(axis=1) == 1

--- a/src/trackers/core/mcbyte/tracker.py
+++ b/src/trackers/core/mcbyte/tracker.py
@@ -150,7 +150,6 @@ def _build_default_mask_manager(
     config: McByteMaskConfig,
 ) -> MaskManager:
     """Create McByte's standard SAM + Cutie mask-management pipeline."""
-
     from trackers.core.masks.cutie import CutieMaskPropagator
     from trackers.core.masks.sam import SAMBoxMaskGenerator
 
@@ -759,8 +758,8 @@ class McByteTracker(BaseTracker):
     ) -> list[TrackletSnapshot]:
         """Convert tracker output detections into mask-manager tracklet snapshots.
 
-        Only detections with valid non-negative tracker IDs are converted. The returned
-        snapshots contain the tracker ID and ``xyxy`` box needed by mask generators.
+        Only detections with valid non-negative tracker IDs are converted. The returned snapshots contain the tracker ID
+        and ``xyxy`` box needed by mask generators.
         """
         if detections.tracker_id is None:
             return []
@@ -782,10 +781,9 @@ class McByteTracker(BaseTracker):
     ) -> None:
         """Store tracker outputs and mask lifecycle events for the next frame.
 
-        The mask manager consumes these values at the beginning of the next ``update()``
-        call. New tracklets are detected among current visible outputs that do not yet
-        have masks. Removed tracklets are provided explicitly from tracker pruning, so
-        temporarily lost but still alive tracklets keep their masks.
+        The mask manager consumes these values at the beginning of the next ``update()`` call. New tracklets are
+        detected among current visible outputs that do not yet have masks. Removed tracklets are provided explicitly
+        from tracker pruning, so temporarily lost but still alive tracklets keep their masks.
         """
         if self.mask_manager is None or frame is None:
             self._previous_frame = None
@@ -1020,10 +1018,8 @@ class McByteTracker(BaseTracker):
         similarity_matrix: np.ndarray,
         min_similarity_thresh: float,
     ) -> tuple[list[tuple[int, int]], list[int], list[int]]:
-        """
-        Associate detections to tracks based on Similarity (IoU) using the
-        Jonker-Volgenant algorithm approach with no initialization instead of the
-        Hungarian algorithm as mentioned in the SORT paper, but it solves the
+        """Associate detections to tracks based on Similarity (IoU) using the Jonker-Volgenant algorithm approach with
+        no initialization instead of the Hungarian algorithm as mentioned in the SORT paper, but it solves the
         assignment problem in an optimal way.
 
         Args:
@@ -1100,9 +1096,9 @@ class McByteTracker(BaseTracker):
     def reset(self) -> None:
         """Reset tracker, camera-motion, and mask-manager state.
 
-        This clears active tracklets, resets the global McByte track ID counter, clears
-        stored mask lifecycle inputs, and resets optional camera motion compensation and
-        mask-manager components. Call this when switching to a new video or scene.
+        This clears active tracklets, resets the global McByte track ID counter, clears stored mask lifecycle inputs,
+        and resets optional camera motion compensation and mask-manager components. Call this when switching to a new
+        video or scene.
         """
         self.tracks = []
         self.frame_id = 0

--- a/src/trackers/core/mcbyte/tracklet.py
+++ b/src/trackers/core/mcbyte/tracklet.py
@@ -179,10 +179,8 @@ class McByteTracklet(BaseTracklet):
     def update(self, bbox: np.ndarray) -> None:
         """Update tracklet with a new observation.
 
-        In the McByte flow **only matched tracks** call ``update(bbox)``
-        with an actual bounding box.  Unmatched tracks simply skip
-        ``update`` (their ``time_since_update`` is incremented in
-        ``predict`` instead).
+        In the McByte flow **only matched tracks** call ``update(bbox)`` with an actual bounding box.  Unmatched tracks
+        simply skip ``update`` (their ``time_since_update`` is incremented in ``predict`` instead).
         """
         self._refresh_noise_from_state()
         self.state_estimator.update(bbox)

--- a/src/trackers/core/ocsort/tracker.py
+++ b/src/trackers/core/ocsort/tracker.py
@@ -24,15 +24,12 @@ from trackers.utils.state_representations import (
 
 
 class OCSORTTracker(BaseTracker):
-    """OC-SORT enhances traditional SORT by shifting to an observation-centric paradigm,
-    using detections to correct Kalman filter errors accumulated during occlusions. It
-    introduces Observation-Centric Re-Update to generate virtual trajectories for
-    parameter refinement upon track reactivation. Association incorporates
-    Observation-Centric Momentum, blending IoU with direction consistency from
-    historical observations. Short-term recoveries are aided by heuristics linking
-    unmatched tracks to prior detections. This rethinking prioritizes real measurements
-    over estimations, making OC-SORT particularly adept at handling real-world tracking
-    challenges.
+    """OC-SORT enhances traditional SORT by shifting to an observation-centric paradigm, using detections to correct
+    Kalman filter errors accumulated during occlusions. It introduces Observation-Centric Re-Update to generate virtual
+    trajectories for parameter refinement upon track reactivation. Association incorporates Observation-Centric
+    Momentum, blending IoU with direction consistency from historical observations. Short-term recoveries are aided by
+    heuristics linking unmatched tracks to prior detections. This rethinking prioritizes real measurements over
+    estimations, making OC-SORT particularly adept at handling real-world tracking challenges.
 
     OC-SORT's primary strength is its robustness to non-linear motions and occlusions,
     outperforming baselines on datasets with erratic movements like DanceTrack. It
@@ -123,8 +120,7 @@ class OCSORTTracker(BaseTracker):
         iou_matrix: np.ndarray,
         direction_consistency_matrix: np.ndarray | None,
     ) -> tuple[list[tuple[int, int]], list[int], list[int]]:
-        """
-        Associate detections to tracks based on IOU.
+        """Associate detections to tracks based on IOU.
 
         Args:
             iou_matrix: IOU cost matrix.
@@ -327,6 +323,7 @@ class OCSORTTracker(BaseTracker):
 
     def reset(self) -> None:
         """Reset tracker state by clearing all tracks and resetting ID counter.
+
         Call this method when switching to a new video or scene.
         """
         self.tracks = []
@@ -356,8 +353,7 @@ class OCSORTTracker(BaseTracker):
         ]
 
     def _compute_direction_consistency_matrix(self, detection_boxes: np.ndarray, confidences: np.ndarray) -> np.ndarray:
-        """Compute the direction consistency matrix for association,
-        including confidence scaling."""
+        """Compute the direction consistency matrix for association, including confidence scaling."""
         tracklet_velocities = np.array(
             [t.velocity if t.velocity is not None else np.array([0.0, 0.0]) for t in self.tracks]
         )

--- a/src/trackers/core/ocsort/tracklet.py
+++ b/src/trackers/core/ocsort/tracklet.py
@@ -59,7 +59,6 @@ class OCSORTTracklet(BaseTracklet):
                 Higher values use observations further in the past to estimate
                 motion direction, providing more stable velocity estimates.
         """
-
         # Initialize state estimator (wraps KalmanFilter + state repr)
         super().__init__(initial_bbox, state_estimator_class)
         self._configure_noise()
@@ -109,10 +108,9 @@ class OCSORTTracklet(BaseTracklet):
     def _unfreeze_xcycsr(self, new_bbox: np.ndarray, time_gap: int, sub_step: float) -> None:
         """ORU interpolation for XCYCSR representation.
 
-        Generates time_gap predict+update cycles with virtual observations
-        interpolated from the last observation to the new bbox. The interpolation
-        factors go from 0 to (time_gap-1)/time_gap. The caller is responsible
-        for the final real update at factor 1.0.
+        Generates time_gap predict+update cycles with virtual observations interpolated from the last observation to the
+        new bbox. The interpolation factors go from 0 to (time_gap-1)/time_gap. The caller is responsible for the final
+        real update at factor 1.0.
         """
         # Convert to (x, y, s, r) format
         last_xcycsr = xyxy_to_xcycsr(self.last_observation)

--- a/src/trackers/core/sort/tracker.py
+++ b/src/trackers/core/sort/tracker.py
@@ -23,14 +23,12 @@ from trackers.utils.state_representations import (
 
 
 class SORTTracker(BaseTracker):
-    """In SORT, object tracking begins with high-confidence detections fed into a
-    Kalman filter framework assuming uniform motion for state prediction across frames.
-    Association occurs via IoU-based costs in the Hungarian algorithm, enforcing a
-    threshold to filter weak matches and initialize new identities. Tracks persist only
-    with consistent associations, terminating quickly to avoid erroneous propagation.
-    This detection-driven approach underscores the importance of upstream detector
-    performance in achieving competitive multi-object tracking results. Over time, SORT
-    has become a cornerstone for evaluating motion-based improvements in the field.
+    """In SORT, object tracking begins with high-confidence detections fed into a Kalman filter framework assuming
+    uniform motion for state prediction across frames. Association occurs via IoU-based costs in the Hungarian
+    algorithm, enforcing a threshold to filter weak matches and initialize new identities. Tracks persist only with
+    consistent associations, terminating quickly to avoid erroneous propagation. This detection-driven approach
+    underscores the importance of upstream detector performance in achieving competitive multi-object tracking results.
+    Over time, SORT has become a cornerstone for evaluating motion-based improvements in the field.
 
     SORT's standout strength is its real-time capability, processing hundreds of frames
     per second while maintaining accuracy comparable to more complex offline methods. It
@@ -119,8 +117,7 @@ class SORTTracker(BaseTracker):
     def _get_associated_indices(
         self, iou_matrix: np.ndarray, detection_boxes: np.ndarray
     ) -> tuple[list[tuple[int, int]], list[int], list[int]]:
-        """
-        Associate detections to tracks based on IOU
+        """Associate detections to tracks based on IOU.
 
         Args:
             iou_matrix: IOU cost matrix.
@@ -257,6 +254,7 @@ class SORTTracker(BaseTracker):
 
     def reset(self) -> None:
         """Reset tracker state by clearing all tracks and resetting ID counter.
+
         Call this method when switching to a new video or scene.
         """
         self.tracks = []

--- a/src/trackers/core/sort/tracklet.py
+++ b/src/trackers/core/sort/tracklet.py
@@ -57,8 +57,7 @@ class SORTTracklet(BaseTracklet):
         return self.state_estimator.state_to_bbox()
 
     def _configure_noise(self) -> None:
-        """Configure Kalman filter noise matrices (OC-SORT paper behaviour) and SORT
-        behaviour for XYXY coordinates."""
+        """Configure Kalman filter noise matrices (OC-SORT paper behaviour) and SORT behaviour for XYXY coordinates."""
         kf = self.state_estimator.kf
         measurement_noise = kf.measurement_noise
         state_covariance = kf.state_covariance

--- a/src/trackers/core/sort/utils.py
+++ b/src/trackers/core/sort/utils.py
@@ -19,9 +19,8 @@ def _get_alive_tracklets(
     maximum_frames_without_update: int,
     maximum_time_without_update: float | None = None,
 ) -> list[T_SORTTracklet]:
-    """
-    Remove dead or immature lost tracklets and return alive trackers
-    that are within the time/frame budget AND (mature OR just updated).
+    """Remove dead or immature lost tracklets and return alive trackers that are within the time/frame budget AND
+    (mature OR just updated).
 
     Note:
         SORT uses total `number_of_successful_updates` (cumulative) for maturity,

--- a/src/trackers/eval/results.py
+++ b/src/trackers/eval/results.py
@@ -6,8 +6,8 @@
 
 """Result classes for tracking evaluation metrics.
 
-This module provides dataclasses for storing and manipulating evaluation results
-with methods for serialization, display, and persistence.
+This module provides dataclasses for storing and manipulating evaluation results with methods for serialization,
+display, and persistence.
 """
 
 from __future__ import annotations
@@ -82,8 +82,9 @@ ALL_FLOAT_FIELDS = CLEAR_FLOAT_FIELDS + HOTA_FLOAT_FIELDS + IDENTITY_FLOAT_FIELD
 
 @dataclass
 class CLEARMetrics:
-    """CLEAR metrics with TrackEval-compatible field names. Float metrics are stored
-    as fractions (0-1 range), not percentages. The values follow the original CLEAR
+    """CLEAR metrics with TrackEval-compatible field names.
+
+    Float metrics are stored as fractions (0-1 range), not percentages. The values follow the original CLEAR
     MOT definitions.
 
     Attributes:
@@ -180,8 +181,9 @@ class CLEARMetrics:
 
 @dataclass
 class HOTAMetrics:
-    """HOTA metrics with TrackEval-compatible field names. HOTA evaluates both
-    detection quality and association quality. Float metrics are stored as fractions
+    """HOTA metrics with TrackEval-compatible field names.
+
+    HOTA evaluates both detection quality and association quality. Float metrics are stored as fractions
     (0-1 range).
 
     Attributes:
@@ -294,8 +296,9 @@ class HOTAMetrics:
 
 @dataclass
 class IdentityMetrics:
-    """Identity metrics with TrackEval-compatible field names. Identity metrics
-    measure global ID consistency using an optimal one-to-one assignment between GT
+    """Identity metrics with TrackEval-compatible field names.
+
+    Identity metrics measure global ID consistency using an optimal one-to-one assignment between GT
     and tracker IDs across the full sequence.
 
     Attributes:

--- a/src/trackers/io/paths.py
+++ b/src/trackers/io/paths.py
@@ -14,8 +14,7 @@ from pathlib import Path
 def _resolve_video_output_path(path: Path) -> Path:
     """Resolve video output path, handling directories.
 
-    If path is an existing directory, generates 'output.mp4' inside it.
-    If path has no extension, adds '.mp4'.
+    If path is an existing directory, generates 'output.mp4' inside it. If path has no extension, adds '.mp4'.
     """
     if path.is_dir():
         return path / "output.mp4"

--- a/src/trackers/io/video.py
+++ b/src/trackers/io/video.py
@@ -99,18 +99,16 @@ class _VideoOutput:
 
     def write(self, frame: np.ndarray) -> bool:
         """Write a frame to the video file; initializes writer on first call.
-                The writer is bound to the first frame's resolution, and a video file
-                cannot hold frames of mixed sizes. A later frame of a different size
-                (e.g. a mid-stream resolution change from an RTSP renegotiation) is
-                resized to the writer's resolution so it is kept in the output stream
-                rather than being silently dropped by the codec. This guarantee only
-                covers height/width mismatches: the writer is opened with
-                `isColor=True` and channel count is not reconciled, so a mid-stream
-                frame with a different number of channels (e.g. single-channel
-                grayscale) can still be silently dropped by the codec.
 
-                Returns:
-                    True if write succeeded or path is None, False on failure.
+        The writer is bound to the first frame's resolution, and a video file cannot hold frames of mixed sizes.
+        A later frame of a different size (e.g. a mid-
+        stream resolution change from an RTSP renegotiation) is resized to the writer's resolution so it is kept in the
+        output stream rather than being silently dropped by the codec. This guarantee only covers height/width
+        mismatches: the writer is opened with `isColor=True` and channel count is not reconciled, so a mid-stream frame
+        with a different number of channels (e.g. single-channel grayscale) can still be silently dropped by the codec.
+
+        Returns:
+            True if write succeeded or path is None, False on failure.
         """
         if self.path is None:
             return True

--- a/src/trackers/io/video.py
+++ b/src/trackers/io/video.py
@@ -98,12 +98,17 @@ class _VideoOutput:
         self._size_mismatch_logged = False
 
     def write(self, frame: np.ndarray) -> bool:
-        """Write a frame to the video file; initializes writer on first call. The writer is bound to the first frame's
-        resolution, and a video file cannot hold frames of mixed sizes. A later frame of a different size (e.g. a mid-
-        stream resolution change from an RTSP renegotiation) is resized to the writer's resolution so it is kept in the
-        output stream rather than being silently dropped by the codec. This guarantee only covers height/width
-        mismatches: the writer is opened with `isColor=True` and channel count is not reconciled, so a mid-stream frame
-        with a different number of channels (e.g. single-channel grayscale) can still be silently dropped by the codec.
+        """Write a frame to the video file; initializes writer on first call.
+
+        The writer is bound to the first frame's resolution, and a video file
+        cannot hold frames of mixed sizes. A later frame of a different size
+        (e.g. a mid-stream resolution change from an RTSP renegotiation) is
+        resized to the writer's resolution so it is kept in the output stream
+        rather than being silently dropped by the codec. This guarantee only
+        covers height/width mismatches: the writer is opened with `isColor=True`
+        and channel count is not reconciled, so a mid-stream frame with a
+        different number of channels (e.g. single-channel grayscale) can still
+        be silently dropped by the codec.
 
         Returns:
             True if write succeeded or path is None, False on failure.

--- a/src/trackers/io/video.py
+++ b/src/trackers/io/video.py
@@ -98,19 +98,15 @@ class _VideoOutput:
         self._size_mismatch_logged = False
 
     def write(self, frame: np.ndarray) -> bool:
-        """Write a frame to the video file; initializes writer on first call.
-                The writer is bound to the first frame's resolution, and a video file
-                cannot hold frames of mixed sizes. A later frame of a different size
-                (e.g. a mid-stream resolution change from an RTSP renegotiation) is
-                resized to the writer's resolution so it is kept in the output stream
-                rather than being silently dropped by the codec. This guarantee only
-                covers height/width mismatches: the writer is opened with
-                `isColor=True` and channel count is not reconciled, so a mid-stream
-                frame with a different number of channels (e.g. single-channel
-                grayscale) can still be silently dropped by the codec.
+        """Write a frame to the video file; initializes writer on first call. The writer is bound to the first frame's
+        resolution, and a video file cannot hold frames of mixed sizes. A later frame of a different size (e.g. a mid-
+        stream resolution change from an RTSP renegotiation) is resized to the writer's resolution so it is kept in the
+        output stream rather than being silently dropped by the codec. This guarantee only covers height/width
+        mismatches: the writer is opened with `isColor=True` and channel count is not reconciled, so a mid-stream frame
+        with a different number of channels (e.g. single-channel grayscale) can still be silently dropped by the codec.
 
-                Returns:
-                    True if write succeeded or path is None, False on failure.
+        Returns:
+            True if write succeeded or path is None, False on failure.
         """
         if self.path is None:
             return True

--- a/src/trackers/io/video.py
+++ b/src/trackers/io/video.py
@@ -24,8 +24,7 @@ _DEFAULT_OUTPUT_FPS = 30.0
 def frames_from_source(
     source: str | Path | int,
 ) -> Iterator[tuple[int, np.ndarray]]:
-    """Yield numbered BGR frames from video files, webcams, network streams, or image
-    directories.
+    """Yield numbered BGR frames from video files, webcams, network streams, or image directories.
 
     Args:
         source: Video file path, RTSP/HTTP stream URL, webcam index, or path to a
@@ -99,20 +98,21 @@ class _VideoOutput:
         self._size_mismatch_logged = False
 
     def write(self, frame: np.ndarray) -> bool:
-        """Write a frame to the video file. Initializes writer on first call.
+        """Write a frame to the video file.
 
-        The writer is bound to the first frame's resolution, and a video file
-        cannot hold frames of mixed sizes. A later frame of a different size
-        (e.g. a mid-stream resolution change from an RTSP renegotiation) is
-        resized to the writer's resolution so it is kept in the output stream
-        rather than being silently dropped by the codec. This guarantee only
-        covers height/width mismatches: the writer is opened with
-        `isColor=True` and channel count is not reconciled, so a mid-stream
-        frame with a different number of channels (e.g. single-channel
-        grayscale) can still be silently dropped by the codec.
+        Initializes writer on first call.
+                The writer is bound to the first frame's resolution, and a video file
+                cannot hold frames of mixed sizes. A later frame of a different size
+                (e.g. a mid-stream resolution change from an RTSP renegotiation) is
+                resized to the writer's resolution so it is kept in the output stream
+                rather than being silently dropped by the codec. This guarantee only
+                covers height/width mismatches: the writer is opened with
+                `isColor=True` and channel count is not reconciled, so a mid-stream
+                frame with a different number of channels (e.g. single-channel
+                grayscale) can still be silently dropped by the codec.
 
-        Returns:
-            True if write succeeded or path is None, False on failure.
+                Returns:
+                    True if write succeeded or path is None, False on failure.
         """
         if self.path is None:
             return True
@@ -144,16 +144,13 @@ class _VideoOutput:
     def _match_writer_size(self, frame: np.ndarray) -> np.ndarray:
         """Resize a frame to the writer's resolution, warning once on mismatch.
 
-        `cv2.VideoWriter.write` silently discards frames whose size differs from
-        the one the writer was opened with, so a resolution change mid-stream
-        would drop frames from the output without any error. Resizing keeps the
-        stream contiguous; the mismatch is logged once to avoid per-frame spam.
-        The resize stretches the frame to the writer's exact dimensions without
-        preserving the source aspect ratio (aspect ratio may be distorted).
-        `cv2.INTER_AREA` is used only when downscaling (both writer dimensions
-        are smaller than the source frame's), since it degrades toward
-        nearest-neighbor quality when upscaling; `cv2.INTER_LINEAR` is used for
-        upscaling or mixed-direction resizes.
+        `cv2.VideoWriter.write` silently discards frames whose size differs from the one the writer was opened with, so
+        a resolution change mid-stream would drop frames from the output without any error. Resizing keeps the stream
+        contiguous; the mismatch is logged once to avoid per-frame spam. The resize stretches the frame to the writer's
+        exact dimensions without preserving the source aspect ratio (aspect ratio may be distorted). `cv2.INTER_AREA` is
+        used only when downscaling (both writer dimensions are smaller than the source frame's), since it degrades
+        toward nearest-neighbor quality when upscaling; `cv2.INTER_LINEAR` is used for upscaling or mixed-direction
+        resizes.
         """
         height, width = frame.shape[:2]
         if self._frame_size is None or self._frame_size == (width, height):

--- a/src/trackers/io/video.py
+++ b/src/trackers/io/video.py
@@ -98,9 +98,7 @@ class _VideoOutput:
         self._size_mismatch_logged = False
 
     def write(self, frame: np.ndarray) -> bool:
-        """Write a frame to the video file.
-
-        Initializes writer on first call.
+        """Write a frame to the video file; initializes writer on first call.
                 The writer is bound to the first frame's resolution, and a video file
                 cannot hold frames of mixed sizes. A later frame of a different size
                 (e.g. a mid-stream resolution change from an RTSP renegotiation) is

--- a/src/trackers/motion/estimator.py
+++ b/src/trackers/motion/estimator.py
@@ -260,8 +260,7 @@ class MotionEstimator:
     def reset(self) -> None:
         """Reset the estimator state.
 
-        Call this when starting a new video or when you want to reset the
-        world coordinate system to the current frame.
+        Call this when starting a new video or when you want to reset the world coordinate system to the current frame.
         """
         self._previous_grayscale = None
         self._previous_features = None
@@ -270,8 +269,7 @@ class MotionEstimator:
     def _reset_accumulator(self) -> None:
         """Reset the accumulated homography to the identity transform.
 
-        Re-baselines the world coordinate system to the current frame. Unlike
-        `reset()`, this does NOT clear the cached previous frame or feature
-        points; use `reset()` when a full state reset is required.
+        Re-baselines the world coordinate system to the current frame. Unlike `reset()`, this does NOT clear the cached
+        previous frame or feature points; use `reset()` when a full state reset is required.
         """
         self._accumulated_homography = np.eye(3, dtype=np.float64)

--- a/src/trackers/motion/transformation.py
+++ b/src/trackers/motion/transformation.py
@@ -14,8 +14,8 @@ import numpy as np
 class CoordinatesTransformation(ABC):
     """Abstract base class for coordinate transformations.
 
-    Subclasses implement specific transformation types that convert points between
-    absolute (world) and relative (frame) coordinates.
+    Subclasses implement specific transformation types that convert points between absolute (world) and relative (frame)
+    coordinates.
     """
 
     @abstractmethod
@@ -50,8 +50,7 @@ class CoordinatesTransformation(ABC):
 class IdentityTransformation(CoordinatesTransformation):
     """No-op transformation where absolute and relative coordinates are identical.
 
-    Used for the first frame (before any camera motion is detected) or when
-    motion estimation fails.
+    Used for the first frame (before any camera motion is detected) or when motion estimation fails.
     """
 
     def abs_to_rel(self, points: np.ndarray) -> np.ndarray:

--- a/src/trackers/tune/tuner.py
+++ b/src/trackers/tune/tuner.py
@@ -200,9 +200,8 @@ class Tuner:
     def _validate_sequence_files(self) -> None:
         """Validate that every selected sequence has required MOT files.
 
-        This performs eager filesystem validation so configuration errors are
-        reported during tuner initialization rather than later during trial
-        execution.
+        This performs eager filesystem validation so configuration errors are reported during tuner initialization
+        rather than later during trial execution.
         """
         missing_detection_files = [
             str(self._detections_dir / f"{seq_name}.txt")

--- a/src/trackers/utils/base_tracklet.py
+++ b/src/trackers/utils/base_tracklet.py
@@ -15,8 +15,8 @@ from trackers.utils.state_representations import BaseStateEstimator
 
 
 class BaseTracklet(ABC):
-    """
-    Abstract base class for all tracker-specific tracklets.
+    """Abstract base class for all tracker-specific tracklets.
+
     Provides common interface and attributes for tracklet management.
     """
 
@@ -44,9 +44,8 @@ class BaseTracklet(ABC):
     def _advance_miss_clocks(self, timing: PredictTiming) -> None:
         """Advance miss counters by one step.
 
-        When ``elapsed_seconds`` is ``None`` (fixed-rate mode), the seconds
-        counter is reset to zero so stale values from a prior timestamp-mode
-        stretch cannot influence later seconds-budget pruning.
+        When ``elapsed_seconds`` is ``None`` (fixed-rate mode), the seconds counter is reset to zero so stale values
+        from a prior timestamp-mode stretch cannot influence later seconds-budget pruning.
         """
         self.time_since_update += 1
         if timing.elapsed_seconds is not None:

--- a/src/trackers/utils/cmc.py
+++ b/src/trackers/utils/cmc.py
@@ -239,8 +239,7 @@ class CMC:
     """
 
     def __init__(self, cfg: CMCConfig | None = None) -> None:
-        """
-        Initialize CMC.
+        """Initialize CMC.
 
         Args:
             cfg: Optional configuration. If None, defaults are used.
@@ -297,8 +296,7 @@ class CMC:
         self.reset()
 
     def reset(self) -> None:
-        """
-        Reset internal state.
+        """Reset internal state.
 
         After calling reset:
         - The next `estimate()` call returns identity and initializes prev-frame state.
@@ -357,9 +355,9 @@ class CMC:
         return np.eye(2, 3, dtype=np.float32)
 
     def _estimate_feature_affine(self, frame_bgr: np.ndarray, dets_xyxy: np.ndarray | None = None) -> np.ndarray:
-        """
-        Feature affine estimation. ORB-based or SIFT-based
-        (different initializations of self.detector, self.extractor and self.matcher for
+        """Feature affine estimation.
+
+        ORB-based or SIFT-based (different initializations of self.detector, self.extractor and self.matcher for
         ORB and SIFT)
 
         Steps:
@@ -486,8 +484,7 @@ class CMC:
         return affine_mtx
 
     def _estimate_sparse_optflow(self, frame_bgr: np.ndarray) -> np.ndarray:
-        """
-        Sparse optical-flow-based affine estimation.
+        """Sparse optical-flow-based affine estimation.
 
         Steps:
             1) grayscale (+ optional downscale)
@@ -603,8 +600,7 @@ class CMC:
         return affine_mtx
 
     def _estimate_ecc(self, frame_bgr: np.ndarray) -> np.ndarray:
-        """
-        ECC-based affine motion estimation.
+        """ECC-based affine motion estimation.
 
         This method estimates a global 2D Euclidean transform between the previous
         frame and the current frame using OpenCV's Enhanced Correlation Coefficient

--- a/src/trackers/utils/downloader.py
+++ b/src/trackers/utils/downloader.py
@@ -94,9 +94,8 @@ def _download_file(
 def _safe_zip_member_parts(member_name: str) -> tuple[str, ...]:
     """Return sanitized ZIP path parts for a member.
 
-    ZIP member names are treated as forward-slash paths. Backslashes and
-    Windows drive-rooted forms are rejected so the extraction contract is
-    consistent across platforms.
+    ZIP member names are treated as forward-slash paths. Backslashes and Windows drive-rooted forms are rejected so the
+    extraction contract is consistent across platforms.
     """
     if not member_name:
         raise ValueError("ZIP archive contains an empty member name")
@@ -179,9 +178,8 @@ def _extract_zip_member_by_path(
 ) -> None:
     """Extract a single ZIP member using validated paths.
 
-    Windows does not expose the dir-fd primitives used by the Unix path, so
-    the fallback keeps the same member validation and writes to resolved
-    absolute paths.
+    Windows does not expose the dir-fd primitives used by the Unix path, so the fallback keeps the same member
+    validation and writes to resolved absolute paths.
     """
     member_parts = _safe_zip_member_parts(zip_info.filename)
     member_path = output_dir.joinpath(*member_parts)

--- a/src/trackers/utils/general.py
+++ b/src/trackers/utils/general.py
@@ -12,8 +12,7 @@ from typing import Any
 def _normalize_list(value: Any | list[Any] | None) -> list[str] | None:
     """Wrap a scalar value in a list, pass lists through, and return None as-is.
 
-    Enum members are converted to their ``.value`` so callers always
-    receive plain strings.
+    Enum members are converted to their ``.value`` so callers always receive plain strings.
     """
     if value is None:
         return None

--- a/src/trackers/utils/iou.py
+++ b/src/trackers/utils/iou.py
@@ -424,8 +424,8 @@ class CIoU(BaseIoU):
     def normalize_for_fusion(self, similarity_matrix: np.ndarray) -> np.ndarray:
         """Shift and clamp CIoU scores into ``[0, 1]`` for BoT-SORT fusion.
 
-        CIoU can fall below ``-1`` (see class docstring), so the clamp inside
-        :func:`_shift_signed_to_unit_range` is non-trivial here.
+        CIoU can fall below ``-1`` (see class docstring), so the clamp inside :func:`_shift_signed_to_unit_range` is
+        non-trivial here.
         """
         return _shift_signed_to_unit_range(similarity_matrix)
 

--- a/src/trackers/utils/kalman_filter.py
+++ b/src/trackers/utils/kalman_filter.py
@@ -11,8 +11,9 @@ from numpy.typing import NDArray
 
 
 class KalmanFilter:
-    """Generic Kalman filter for state estimation. A standard linear Kalman filter for state estimation. This is a
-    clean, general-purpose implementation that can be used by any tracker. Performs predict/update algebra only. Process
+    """Generic Kalman filter for state estimation.
+
+    A standard linear Kalman filter for state estimation. This is a clean, general-purpose implementation that can be used by any tracker. Performs predict/update algebra only. Process
     models (transition_mtx, process_noise) are supplied externally — see ``trackers.utils.motion_models`` and
     ``BaseStateEstimator`` in ``state_representations.py``.
 

--- a/src/trackers/utils/kalman_filter.py
+++ b/src/trackers/utils/kalman_filter.py
@@ -11,8 +11,11 @@ from numpy.typing import NDArray
 
 
 class KalmanFilter:
-    """Generic Kalman filter for state estimation. A standard linear Kalman filter for state estimation. This is a
-    clean, general-purpose implementation that can be used by any tracker. Performs predict/update algebra only. Process
+    """Generic Kalman filter for state estimation.
+
+    A standard linear Kalman filter for state estimation.
+    This is a clean, general-purpose implementation that can be used by any tracker.
+    Performs predict/update algebra only. Process
     models (transition_mtx, process_noise) are supplied externally — see ``trackers.utils.motion_models`` and
     ``BaseStateEstimator`` in ``state_representations.py``.
 

--- a/src/trackers/utils/kalman_filter.py
+++ b/src/trackers/utils/kalman_filter.py
@@ -11,12 +11,10 @@ from numpy.typing import NDArray
 
 
 class KalmanFilter:
-    """Generic Kalman filter for state estimation.
-    A standard linear Kalman filter for state estimation. This is a clean,
-    general-purpose implementation that can be used by any tracker.
-    Performs predict/update algebra only. Process models (transition_mtx,
-    process_noise) are supplied externally — see ``trackers.utils.motion_models``
-    and ``BaseStateEstimator`` in ``state_representations.py``.
+    """Generic Kalman filter for state estimation. A standard linear Kalman filter for state estimation. This is a
+    clean, general-purpose implementation that can be used by any tracker. Performs predict/update algebra only. Process
+    models (transition_mtx, process_noise) are supplied externally — see ``trackers.utils.motion_models`` and
+    ``BaseStateEstimator`` in ``state_representations.py``.
 
     Attributes:
         dim_x: Dimension of state vector.

--- a/src/trackers/utils/kalman_filter.py
+++ b/src/trackers/utils/kalman_filter.py
@@ -13,9 +13,13 @@ from numpy.typing import NDArray
 class KalmanFilter:
     """Generic Kalman filter for state estimation.
 
-    A standard linear Kalman filter for state estimation. This is a clean, general-purpose implementation that can be used by any tracker. Performs predict/update algebra only. Process
-    models (transition_mtx, process_noise) are supplied externally — see ``trackers.utils.motion_models`` and
-    ``BaseStateEstimator`` in ``state_representations.py``.
+    A standard linear Kalman filter for state estimation.
+
+    This is a clean, general-purpose implementation that can be used by any
+    tracker. Performs predict/update algebra only. Process models
+    (transition_mtx, process_noise) are supplied externally — see
+    ``trackers.utils.motion_models`` and ``BaseStateEstimator`` in
+    ``state_representations.py``.
 
     Attributes:
         dim_x: Dimension of state vector.

--- a/src/trackers/utils/motion_models.py
+++ b/src/trackers/utils/motion_models.py
@@ -137,9 +137,8 @@ class ScalableProcessNoise:
     def _ensure_calibrated(self) -> None:
         """Extract per-axis acceleration variance from the stored reference Q.
 
-        The velocity-diagonal entries of ``baseline_Q`` define ``sigma_a2``,
-        which scales noise for ``frame_step != 1.0`` via DWNA. Runs only when a
-        ``calibrate`` call marked the extraction as pending.
+        The velocity-diagonal entries of ``baseline_Q`` define ``sigma_a2``, which scales noise for ``frame_step !=
+        1.0`` via DWNA. Runs only when a ``calibrate`` call marked the extraction as pending.
         """
         if not self._needs_calibration:
             return
@@ -341,8 +340,8 @@ class KalmanMotionModel:
     def reset_cache(self) -> None:
         """Clear cached step and matrices.
 
-        Call after restoring a filter state (e.g. via ``set_state``) to ensure
-        the next ``apply`` recomputes transition_matrix and Q rather than reusing stale values.
+        Call after restoring a filter state (e.g. via ``set_state``) to ensure the next ``apply`` recomputes
+        transition_matrix and Q rather than reusing stale values.
         """
         self.cached_step = None
         self._cached_transition_mtx = None

--- a/src/trackers/utils/predict_timing.py
+++ b/src/trackers/utils/predict_timing.py
@@ -6,9 +6,9 @@
 
 """Timing for one Kalman predict step.
 
-Stores how large the predict step is (in frame units) and how many seconds passed since the
-last step. Two fields are used because Kalman ``F``/``Q`` scale in frame units,
-while timestamped updates also need real elapsed time between calls.
+Stores how large the predict step is (in frame units) and how many seconds passed since the last step. Two fields are
+used because Kalman ``F``/``Q`` scale in frame units, while timestamped updates also need real elapsed time between
+calls.
 """
 
 from __future__ import annotations

--- a/src/trackers/utils/state_representations.py
+++ b/src/trackers/utils/state_representations.py
@@ -227,11 +227,9 @@ class BaseStateEstimator(ABC):
 class XCYCSRStateEstimator(BaseStateEstimator):
     """Center-based Kalman filter with 7 state dimensions and 4 measurements.
 
-    State vector contains `x_center`, `y_center` (box center), `scale` (area),
-    `aspect_ratio` (width/height), and velocities `vx`, `vy`, `vs`. Aspect ratio
-    is treated as constant (no velocity term), which works well for rigid objects
-    that maintain their shape. Matches the representation used in the original
-    SORT and OC-SORT papers.
+    State vector contains `x_center`, `y_center` (box center), `scale` (area), `aspect_ratio` (width/height), and
+    velocities `vx`, `vy`, `vs`. Aspect ratio is treated as constant (no velocity term), which works well for rigid
+    objects that maintain their shape. Matches the representation used in the original SORT and OC-SORT papers.
     """
 
     # State layout: [xc, yc, s, r, vx, vy, vs]
@@ -270,15 +268,13 @@ class XCYCSRStateEstimator(BaseStateEstimator):
 class XCYCWHStateEstimator(BaseStateEstimator):
     """Center-width-height Kalman filter with 8 state dims and 4 measurements.
 
-    State vector contains `x_center`, `y_center` (box center), `w` (width),
-    `h` (height), and velocities `vx`, `vy`, `vw`, `vh`.  Unlike
-    `XCYCSRStateEstimator`, both width and height have independent velocity
-    terms and can change freely.
+    State vector contains `x_center`, `y_center` (box center), `w` (width), `h` (height), and velocities `vx`, `vy`,
+    `vw`, `vh`.  Unlike `XCYCSRStateEstimator`, both width and height have independent velocity terms and can change
+    freely.
 
-    This estimator only provides the coordinate-transform and filter-layout
-    logic (F, H, conversions).  Noise tuning (Q, R, P) and any dynamic
-    noise refresh are the responsibility of the tracklet that owns the
-    estimator — exactly like `XYXYStateEstimator` and `XCYCSRStateEstimator`.
+    This estimator only provides the coordinate-transform and filter-layout logic (F, H, conversions).  Noise tuning (Q,
+    R, P) and any dynamic noise refresh are the responsibility of the tracklet that owns the estimator — exactly like
+    `XYXYStateEstimator` and `XCYCSRStateEstimator`.
     """
 
     # State layout: [xc, yc, w, h, vx, vy, vw, vh]
@@ -307,10 +303,9 @@ class XCYCWHStateEstimator(BaseStateEstimator):
 class XYXYStateEstimator(BaseStateEstimator):
     """Corner-based Kalman filter with 8 state dimensions and 4 measurements.
 
-    State vector contains `x1`, `y1` (top-left corner), `x2`, `y2` (bottom-right
-    corner), and independent velocities `vx1`, `vy1`, `vx2`, `vy2` for each
-    coordinate. This allows the box shape to change over time, which may be
-    better suited for non-rigid or deformable objects.
+    State vector contains `x1`, `y1` (top-left corner), `x2`, `y2` (bottom-right corner), and independent velocities
+    `vx1`, `vy1`, `vx2`, `vy2` for each coordinate. This allows the box shape to change over time, which may be better
+    suited for non-rigid or deformable objects.
     """
 
     # State layout: [x1, y1, x2, y2, vx1, vy1, vx2, vy2]
@@ -328,7 +323,6 @@ class XYXYStateEstimator(BaseStateEstimator):
 
     def clamp_velocity(self, frame_step: float = 1.0) -> None:
         """Ignore `frame_step`; kept for interface compatibility because XYXY-style velocity is unconstrained."""
-
 
 # ---------------------------------------------------------------------------
 # Factory helper

--- a/src/trackers/utils/state_representations.py
+++ b/src/trackers/utils/state_representations.py
@@ -323,6 +323,8 @@ class XYXYStateEstimator(BaseStateEstimator):
 
     def clamp_velocity(self, frame_step: float = 1.0) -> None:
         """Ignore `frame_step`; kept for interface compatibility because XYXY-style velocity is unconstrained."""
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Factory helper

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -49,7 +49,7 @@ class TestDownload:
         ],
     )
     def test_split_comma_parsing(self, split_arg: str, expected_splits: list[str]) -> None:
-        """split values are split on commas and whitespace-stripped."""
+        """Split values are split on commas and whitespace-stripped."""
         with patch("trackers.datasets.download.download_dataset") as mock_dl:
             rc = download_command(name="mot17", split=split_arg, asset="annotations")
             assert rc == 0
@@ -70,7 +70,7 @@ class TestDownload:
         ],
     )
     def test_split_comma_parsing_boundary(self, split_arg: str, expected_splits: list[str]) -> None:
-        """split handles malformed comma inputs gracefully."""
+        """Split handles malformed comma inputs gracefully."""
         with patch("trackers.datasets.download.download_dataset") as mock_dl:
             rc = download_command(name="mot17", split=split_arg, asset="annotations")
             assert rc == 0
@@ -91,7 +91,7 @@ class TestDownload:
         ],
     )
     def test_asset_comma_parsing(self, asset_arg: str, expected_assets: list[str]) -> None:
-        """asset values are split on commas and whitespace-stripped."""
+        """Asset values are split on commas and whitespace-stripped."""
         with patch("trackers.datasets.download.download_dataset") as mock_dl:
             rc = download_command(name="sportsmot", split="train", asset=asset_arg)
             assert rc == 0
@@ -117,7 +117,7 @@ class TestDownload:
             )
 
     def test_output_directory_forwarded(self) -> None:
-        """output value is forwarded to download_dataset."""
+        """Output value is forwarded to download_dataset."""
         with patch("trackers.datasets.download.download_dataset") as mock_dl:
             rc = download_command(name="mot17", output="/custom/path")
             assert rc == 0
@@ -139,7 +139,7 @@ class TestDownload:
             assert rc == 1
 
     def test_split_with_spaces_stripped(self) -> None:
-        """split with spaces around commas strips whitespace."""
+        """Split with spaces around commas strips whitespace."""
         with patch("trackers.datasets.download.download_dataset") as mock_dl:
             rc = download_command(name="mot17", split="train , val", asset="annotations")
             assert rc == 0

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -6,9 +6,8 @@
 
 """Tests for the ``trackers inspect`` component group.
 
-Every test here stops at the parsing and validation surface. None of the
-components can run without SAM and Cutie weights, so the contract under test is
-that a wrong invocation is rejected before any model is touched.
+Every test here stops at the parsing and validation surface. None of the components can run without SAM and Cutie
+weights, so the contract under test is that a wrong invocation is rejected before any model is touched.
 """
 
 from __future__ import annotations
@@ -122,10 +121,9 @@ class TestMaskManagerModeValidation:
     def test_every_mode_specific_parameter_is_registered(self) -> None:
         """A new mode-specific option must join a mode tuple, or its mode is never enforced.
 
-        The tuples are hand-maintained, so they drift from the signature silently:
-        an unregistered option is accepted under both modes instead of one.
-        Equality rather than containment, so a tuple entry left behind by a
-        rename is caught in the same assertion.
+        The tuples are hand-maintained, so they drift from the signature silently: an unregistered option is accepted
+        under both modes instead of one. Equality rather than containment, so a tuple entry left behind by a rename is
+        caught in the same assertion.
         """
         parameters = set(inspect.signature(mask_manager_inspection).parameters)
 
@@ -200,8 +198,8 @@ class TestMaskManagerModeValidation:
     def test_conflict_is_reported_before_any_model_loads(self, capsys: pytest.CaptureFixture) -> None:
         """The command returns non-zero without importing SAM or Cutie.
 
-        The image directory does not exist either. Reaching the filesystem check
-        first would mean the mode check ran too late to be the guard it claims.
+        The image directory does not exist either. Reaching the filesystem check first would mean the mode check ran too
+        late to be the guard it claims.
         """
         exit_code = mask_manager_inspection(Path("does-not-exist"), mode="manual", gt_file=Path("gt.txt"))
 
@@ -229,9 +227,8 @@ class TestInspectCommonHelpers:
     def test_parse_xyxy_box_rejects_malformed_input(self, box: str) -> None:
         """Wrong count and non-numeric tokens are the same mistake, reported the same way.
 
-        A non-numeric token used to escape as a bare ``could not convert string
-        to float`` from the standard library, naming neither the option nor the
-        expected format.
+        A non-numeric token used to escape as a bare ``could not convert string to float`` from the standard library,
+        naming neither the option nor the expected format.
         """
         with pytest.raises(ValueError, match="exactly 4 comma-separated numbers"):
             parse_xyxy_box(box)
@@ -239,8 +236,8 @@ class TestInspectCommonHelpers:
     def test_require_torch_names_the_mask_extra(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A torch-free install is told which extra to install, not that an import failed.
 
-        ``None`` in ``sys.modules`` makes the interpreter itself refuse the
-        import, which is the closest stand-in for the extra being absent.
+        ``None`` in ``sys.modules`` makes the interpreter itself refuse the import, which is the closest stand-in for
+        the extra being absent.
         """
         monkeypatch.setitem(sys.modules, "torch", None)
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -438,9 +438,8 @@ class TestCliMigration:
     def test_legacy_warnings_state_the_scheduled_removal_release(self, args: list[str]) -> None:
         """Every legacy CLI transition names the release in which it is removed.
 
-        The release is asserted as a literal rather than recomputed from the
-        installed version. Deriving it here would mirror the implementation and
-        keep passing even if the deadline started moving with each release.
+        The release is asserted as a literal rather than recomputed from the installed version. Deriving it here would
+        mirror the implementation and keep passing even if the deadline started moving with each release.
         """
         with pytest.warns(FutureWarning, match=re.escape("removed in 2.10.0")):
             _translate_legacy_args(args)
@@ -901,11 +900,9 @@ class TestEntryPointCentralisation:
     def test_every_subcommand_is_dispatchable_and_translatable(self) -> None:
         """The dispatch table and the two per-subcommand tables cannot drift apart.
 
-        ``_SUBCOMMANDS`` gates argv normalisation and ``_LEGACY_ARGUMENTS`` is
-        subscripted unguarded, so a command present in one table and missing
-        from another half-works rather than failing cleanly. Both are checked
-        against the real dispatch table rather than a copy of it, so adding a
-        subcommand to ``_COMMANDS`` alone fails here.
+        ``_SUBCOMMANDS`` gates argv normalisation and ``_LEGACY_ARGUMENTS`` is subscripted unguarded, so a command
+        present in one table and missing from another half-works rather than failing cleanly. Both are checked against
+        the real dispatch table rather than a copy of it, so adding a subcommand to ``_COMMANDS`` alone fails here.
         """
         dispatched = set(_COMMANDS)
 
@@ -915,8 +912,8 @@ class TestEntryPointCentralisation:
     def test_the_entry_point_imports_without_torch(self) -> None:
         """Importing the CLI must not drag in the optional ``mask`` extra.
 
-        ``torch`` ships only in the ``mask`` extra, so a default install would
-        stop having a CLI at all if a subcommand imported it at module level.
+        ``torch`` ships only in the ``mask`` extra, so a default install would stop having a CLI at all if a subcommand
+        imported it at module level.
         """
         # A subprocess, because this test session has already imported torch.
         script = "import sys; import trackers.cli.__main__; print('torch' in sys.modules)"
@@ -928,9 +925,9 @@ class TestEntryPointCentralisation:
     def test_parser_and_legacy_modules_never_import_main(self) -> None:
         """_parser.py and _legacy.py must not import from __main__ to avoid circular imports.
 
-        The entry point (__main__) imports every subcommand and imports from these
-        modules, so a reverse import would create a cycle and leave __main__ partially
-        initialized. This test uses static AST inspection to verify no such imports exist.
+        The entry point (__main__) imports every subcommand and imports from these modules, so a reverse import would
+        create a cycle and leave __main__ partially initialized. This test uses static AST inspection to verify no such
+        imports exist.
         """
         import ast
         from pathlib import Path
@@ -966,9 +963,8 @@ class TestTopLevelHelp:
     def _rendered_help() -> str:
         """Return the top-level help as one whitespace-normalised line.
 
-        ``format_help`` wraps to the terminal width, so a summary that fits on
-        one line here can be split across two on a narrower terminal. Collapsing
-        the whitespace lets a test assert on whole sentences.
+        ``format_help`` wraps to the terminal width, so a summary that fits on one line here can be split across two on
+        a narrower terminal. Collapsing the whitespace lets a test assert on whole sentences.
         """
         parser = auto_parser(_COMMANDS, args=[], as_positional=False, prog="trackers", parser_class=_CLIParser)
         return " ".join(parser.format_help().split())
@@ -976,10 +972,9 @@ class TestTopLevelHelp:
     def test_the_command_groups_are_described(self) -> None:
         """A group is a dict, which has no docstring for jsonargparse to lift.
 
-        ``track`` and friends get their summary from the command's docstring;
-        ``benchmark`` and ``inspect`` only have one because ``_COMMANDS`` gives
-        them a ``_help`` key. Dropping that key leaves them blank in ``--help``,
-        which is silent — nothing errors, the description is simply missing.
+        ``track`` and friends get their summary from the command's docstring; ``benchmark`` and ``inspect`` only have
+        one because ``_COMMANDS`` gives them a ``_help`` key. Dropping that key leaves them blank in ``--help``, which
+        is silent — nothing errors, the description is simply missing.
         """
         rendered = self._rendered_help()
 

--- a/tests/cli/test_track.py
+++ b/tests/cli/test_track.py
@@ -208,10 +208,9 @@ class TestResolveTrackIdFilter:
 class TestTrackerParameterAbbreviations:
     """Abbreviated CLI parameter names must survive the trip to the constructor.
 
-    ``_init_tracker`` forwards only keys matching the tracker ``__init__``
-    signature, so a CLI-side rename with no matching alias is dropped without
-    an error and the tracker silently keeps its own default. These tests make
-    that failure mode visible.
+    ``_init_tracker`` forwards only keys matching the tracker ``__init__`` signature, so a CLI-side rename with no
+    matching alias is dropped without an error and the tracker silently keeps its own default. These tests make that
+    failure mode visible.
     """
 
     @pytest.mark.parametrize(

--- a/tests/core/test_associated_indices.py
+++ b/tests/core/test_associated_indices.py
@@ -6,8 +6,7 @@
 
 """Unit tests for deterministic unmatched-index ordering in _get_associated_indices.
 
-All trackers must return sorted lists for
-unmatched tracks and unmatched detections so that tracker-ID assignment is
+All trackers must return sorted lists for unmatched tracks and unmatched detections so that tracker-ID assignment is
 stable across CPython versions and implementations.
 """
 
@@ -109,11 +108,10 @@ class TestGetAssociatedIndicesSortedOutput:
 def test_ocsort_none_direction_matrix_matches_explicit_zero_matrix() -> None:
     """OCSORT weight-0 path (``None`` direction matrix) associates identically to a zero matrix.
 
-    The direction-consistency matrix is finite and bounded, so the historical
-    ``iou_matrix + weight * matrix`` reduced to ``iou_matrix`` whenever the matrix
-    was all zeros. Passing ``None`` (the weight-0 early-out) must be bit-identical
-    to passing an explicit zero matrix. ``None`` is only valid at weight 0, so the
-    tracker is constructed with ``direction_consistency_weight=0``.
+    The direction-consistency matrix is finite and bounded, so the historical ``iou_matrix + weight * matrix`` reduced
+    to ``iou_matrix`` whenever the matrix was all zeros. Passing ``None`` (the weight-0 early-out) must be bit-identical
+    to passing an explicit zero matrix. ``None`` is only valid at weight 0, so the tracker is constructed with
+    ``direction_consistency_weight=0``.
     """
     tracker = OCSORTTracker(direction_consistency_weight=0.0)
     iou_matrix = np.zeros((4, 5))

--- a/tests/core/test_botsort_cmc.py
+++ b/tests/core/test_botsort_cmc.py
@@ -49,16 +49,14 @@ def _xyxy_tracklet(bbox: np.ndarray) -> BoTSORTTracklet:
 class TestCMCEstimateAcrossMethods:
     """CMC.estimate() contract — parametrised over every supported method.
 
-    All tests instantiate CMC via `_make_cmc(method)` (skips when the method is
-    unavailable in the local OpenCV build) and feed it `_bgr_frame(...)` noise
-    frames; assertions cover the documented `estimate()` return contract:
-    shape (2, 3), dtype float32, identity on degenerate inputs, finite values
-    on real inputs.
+    All tests instantiate CMC via `_make_cmc(method)` (skips when the method is unavailable in the local OpenCV build)
+    and feed it `_bgr_frame(...)` noise frames; assertions cover the documented `estimate()` return contract: shape (2,
+    3), dtype float32, identity on degenerate inputs, finite values on real inputs.
     """
 
     @pytest.mark.parametrize("method", ALL_METHODS)
     def test_output_is_2x3_float32(self, method: str) -> None:
-        """estimate() must always return a (2, 3) float32 matrix."""
+        """Estimate() must always return a (2, 3) float32 matrix."""
         cmc = _make_cmc(method)
         frame1 = _bgr_frame(seed=0)
         frame2 = _bgr_frame(seed=1)
@@ -125,7 +123,7 @@ class TestCMCEstimateAcrossMethods:
 
     @pytest.mark.parametrize("method", ALL_METHODS)
     def test_downscale_produces_valid_output(self, method: str) -> None:
-        """downscale>1 must still return a finite (2,3) float32 transform."""
+        """Downscale>1 must still return a finite (2,3) float32 transform."""
         cmc_ds1 = _make_cmc(method, downscale=1)
         cmc_ds2 = _make_cmc(method, downscale=2)
 
@@ -149,9 +147,8 @@ class TestCMCEstimateAcrossMethods:
 class TestCMCApplyBatch:
     """`CMC.apply_batch` against center-state tracklets.
 
-    All tests build default `BoTSORTTracklet(bbox)` instances (center-state
-    estimator) and verify the batch entry-point against the per-track
-    `apply_cmc` contract (equivalence, multi-tracklet, no-op cases).
+    All tests build default `BoTSORTTracklet(bbox)` instances (center-state estimator) and verify the batch entry-point
+    against the per-track `apply_cmc` contract (equivalence, multi-tracklet, no-op cases).
     """
 
     def test_matches_single(self) -> None:
@@ -221,9 +218,8 @@ class TestCMCApplyBatch:
 class TestCMCApplyToXYXY:
     """Direct unit tests on `CMC.warp_xyxy_corners(x1, y1, x2, y2, R, t=None)`.
 
-    Each test passes raw 1-D NumPy arrays for the four corner channels and a
-    2x2 `R` (and optional 1-D `t`), then asserts on the four return arrays.
-    No tracklet, no Kalman state — just the pure helper contract.
+    Each test passes raw 1-D NumPy arrays for the four corner channels and a 2x2 `R` (and optional 1-D `t`), then
+    asserts on the four return arrays. No tracklet, no Kalman state — just the pure helper contract.
     """
 
     def test_identity_translation_only(self) -> None:
@@ -335,11 +331,9 @@ class TestCMCApplyToXYXY:
 class TestXYXYCovarianceUpdate:
     """Covariance (P) update contract for XYXY-state tracklets under CMC.
 
-    All tests build an `_xyxy_tracklet([10, 20, 50, 80])`, snapshot
-    `kf.state_covariance`, construct an H matrix from a chosen 2x2 R block, apply CMC
-    (single via `tracklet.apply_cmc`, batch via `tracker.apply_cmc_batch`),
-    then assert P either propagates as `A @ P @ A.T` (axis-aligned R) or
-    is left untouched (cross-axis R).
+    All tests build an `_xyxy_tracklet([10, 20, 50, 80])`, snapshot `kf.state_covariance`, construct an H matrix from a
+    chosen 2x2 R block, apply CMC (single via `tracklet.apply_cmc`, batch via `tracker.apply_cmc_batch`), then assert P
+    either propagates as `A @ P @ A.T` (axis-aligned R) or is left untouched (cross-axis R).
     """
 
     @pytest.mark.parametrize(
@@ -431,10 +425,9 @@ class TestXYXYCovarianceUpdate:
 class TestXYXYAxisAlignedTolerance:
     """Boundary tests on the `atol=1e-6` axis-aligned classifier in CMC.
 
-    Both tests build the same `_xyxy_tracklet` and an R whose cross-axis
-    residual sits just below or just above 1e-6, then verify which branch
-    (P-update vs P-freeze) `tracklet.apply_cmc(H)` selected by inspecting
-    the post-call `kf.state_covariance`.
+    Both tests build the same `_xyxy_tracklet` and an R whose cross-axis residual sits just below or just above 1e-6,
+    then verify which branch (P-update vs P-freeze) `tracklet.apply_cmc(H)` selected by inspecting the post-call
+    `kf.state_covariance`.
     """
 
     def test_residual_below_atol_treated_as_axis_aligned(self) -> None:
@@ -541,8 +534,7 @@ def test_xyxy_velocity_rotates_without_translation() -> None:
 class TestCMCApplyBatchAdversarial:
     """Adversarial H inputs to CMC.apply_batch.
 
-    Covers wrong-shape H (should raise) and non-finite H values
-    (should propagate to state without raising).
+    Covers wrong-shape H (should raise) and non-finite H values (should propagate to state without raising).
     """
 
     def test_wrong_shape_h_raises(self) -> None:

--- a/tests/core/test_botsort_tracker.py
+++ b/tests/core/test_botsort_tracker.py
@@ -61,9 +61,8 @@ class TestBoTSORTTrackerLifecycle:
     def test_instant_activated_track_survives_a_miss(self) -> None:
         """A first-frame track keeps its ID after a single miss (no ID switch).
 
-        With the default ``minimum_consecutive_frames=2`` an instant-activated
-        track has only one update, so without sticky maturity it is treated as
-        unconfirmed and deleted on a miss — an ID switch when the object returns.
+        With the default ``minimum_consecutive_frames=2`` an instant-activated track has only one update, so without
+        sticky maturity it is treated as unconfirmed and deleted on a miss — an ID switch when the object returns.
         """
         tracker = BoTSORTTracker(enable_cmc=False)
         obj = (10.0, 10.0, 50.0, 50.0)
@@ -91,9 +90,8 @@ class TestBoTSORTTrackerLifecycle:
     def test_instant_activated_track_survives_multiple_misses(self) -> None:
         """Track keeps its ID through two consecutive misses (confirmed then lost).
 
-        After the first miss the track sits in confirmed_tracks (time_since_update=1).
-        After the second miss it moves to lost_tracks (time_since_update=2).
-        get_alive_tracklets must keep it alive via the tracker_id != -1 guard.
+        After the first miss the track sits in confirmed_tracks (time_since_update=1). After the second miss it moves to
+        lost_tracks (time_since_update=2). get_alive_tracklets must keep it alive via the tracker_id != -1 guard.
         """
         tracker = BoTSORTTracker(enable_cmc=False)
         obj = (10.0, 10.0, 50.0, 50.0)
@@ -174,7 +172,7 @@ class TestBoTSORTTrackerCMC:
         assert result.tracker_id is not None
 
     def test_update_with_frame_applies_cmc_without_error(self) -> None:
-        """update() with a real textured frame and CMC enabled runs without error."""
+        """Update() with a real textured frame and CMC enabled runs without error."""
         tracker = BoTSORTTracker(
             enable_cmc=True,
             cmc_method="sparseOptFlow",
@@ -189,7 +187,7 @@ class TestBoTSORTTrackerCMC:
         assert result.tracker_id[0] >= 0
 
     def test_cmc_reset_clears_cmc_state(self) -> None:
-        """reset() also resets the internal CMC state."""
+        """Reset() also resets the internal CMC state."""
         tracker = BoTSORTTracker(
             enable_cmc=True,
             cmc_method="sparseOptFlow",
@@ -232,10 +230,9 @@ def test_get_iou_matrix_reads_cache_without_decoding(monkeypatch: pytest.MonkeyP
 def test_get_iou_matrix_raises_contextual_error_on_cache_miss() -> None:
     """_get_iou_matrix raises a contextual KeyError when a tracklet is absent from the cache.
 
-    The decode-once map must contain every tracklet passed to the helper (it is
-    built from ``self.tracks`` once per ``update()``). A miss is an internal-invariant
-    violation; the helper surfaces it with a message naming the cache contract rather
-    than a bare ``KeyError: <id int>``.
+    The decode-once map must contain every tracklet passed to the helper (it is built from ``self.tracks`` once per
+    ``update()``). A miss is an internal-invariant violation; the helper surfaces it with a message naming the cache
+    contract rather than a bare ``KeyError: <id int>``.
     """
     tracker = BoTSORTTracker(enable_cmc=False)
     tracklet = BoTSORTTracklet(np.array([0.0, 0.0, 10.0, 10.0]))

--- a/tests/core/test_botsort_tracklet.py
+++ b/tests/core/test_botsort_tracklet.py
@@ -6,8 +6,7 @@
 
 """BoT-SORT-specific tracklet tests.
 
-Generic predict/update contracts (time_since_update, age) are covered for all
-tracklet classes in test_tracklets.py.
+Generic predict/update contracts (time_since_update, age) are covered for all tracklet classes in test_tracklets.py.
 """
 
 from __future__ import annotations

--- a/tests/core/test_cbiou_tracker.py
+++ b/tests/core/test_cbiou_tracker.py
@@ -253,9 +253,8 @@ class TestCBIoUStickyMaturity:
     def test_instant_activated_track_survives_multiple_misses(self) -> None:
         """Track keeps its ID through two consecutive misses (confirmed then lost).
 
-        After the first miss the track sits in confirmed_tracks (time_since_update=1).
-        After the second miss it moves to lost_tracks (time_since_update=2).
-        get_alive_tracklets must keep it alive via the tracker_id != -1 guard.
+        After the first miss the track sits in confirmed_tracks (time_since_update=1). After the second miss it moves to
+        lost_tracks (time_since_update=2). get_alive_tracklets must keep it alive via the tracker_id != -1 guard.
         """
         tracker = CBIoUTracker()
         obj = (10.0, 10.0, 50.0, 50.0)
@@ -301,14 +300,11 @@ class TestCBIoUStickyMaturity:
     def test_instant_activated_track_survives_a_miss_with_shifted_return_box(self) -> None:
         """Sticky track keeps its ID after a miss even when it reappears shifted.
 
-        Box A (spawn): [0, 0, 100, 100]. Box B (return, after the miss):
-        [100, 0, 200, 100] — flush against A's right edge, so plain IoU is
-        exactly 0 (no overlap: Step 1's raw box overlap would miss it). With
-        the tracker's default ``buffer_ratio_first=0.3``, BIoU expands both
-        boxes by 30px on every side before Step 1 association, producing
-        enough overlap to re-associate the returning detection with the
-        sticky (instant-activated) track. Mirrors the box-A/box-B
-        construction in ``TestCBIoUAssociationTolerance``.
+        Box A (spawn): [0, 0, 100, 100]. Box B (return, after the miss): [100, 0, 200, 100] — flush against A's right
+        edge, so plain IoU is exactly 0 (no overlap: Step 1's raw box overlap would miss it). With the tracker's default
+        ``buffer_ratio_first=0.3``, BIoU expands both boxes by 30px on every side before Step 1 association, producing
+        enough overlap to re-associate the returning detection with the sticky (instant-activated) track. Mirrors the
+        box-A/box-B construction in ``TestCBIoUAssociationTolerance``.
         """
         tracker = CBIoUTracker()
         box_a = (0.0, 0.0, 100.0, 100.0)
@@ -328,11 +324,9 @@ class TestCBIoUStickyMaturity:
     def test_sticky_track_pruned_once_time_since_update_exceeds_lost_track_buffer(self) -> None:
         """Sticky maturity delays deletion; it does not grant permanent immunity.
 
-        With ``lost_track_buffer=1`` (and the default 30 FPS ``frame_rate``),
-        ``maximum_frames_without_update`` scales to 1. An instant-activated
-        (sticky) track survives the first miss (``time_since_update == 1``,
-        within budget) but must be pruned once a second consecutive miss
-        pushes ``time_since_update`` to 2, past the budget.
+        With ``lost_track_buffer=1`` (and the default 30 FPS ``frame_rate``), ``maximum_frames_without_update`` scales
+        to 1. An instant-activated (sticky) track survives the first miss (``time_since_update == 1``, within budget)
+        but must be pruned once a second consecutive miss pushes ``time_since_update`` to 2, past the budget.
         """
         tracker = CBIoUTracker(lost_track_buffer=1)
         obj = (10.0, 10.0, 50.0, 50.0)
@@ -406,10 +400,9 @@ def test_biou_matrix_reads_cache_without_decoding(monkeypatch: pytest.MonkeyPatc
 def test_biou_matrix_raises_contextual_error_on_cache_miss() -> None:
     """_biou_matrix raises a contextual KeyError when a tracklet is absent from the cache.
 
-    The decode-once map must contain every tracklet passed to the helper (it is
-    built from ``self.tracks`` once per ``update()``). A miss is an internal-invariant
-    violation; the helper surfaces it with a message naming the cache contract rather
-    than a bare ``KeyError: <id int>``.
+    The decode-once map must contain every tracklet passed to the helper (it is built from ``self.tracks`` once per
+    ``update()``). A miss is an internal-invariant violation; the helper surfaces it with a message naming the cache
+    contract rather than a bare ``KeyError: <id int>``.
     """
     tracker = CBIoUTracker()
     tracklet = BoTSORTTracklet(np.array([0.0, 0.0, 10.0, 10.0]))

--- a/tests/core/test_masks_base.py
+++ b/tests/core/test_masks_base.py
@@ -39,8 +39,7 @@ class TestResolveAutoDevice:
     def test_mps_is_never_auto_selected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """MPS is measurably slower than CPU for this pipeline, so ``auto`` must skip it.
 
-        Availability is forced on for both accelerators; only an explicit
-        ``device="mps"`` may opt in.
+        Availability is forced on for both accelerators; only an explicit ``device="mps"`` may opt in.
         """
         monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
         monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)

--- a/tests/core/test_masks_cutie.py
+++ b/tests/core/test_masks_cutie.py
@@ -48,9 +48,8 @@ class _FakeObjectManager:
 class _FakeFeatureStore:
     """ImageFeatureStore stub modeling encode-on-miss plus explicit delete.
 
-    ``encode_count`` records how many distinct time indices were encoded so a
-    test can assert an add_masks reused a prior propagate's features (count
-    unchanged) instead of re-encoding the identical frame.
+    ``encode_count`` records how many distinct time indices were encoded so a test can assert an add_masks reused a
+    prior propagate's features (count unchanged) instead of re-encoding the identical frame.
     """
 
     def __init__(self) -> None:
@@ -71,10 +70,9 @@ class _FakeFeatureStore:
 class _FakeInferenceCore:
     """InferenceCore stub mirroring curr_ti bookkeeping and delete_buffer.
 
-    ``step`` increments ``curr_ti`` before its feature lookup (as the real core
-    does), encodes on a store miss, and drops the entry when ``delete_buffer`` is
-    True. It returns a fixed probability tensor so the wrapper's downstream mask
-    conversion runs unchanged.
+    ``step`` increments ``curr_ti`` before its feature lookup (as the real core does), encodes on a store miss, and
+    drops the entry when ``delete_buffer`` is True. It returns a fixed probability tensor so the wrapper's downstream
+    mask conversion runs unchanged.
     """
 
     def __init__(self, prob: Any, tmp_id_to_obj: dict[int, _FakeObject]) -> None:
@@ -192,7 +190,7 @@ def test_add_masks_reencodes_when_frame_differs_from_cache() -> None:
 
 
 def test_propagate_retains_single_feature_entry_and_reset_clears_it() -> None:
-    """propagate keeps exactly one feature entry alive for reuse; reset drops it to avoid ti collisions."""
+    """Propagate keeps exactly one feature entry alive for reuse; reset drops it to avoid ti collisions."""
     prob = torch.zeros((2, 2, 2), dtype=torch.float32)
     prob[0] = 1.0
     propagator = _make_reuse_propagator(prob, {1: _FakeObject(1)})

--- a/tests/core/test_masks_manager.py
+++ b/tests/core/test_masks_manager.py
@@ -18,10 +18,9 @@ from trackers.core.masks.manager import MaskManager
 class _FlakyMaskPropagator(DummyIdentityMaskPropagator):
     """Propagator that succeeds a bounded number of times, then fails.
 
-    Unlike ``DummyIdentityMaskPropagator``, which never returns ``None`` once
-    initialized, this test double reproduces a propagation-runtime failure
-    (e.g. an external backend such as Cutie losing its internal memory)
-    occurring mid-sequence, after the manager has already been initialized.
+    Unlike ``DummyIdentityMaskPropagator``, which never returns ``None`` once initialized, this test double reproduces a
+    propagation-runtime failure (e.g. an external backend such as Cutie losing its internal memory) occurring mid-
+    sequence, after the manager has already been initialized.
     """
 
     def __init__(self, succeed_calls: int = 1) -> None:
@@ -39,9 +38,8 @@ class _FlakyMaskPropagator(DummyIdentityMaskPropagator):
 class _WrongResolutionMaskPropagator(DummyIdentityMaskPropagator):
     """Propagator that returns masks at a resolution different from the frame.
 
-    Reproduces a backend that internally resizes or pads without upsampling
-    back to the input frame grid, which would make mask-conditioning gate
-    associations in the wrong coordinate space.
+    Reproduces a backend that internally resizes or pads without upsampling back to the input frame grid, which would
+    make mask-conditioning gate associations in the wrong coordinate space.
     """
 
     def propagate(self, frame: np.ndarray) -> MaskOutput | None:
@@ -518,9 +516,8 @@ def test_mask_manager_removes_terminated_tracklet_from_pending_pool_before_initi
 def test_mask_manager_resets_initialized_flag_when_propagation_fails_after_init() -> None:
     """Scenario: propagate() returns None after a prior successful init.
 
-    The manager must reset ``_initialized`` to False so that a later call
-    re-attempts mask creation from scratch instead of assuming a still-valid
-    propagator state.
+    The manager must reset ``_initialized`` to False so that a later call re-attempts mask creation from scratch instead
+    of assuming a still-valid propagator state.
     """
     manager = MaskManager(
         mask_generator=DummyBoxMaskGenerator(),
@@ -551,8 +548,8 @@ def test_mask_manager_resets_initialized_flag_when_propagation_fails_after_init(
 
 
 def test_mask_manager_init_raises_value_error_for_out_of_range_threshold() -> None:
-    """Scenario: constructing MaskManager with an overlap threshold outside
-    [0, 1] must raise ValueError instead of silently accepting it."""
+    """Scenario: constructing MaskManager with an overlap threshold outside [0, 1] must raise ValueError instead of
+    silently accepting it."""
     with pytest.raises(ValueError, match="mask_creation_bbox_overlap_threshold"):
         MaskManager(
             mask_generator=DummyBoxMaskGenerator(),
@@ -562,8 +559,8 @@ def test_mask_manager_init_raises_value_error_for_out_of_range_threshold() -> No
 
 
 def test_mask_manager_pending_tracklet_ids_property_snapshots_the_pool() -> None:
-    """Scenario: the public property mirrors the deferral pool and hands back a
-    read-only copy, so a caller cannot mutate the manager through it."""
+    """Scenario: the public property mirrors the deferral pool and hands back a read-only copy, so a caller cannot
+    mutate the manager through it."""
     manager = MaskManager(
         mask_generator=DummyBoxMaskGenerator(),
         mask_propagator=DummyIdentityMaskPropagator(),

--- a/tests/core/test_mcbyte_deprecated_shims.py
+++ b/tests/core/test_mcbyte_deprecated_shims.py
@@ -6,10 +6,9 @@
 
 """Back-compat shims for the mask stack moved out of ``trackers.core.mcbyte``.
 
-The shims use two mechanisms, so the tests are split the same way: the
-``deprecated_class`` proxies warn on use and forward to the real class, while
-the abstract base classes are served by a module ``__getattr__`` that warns on
-import and hands back the real class so it stays subclassable.
+The shims use two mechanisms, so the tests are split the same way: the ``deprecated_class`` proxies warn on use and
+forward to the real class, while the abstract base classes are served by a module ``__getattr__`` that warns on import
+and hands back the real class so it stays subclassable.
 """
 
 from __future__ import annotations
@@ -75,9 +74,8 @@ PROXIED_SYMBOLS = [
 class TestProxiedSymbolsWarnOnUseNotOnImport:
     """``MaskOutput``, ``TrackletSnapshot`` and ``MaskManager`` are pyDeprecate proxies.
 
-    Their warning fires when the name is *used*, which is the half of the split
-    that differs from the abstract base classes below. Both directions are
-    asserted so the asymmetry cannot drift unnoticed.
+    Their warning fires when the name is *used*, which is the half of the split that differs from the abstract base
+    classes below. Both directions are asserted so the asymmetry cannot drift unnoticed.
     """
 
     @pytest.mark.parametrize(("name", "real"), PROXIED_SYMBOLS)
@@ -135,8 +133,8 @@ class TestProxiedSymbolsWarnOnUseNotOnImport:
 class TestForwardedAbstractBasesWarnOnImport:
     """``MaskGenerator`` and ``MaskPropagator`` are served by a module ``__getattr__``.
 
-    Unlike the proxies above, these warn at *import* and hand back the real
-    class, which is what keeps them subclassable.
+    Unlike the proxies above, these warn at *import* and hand back the real class, which is what keeps them
+    subclassable.
     """
 
     @pytest.mark.parametrize(("name", "expected"), FORWARDED_ABCS)

--- a/tests/core/test_mcbyte_tracker.py
+++ b/tests/core/test_mcbyte_tracker.py
@@ -206,10 +206,8 @@ def test_mcbyte_does_not_advance_masks_on_duplicate_timestamp() -> None:
 def test_mcbyte_warns_once_for_mask_manager_with_dynamic_rate_timestamps() -> None:
     """enable_mask_manager + dynamic-rate timestamps warns once, not on every call.
 
-    The mask backend advances one step per update() call regardless of
-    elapsed time, while Kalman prediction and pruning scale by timestamp —
-    a desync that grows with gap size. Disclosed in docs; this warning
-    surfaces it at runtime too.
+    The mask backend advances one step per update() call regardless of elapsed time, while Kalman prediction and pruning
+    scale by timestamp — a desync that grows with gap size. Disclosed in docs; this warning surfaces it at runtime too.
     """
     mask_manager = SpyMaskManager()
     tracker = McByteTracker(
@@ -804,10 +802,9 @@ def test_mcbyte_rejects_unused_mask_config() -> None:
 def test_get_iou_matrix_raises_contextual_error_on_cache_miss() -> None:
     """_get_iou_matrix raises a contextual KeyError when a tracklet is absent from the cache.
 
-    The decode-once map must contain every tracklet passed to the helper (it is
-    built from ``self.tracks`` once per ``update()``). A miss is an internal-invariant
-    violation; the helper surfaces it with a message naming the cache contract rather
-    than a bare ``KeyError: <id int>``.
+    The decode-once map must contain every tracklet passed to the helper (it is built from ``self.tracks`` once per
+    ``update()``). A miss is an internal-invariant violation; the helper surfaces it with a message naming the cache
+    contract rather than a bare ``KeyError: <id int>``.
     """
     tracker = McByteTracker(enable_cmc=False, enable_mask_manager=False)
     tracklet = McByteTracklet(initial_bbox=np.array([0.0, 0.0, 10.0, 10.0], dtype=np.float32))

--- a/tests/core/test_registration.py
+++ b/tests/core/test_registration.py
@@ -29,12 +29,13 @@ class TestParseDocstringArguments:
             ("", {}),
             # No Args section
             (
-                """
-                Some description without Args section.
+                """Some description without Args section.
 
                 Returns:
                     Something.
-                """,
+                """
+
+                   ,
                 {},
             ),
             # Simple param_name: description format
@@ -51,7 +52,9 @@ class TestParseDocstringArguments:
                 Args:
                     param1: Description that spans
                         multiple lines here.
-                """,
+                """
+
+                   ,
                 {"param1": "Description that spans multiple lines here."},
             ),
             # Multiple parameters
@@ -76,7 +79,9 @@ class TestParseDocstringArguments:
 
                 Returns:
                     Something.
-                """,
+                """
+
+                   ,
                 {"param1": "Description."},
             ),
             # Real-world style with type in description
@@ -94,7 +99,9 @@ class TestParseDocstringArguments:
                 Args:
                     param1 (int): First parameter.
                     param2 (str): Second parameter.
-                """,
+                """
+
+                   ,
                 {"param1": "First parameter.", "param2": "Second parameter."},
             ),
             # param (type, optional): format
@@ -111,7 +118,9 @@ class TestParseDocstringArguments:
                 Args:
                     config.threshold: The threshold value for detection.
                     model.weights: Path to model weights file.
-                """,
+                """
+
+                   ,
                 {
                     "config.threshold": "The threshold value for detection.",
                     "model.weights": "Path to model weights file.",
@@ -290,7 +299,6 @@ class TestTrackerAutoRegistration:
 
 class TestSearchSpaceValidation:
     """Tests for search_space ClassVar validation in __init_subclass__."""
-
     def test_search_space_keys_match_init_params(self) -> None:
         """Registered trackers' search_space keys are valid __init__ params."""
         from trackers import (
@@ -311,10 +319,8 @@ class TestSearchSpaceValidation:
             init_params = set(inspect.signature(tracker_cls.__init__).parameters) - {"self"}
             for key in tracker_cls.search_space:
                 assert key in init_params, f"{tracker_cls.__name__}.search_space has invalid key: {key}"
-
     def test_search_space_invalid_key_raises_value_error(self) -> None:
         """A tracker with search_space key not in __init__ raises ValueError."""
-
         with pytest.raises(ValueError, match=r"search_space key .* is not a parameter"):
 
             class BadTracker(BaseTracker):

--- a/tests/core/test_registration.py
+++ b/tests/core/test_registration.py
@@ -340,6 +340,7 @@ class TestSearchSpaceValidation:
 
                 def reset(self) -> None:
                     pass
+
     def test_tracker_without_search_space_works(self) -> None:
         """Trackers without search_space are still valid."""
 
@@ -359,8 +360,10 @@ class TestSearchSpaceValidation:
 
             def reset(self) -> None:
                 pass
+
         assert not hasattr(MinimalTracker, "search_space") or getattr(MinimalTracker, "search_space", None) is None
         assert "minimal" in BaseTracker._registered_trackers()
+
     def test_tracker_with_empty_search_space_works(self) -> None:
         """Trackers with empty search_space skip validation."""
 
@@ -457,6 +460,7 @@ class TestTrackerInstantiation:
         tracker = info.tracker_class(lost_track_buffer=60, frame_rate=60.0)  # type: ignore[call-arg]
         # max(1, ceil(60.0/30.0 * 60)) = 120
         assert tracker.maximum_frames_without_update == 120  # type: ignore[attr-defined]
+
     def test_instantiate_with_registry_params(self) -> None:
         """Test creating tracker with params dict like CLI would do."""
         info = BaseTracker._lookup_tracker("sort")

--- a/tests/core/test_registration.py
+++ b/tests/core/test_registration.py
@@ -345,7 +345,6 @@ class TestSearchSpaceValidation:
 
                 def reset(self) -> None:
                     pass
-
     def test_tracker_without_search_space_works(self) -> None:
         """Trackers without search_space are still valid."""
 
@@ -365,10 +364,8 @@ class TestSearchSpaceValidation:
 
             def reset(self) -> None:
                 pass
-
         assert not hasattr(MinimalTracker, "search_space") or getattr(MinimalTracker, "search_space", None) is None
         assert "minimal" in BaseTracker._registered_trackers()
-
     def test_tracker_with_empty_search_space_works(self) -> None:
         """Trackers with empty search_space skip validation."""
 
@@ -463,10 +460,8 @@ class TestTrackerInstantiation:
         info = BaseTracker._lookup_tracker("bytetrack")
         assert info is not None
         tracker = info.tracker_class(lost_track_buffer=60, frame_rate=60.0)  # type: ignore[call-arg]
-
         # max(1, ceil(60.0/30.0 * 60)) = 120
         assert tracker.maximum_frames_without_update == 120  # type: ignore[attr-defined]
-
     def test_instantiate_with_registry_params(self) -> None:
         """Test creating tracker with params dict like CLI would do."""
         info = BaseTracker._lookup_tracker("sort")

--- a/tests/core/test_registration.py
+++ b/tests/core/test_registration.py
@@ -20,6 +20,72 @@ from trackers.core.base import (
 
 from .shared_ids import ALL_TRACKER_IDS
 
+# Raw docstring fixtures for TestParseDocstringArguments, kept as module-level
+# constants (not inline in the parametrize list) because docformatter
+# misidentifies bare triple-quoted strings in that position as real
+# docstrings and reformats them, fighting ruff-format on every run.
+_DOCSTRING_NO_ARGS_SECTION = """\
+Some description without Args section.
+
+Returns:
+    Something.
+"""
+
+_DOCSTRING_SIMPLE_PARAM = """
+Args:
+    param1: Description of param1.
+"""
+
+_DOCSTRING_MULTILINE_DESCRIPTION = """
+Args:
+    param1: Description that spans
+        multiple lines here.
+"""
+
+_DOCSTRING_MULTIPLE_PARAMS = """
+Args:
+    param1: First parameter.
+    param2: Second parameter.
+    param3: Third parameter.
+"""
+
+_DOCSTRING_ARGS_ENDS_AT_RETURNS = """
+Args:
+    param1: Description.
+
+Returns:
+    Something.
+"""
+
+_DOCSTRING_REAL_WORLD_TYPE = """
+Args:
+    lost_track_buffer: `int` specifying number of frames
+        to buffer when track is lost.
+"""
+
+_DOCSTRING_PARAM_WITH_TYPE = """
+Args:
+    param1 (int): First parameter.
+    param2 (str): Second parameter.
+"""
+
+_DOCSTRING_PARAM_OPTIONAL_TYPE = """
+Args:
+    param1 (int, optional): Optional integer.
+"""
+
+_DOCSTRING_DOTTED_PARAM = """
+Args:
+    config.threshold: The threshold value for detection.
+    model.weights: Path to model weights file.
+"""
+
+_DOCSTRING_DESCRIPTION_WITH_COLON = """
+Args:
+    format_str: Use format: key=value for configuration.
+    path: File path, e.g.: /home/user/file.txt
+"""
+
 
 class TestParseDocstringArguments:
     @pytest.mark.parametrize(
@@ -28,99 +94,30 @@ class TestParseDocstringArguments:
             # Empty docstring
             ("", {}),
             # No Args section
-            (
-                """Some description without Args section.
-
-                Returns:
-                    Something.
-                """
-
-                   ,
-                {},
-            ),
+            (_DOCSTRING_NO_ARGS_SECTION, {}),
             # Simple param_name: description format
-            (
-                """
-                Args:
-                    param1: Description of param1.
-                """,
-                {"param1": "Description of param1."},
-            ),
+            (_DOCSTRING_SIMPLE_PARAM, {"param1": "Description of param1."}),
             # Multi-line description
-            (
-                """
-                Args:
-                    param1: Description that spans
-                        multiple lines here.
-                """
-
-                   ,
-                {"param1": "Description that spans multiple lines here."},
-            ),
+            (_DOCSTRING_MULTILINE_DESCRIPTION, {"param1": "Description that spans multiple lines here."}),
             # Multiple parameters
             (
-                """
-                Args:
-                    param1: First parameter.
-                    param2: Second parameter.
-                    param3: Third parameter.
-                """,
-                {
-                    "param1": "First parameter.",
-                    "param2": "Second parameter.",
-                    "param3": "Third parameter.",
-                },
+                _DOCSTRING_MULTIPLE_PARAMS,
+                {"param1": "First parameter.", "param2": "Second parameter.", "param3": "Third parameter."},
             ),
             # Args section ends at Returns
-            (
-                """
-                Args:
-                    param1: Description.
-
-                Returns:
-                    Something.
-                """
-
-                   ,
-                {"param1": "Description."},
-            ),
+            (_DOCSTRING_ARGS_ENDS_AT_RETURNS, {"param1": "Description."}),
             # Real-world style with type in description
             (
-                """
-                Args:
-                    lost_track_buffer: `int` specifying number of frames
-                        to buffer when track is lost.
-                """,
+                _DOCSTRING_REAL_WORLD_TYPE,
                 {"lost_track_buffer": "`int` specifying number of frames to buffer when track is lost."},
             ),
             # param (type): format
-            (
-                """
-                Args:
-                    param1 (int): First parameter.
-                    param2 (str): Second parameter.
-                """
-
-                   ,
-                {"param1": "First parameter.", "param2": "Second parameter."},
-            ),
+            (_DOCSTRING_PARAM_WITH_TYPE, {"param1": "First parameter.", "param2": "Second parameter."}),
             # param (type, optional): format
-            (
-                """
-                Args:
-                    param1 (int, optional): Optional integer.
-                """,
-                {"param1": "Optional integer."},
-            ),
+            (_DOCSTRING_PARAM_OPTIONAL_TYPE, {"param1": "Optional integer."}),
             # Dotted parameter name
             (
-                """
-                Args:
-                    config.threshold: The threshold value for detection.
-                    model.weights: Path to model weights file.
-                """
-
-                   ,
+                _DOCSTRING_DOTTED_PARAM,
                 {
                     "config.threshold": "The threshold value for detection.",
                     "model.weights": "Path to model weights file.",
@@ -128,11 +125,7 @@ class TestParseDocstringArguments:
             ),
             # Description containing colon
             (
-                """
-                Args:
-                    format_str: Use format: key=value for configuration.
-                    path: File path, e.g.: /home/user/file.txt
-                """,
+                _DOCSTRING_DESCRIPTION_WITH_COLON,
                 {
                     "format_str": "Use format: key=value for configuration.",
                     "path": "File path, e.g.: /home/user/file.txt",
@@ -299,6 +292,7 @@ class TestTrackerAutoRegistration:
 
 class TestSearchSpaceValidation:
     """Tests for search_space ClassVar validation in __init_subclass__."""
+
     def test_search_space_keys_match_init_params(self) -> None:
         """Registered trackers' search_space keys are valid __init__ params."""
         from trackers import (
@@ -319,6 +313,7 @@ class TestSearchSpaceValidation:
             init_params = set(inspect.signature(tracker_cls.__init__).parameters) - {"self"}
             for key in tracker_cls.search_space:
                 assert key in init_params, f"{tracker_cls.__name__}.search_space has invalid key: {key}"
+
     def test_search_space_invalid_key_raises_value_error(self) -> None:
         """A tracker with search_space key not in __init__ raises ValueError."""
         with pytest.raises(ValueError, match=r"search_space key .* is not a parameter"):

--- a/tests/core/test_timestamp_plumbing.py
+++ b/tests/core/test_timestamp_plumbing.py
@@ -5,8 +5,8 @@
 # ------------------------------------------------------------------------
 """Timestamp plumbing and time-based pruning tests.
 
-``_predict_timing`` unit tests run on SORT only (shared ``BaseTracker`` impl).
-Integration behaviour is parametrized over timestamp-aware trackers.
+``_predict_timing`` unit tests run on SORT only (shared ``BaseTracker`` impl). Integration behaviour is parametrized
+over timestamp-aware trackers.
 """
 
 from __future__ import annotations
@@ -556,15 +556,13 @@ def test_same_process_noise_at_reference_fps(
 def test_mcbyte_predict_forwards_frame_rate_for_mid_band_gap() -> None:
     """McByte's ``predict()`` must forward ``frame_rate`` for a mid-band gap.
 
-    ``frame_step=1.15`` sits outside the fixed 0.1 frame-unit fallback
-    tolerance but inside the fps-scaled ``0.004 * frame_rate`` band at 60 FPS
-    (0.24) — the exact divergence zone a dropped ``frame_rate`` falls out of.
+    ``frame_step=1.15`` sits outside the fixed 0.1 frame-unit fallback tolerance but inside the fps-scaled ``0.004 *
+    frame_rate`` band at 60 FPS (0.24) — the exact divergence zone a dropped ``frame_rate`` falls out of.
 
-    Asserted directly on the tracklet, not through ``McByteTracker.update()``:
-    McByte's ``update()`` unconditionally recalibrates ``Q`` from the current
-    bbox scale via ``_refresh_noise_from_state``, which overwrites whatever
-    ``predict()`` computed before the next frame — the only place this
-    regression is observable is the tracklet's state right after ``predict()``.
+    Asserted directly on the tracklet, not through ``McByteTracker.update()``: McByte's ``update()`` unconditionally
+    recalibrates ``Q`` from the current bbox scale via ``_refresh_noise_from_state``, which overwrites whatever
+    ``predict()`` computed before the next frame — the only place this regression is observable is the tracklet's state
+    right after ``predict()``.
     """
     box = np.array([100.0, 100.0, 150.0, 200.0], dtype=np.float32)
     nominal = McByteTracklet(initial_bbox=box)

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -101,7 +101,7 @@ class _TrackingIoU(BaseIoU):
     ids=["single_detection", "two_detections"],
 )
 def test_tracker_update_does_not_mutate_input(tracker_id: str, xyxy: np.ndarray, confidence: np.ndarray) -> None:
-    """update() must not assign tracker_id on the caller's sv.Detections."""
+    """Update() must not assign tracker_id on the caller's sv.Detections."""
     tracker = _instantiate(tracker_id, minimum_consecutive_frames=1)
     dets = sv.Detections(xyxy=xyxy)
     dets.confidence = confidence
@@ -115,7 +115,7 @@ def test_tracker_update_does_not_mutate_input(tracker_id: str, xyxy: np.ndarray,
 
 @pytest.mark.parametrize("tracker_id", ALL_TRACKER_IDS)
 def test_tracker_update_empty_does_not_mutate_input(tracker_id: str) -> None:
-    """update() with empty detections must not mutate input."""
+    """Update() with empty detections must not mutate input."""
     tracker = _instantiate(tracker_id, minimum_consecutive_frames=1)
     dets = sv.Detections(xyxy=np.zeros((0, 4), dtype=float))
     dets.confidence = np.array([], dtype=float)
@@ -177,9 +177,8 @@ def test_no_confidence_detections_can_spawn_confirmed_tracks(tracker_id: str) ->
 def test_no_confidence_matches_explicit_ones_confidence(tracker_id: str, xyxy_boxes: np.ndarray) -> None:
     """Every tracker treats confidence=None the same as all-ones across multi-box batches.
 
-    Multi-detection batches exercise confidence bucketing in trackers that split
-    high/low detections; a regression that mis-buckets ``confidence=None`` would
-    still pass single-box equality but diverge here.
+    Multi-detection batches exercise confidence bucketing in trackers that split high/low detections; a regression that
+    mis-buckets ``confidence=None`` would still pass single-box equality but diverge here.
     """
     no_confidence_tracker = _instantiate(tracker_id, minimum_consecutive_frames=1)
     explicit_confidence_tracker = _instantiate(tracker_id, minimum_consecutive_frames=1)
@@ -205,11 +204,10 @@ def test_no_confidence_matches_explicit_ones_confidence(tracker_id: str, xyxy_bo
 
 
 def test_bytetrack_no_confidence_spawns_tracks_below_activation_threshold() -> None:
-    """confidence=None must route every detection to Stage 1 even when explicit-low-conf would not spawn.
+    """Confidence=None must route every detection to Stage 1 even when explicit-low-conf would not spawn.
 
-    Asserts the actual semantic of treating `None` as 1.0: explicit
-    confidences that fall under `track_activation_threshold` get suppressed
-    in the low-confidence branch, but the same boxes with `confidence=None`
+    Asserts the actual semantic of treating `None` as 1.0: explicit confidences that fall under
+    `track_activation_threshold` get suppressed in the low-confidence branch, but the same boxes with `confidence=None`
     still produce confirmed tracker IDs.
     """
     activation_threshold = 0.6
@@ -254,9 +252,8 @@ def test_bytetrack_no_confidence_spawns_tracks_below_activation_threshold() -> N
 
 
 def test_bytetrack_returns_unmatched_detection_between_thresholds() -> None:
-    """A detection whose confidence sits between high_conf_det_threshold and
-    track_activation_threshold must still be returned (with tracker_id -1) when
-    it matches no track, not silently dropped."""
+    """A detection whose confidence sits between high_conf_det_threshold and track_activation_threshold must still be
+    returned (with tracker_id -1) when it matches no track, not silently dropped."""
     tracker = ByteTrackTracker(
         high_conf_det_threshold=0.6,
         track_activation_threshold=0.7,
@@ -278,8 +275,8 @@ def test_bytetrack_returns_unmatched_detection_between_thresholds() -> None:
 def test_bytetrack_all_detections_in_gap() -> None:
     """All detections in [high_conf_det_threshold, track_activation_threshold) return tracker_id=-1.
 
-    When every detection falls in the confidence gap, Stage 2 loop is empty and
-    _spawn_new_tracks processes them all but spawns no tracks.
+    When every detection falls in the confidence gap, Stage 2 loop is empty and _spawn_new_tracks processes them all but
+    spawns no tracks.
     """
     tracker = ByteTrackTracker(
         high_conf_det_threshold=0.5,
@@ -301,8 +298,8 @@ def test_bytetrack_all_detections_in_gap() -> None:
 def test_bytetrack_mid_gap_detection_returned_across_frames() -> None:
     """Mid-gap detection (tracker_id=-1) continues to appear in output on frame 2+.
 
-    A regression where a mid-gap detection stops being returned on subsequent
-    frames would not be caught by the single-frame test.
+    A regression where a mid-gap detection stops being returned on subsequent frames would not be caught by the single-
+    frame test.
     """
     tracker = ByteTrackTracker(
         high_conf_det_threshold=0.6,
@@ -473,7 +470,7 @@ def _run_until_n_confirmed(
 
 @pytest.mark.parametrize("tracker_id", ALL_TRACKER_IDS)
 def test_reset_clears_tracks_and_restarts_ids(tracker_id: str) -> None:
-    """reset() must clear state and restart tracker IDs from zero."""
+    """Reset() must clear state and restart tracker IDs from zero."""
     tracker = _instantiate(tracker_id, minimum_consecutive_frames=1)
     det = _detection((100.0, 100.0, 200.0, 200.0))
 

--- a/tests/core/test_tracklets.py
+++ b/tests/core/test_tracklets.py
@@ -72,7 +72,7 @@ def test_tracklet_starts_with_zero_time_since_update(
 def test_tracklet_predict_increments_time_since_update(
     tracklet_class: type[BaseTracklet],
 ) -> None:
-    """predict() must increment time_since_update by 1 each call."""
+    """Predict() must increment time_since_update by 1 each call."""
     t = _new_tracklet(tracklet_class, _BBOX)
     t.predict()
     assert t.time_since_update == 1
@@ -84,7 +84,7 @@ def test_tracklet_predict_increments_time_since_update(
 def test_tracklet_predict_increments_age(
     tracklet_class: type[BaseTracklet],
 ) -> None:
-    """predict() must increment age by 1 each call."""
+    """Predict() must increment age by 1 each call."""
     t = _new_tracklet(tracklet_class, _BBOX)
     initial_age = t.age
     t.predict()
@@ -95,7 +95,7 @@ def test_tracklet_predict_increments_age(
 def test_tracklet_predict_returns_finite_bbox(
     tracklet_class: type[BaseTracklet],
 ) -> None:
-    """predict() must always return finite bbox coordinates."""
+    """Predict() must always return finite bbox coordinates."""
     t = _new_tracklet(tracklet_class, _BBOX)
     for _ in range(10):
         bbox_out = t.predict()
@@ -106,7 +106,7 @@ def test_tracklet_predict_returns_finite_bbox(
 def test_tracklet_update_resets_time_since_update(
     tracklet_class: type[BaseTracklet],
 ) -> None:
-    """update(bbox) must reset time_since_update to 0."""
+    """Update(bbox) must reset time_since_update to 0."""
     t = _new_tracklet(tracklet_class, _BBOX)
     t.predict()
     assert t.time_since_update == 1
@@ -127,7 +127,7 @@ def test_tracklet_starts_with_one_successful_update(
 def test_tracklet_update_increments_successful_updates(
     tracklet_class: type[BaseTracklet],
 ) -> None:
-    """update(bbox) increments number_of_successful_updates for SORT-like counters."""
+    """Update(bbox) increments number_of_successful_updates for SORT-like counters."""
     tracklet = _new_tracklet(tracklet_class, _BBOX)
     before = getattr(tracklet, "number_of_successful_updates")
     tracklet.update(_BBOX2)
@@ -161,13 +161,11 @@ def test_bytetrack_tracklet_starts_with_one_successful_consecutive_update(
 def test_ocsort_oru_triggers_on_single_frame_gap(bbox: np.ndarray) -> None:
     """ORU unfreeze fires correctly after exactly one missed frame.
 
-    Copilot raised a concern that ``_observed`` stays ``True`` throughout
-    the first missed frame, so ORU would not fire on a 1-frame gap.  The
-    freeze is intentionally deferred to the *start* of the next
-    ``predict()`` call (the re-match frame), where ``time_since_update > 0
-    AND _observed`` is the reliable first-miss signal.  At that point the
-    frozen KF state is identical to what an immediate freeze would have
-    saved, and ``_unfreeze()`` is called by ``update()`` in the same frame.
+    Copilot raised a concern that ``_observed`` stays ``True`` throughout the first missed frame, so ORU would not fire
+    on a 1-frame gap.  The freeze is intentionally deferred to the *start* of the next ``predict()`` call (the re-match
+    frame), where ``time_since_update > 0 AND _observed`` is the reliable first-miss signal.  At that point the frozen
+    KF state is identical to what an immediate freeze would have saved, and ``_unfreeze()`` is called by ``update()`` in
+    the same frame.
     """
     tracklet = OCSORTTracklet(bbox)
 
@@ -199,8 +197,8 @@ def test_ocsort_oru_triggers_on_single_frame_gap(bbox: np.ndarray) -> None:
 def test_ocsort_oru_unfreeze_uses_timing_frame_step_predicts(bbox: np.ndarray) -> None:
     """ORU virtual trajectory passes timing.frame_step to each sub-step predict.
 
-    Each sub-step calls ``state_estimator.predict(timing.frame_step)`` so that
-    variable-FPS gaps are scaled correctly, not fixed at 1.0.
+    Each sub-step calls ``state_estimator.predict(timing.frame_step)`` so that variable-FPS gaps are scaled correctly,
+    not fixed at 1.0.
     """
     from trackers.utils.predict_timing import PredictTiming
 

--- a/tests/eval/test_evaluate.py
+++ b/tests/eval/test_evaluate.py
@@ -74,7 +74,7 @@ class TestEvaluateMOTSequence:
         assert result.Identity is not None
 
     def test_table_hota_only(self, sample_mot_files: tuple[Path, Path]) -> None:
-        """table() shows HOTA and DetA; MOTA absent when only HOTA computed."""
+        """Table() shows HOTA and DetA; MOTA absent when only HOTA computed."""
         gt_path, tracker_path = sample_mot_files
 
         result = evaluate_mot_sequence(
@@ -89,7 +89,7 @@ class TestEvaluateMOTSequence:
         assert "MOTA" not in table_str
 
     def test_json_hota_only(self, sample_mot_files: tuple[Path, Path]) -> None:
-        """json() includes HOTA fields when only HOTA computed."""
+        """Json() includes HOTA fields when only HOTA computed."""
         gt_path, tracker_path = sample_mot_files
 
         result = evaluate_mot_sequence(

--- a/tests/eval/test_hota.py
+++ b/tests/eval/test_hota.py
@@ -25,8 +25,8 @@ def _sequential_hota_reference(
 ) -> dict[str, np.ndarray]:
     """Pre-vectorization HOTA reference: per-alpha Python loop + dict id-remapping.
 
-    Mirrors the pre-PR second-pass logic (commit 2ca10bd^) for differential testing.
-    Used only by test_output_matches_sequential_reference to guard the hot path.
+    Mirrors the pre-PR second-pass logic (commit 2ca10bd^) for differential testing. Used only by
+    test_output_matches_sequential_reference to guard the hot path.
     """
     from scipy.optimize import linear_sum_assignment
 
@@ -301,9 +301,8 @@ class TestComputeHOTAMetrics:
     def test_metrics_invariant_to_id_relabeling(self) -> None:
         """HOTA depends only on association structure, not on the integer id values.
 
-        Relabeling ground-truth and tracker ids with a consistent, non-monotonic
-        bijection (including ids that are unsorted within a frame) must leave every
-        metric unchanged. This guards the internal id-to-index remapping.
+        Relabeling ground-truth and tracker ids with a consistent, non-monotonic bijection (including ids that are
+        unsorted within a frame) must leave every metric unchanged. This guards the internal id-to-index remapping.
         """
         gt_ids = [
             np.array([0, 1, 2]),
@@ -395,9 +394,8 @@ class TestComputeHOTAMetrics:
     ) -> None:
         """Vectorized implementation is bit-identical to pre-vectorization sequential version.
 
-        Guards the hot path against future silent drift. Compares per-alpha arrays
-        between the vectorized code and _sequential_hota_reference (dict map +
-        per-alpha Python loop, matching commit 2ca10bd^).
+        Guards the hot path against future silent drift. Compares per-alpha arrays between the vectorized code and
+        _sequential_hota_reference (dict map + per-alpha Python loop, matching commit 2ca10bd^).
         """
         new_result = compute_hota_metrics(gt_ids, tracker_ids, similarity_scores)
         ref_result = _sequential_hota_reference(gt_ids, tracker_ids, similarity_scores)

--- a/tests/eval/test_integration.py
+++ b/tests/eval/test_integration.py
@@ -6,9 +6,8 @@
 
 """Integration tests comparing our metrics against TrackEval on real data.
 
-These tests download SportsMOT and DanceTrack test datasets and verify that our
-benchmark evaluation produces identical results to TrackEval.
-Numerical parity is the key requirement.
+These tests download SportsMOT and DanceTrack test datasets and verify that our benchmark evaluation produces identical
+results to TrackEval. Numerical parity is the key requirement.
 """
 
 from __future__ import annotations

--- a/tests/io/test_mot.py
+++ b/tests/io/test_mot.py
@@ -30,15 +30,15 @@ def _frame(
 class TestMotDistractorPreprocessing:
     """GT preprocessing must follow TrackEval's class-based distractor handling.
 
-    TrackEval (`mot_challenge_2d_box.py`) scores only the pedestrian class (1)
-    and drops tracker detections that best-match a distractor-class region
-    `{2, 7, 8, 12}`. These cases never appear in the single-class SportsMOT /
-    DanceTrack integration fixtures, so they are covered here directly.
+    TrackEval (`mot_challenge_2d_box.py`) scores only the pedestrian class (1) and drops tracker detections that best-
+    match a distractor-class region `{2, 7, 8, 12}`. These cases never appear in the single-class SportsMOT / DanceTrack
+    integration fixtures, so they are covered here directly.
     """
 
     def test_distractor_class_excluded_and_matching_tracker_removed(self) -> None:
-        """A distractor-class GT (conf==1) must not be scored as GT, and a
-        tracker detection overlapping it must be removed rather than counted FP.
+        """A distractor-class GT (conf==1) must not be scored as GT, and a tracker detection overlapping it must be
+        removed rather than counted FP.
+
         A separate ignored pedestrian (conf==0) must also be dropped from GT.
         """
         ground_truth = {
@@ -91,9 +91,7 @@ class TestMotDistractorPreprocessing:
         ],
     )
     def test_all_distractor_classes_excluded(self, distractor_class: int) -> None:
-        """Every class in _DISTRACTOR_CLASSES must be excluded from GT and suppress
-        an overlapping tracker detection.
-        """
+        """Every class in _DISTRACTOR_CLASSES must be excluded from GT and suppress an overlapping tracker detection."""
         ground_truth = {1: _frame([1], [[0, 0, 10, 10]], [1.0], [distractor_class])}
         tracker = {1: _frame([10], [[0, 0, 10, 10]], [1.0], [1])}
 
@@ -105,9 +103,8 @@ class TestMotDistractorPreprocessing:
     def test_ignored_non_distractor_gt_does_not_suppress_tracker(self) -> None:
         """GT (conf=0, non-distractor class) is neither scored GT nor a distractor.
 
-        A tracker detection overlapping it must be kept, not suppressed.  Before
-        this PR the old `~valid_mask` would have included such rows in the
-        distractor mask; the new class-based mask must NOT.
+        A tracker detection overlapping it must be kept, not suppressed.  Before this PR the old `~valid_mask` would
+        have included such rows in the distractor mask; the new class-based mask must NOT.
         """
         ground_truth = {
             1: _frame([1], [[0, 0, 10, 10]], [0.0], [5])  # conf=0, class=5 (vehicle)
@@ -161,9 +158,8 @@ class TestMotDistractorPreprocessing:
         assert len(sequence.tracker_ids) == 2
 
     def test_single_class_sequence_unaffected(self) -> None:
-        """SportsMOT / DanceTrack-style data (all pedestrian, conf==1) must be
-        passed through unchanged, so existing parity is preserved.
-        """
+        """SportsMOT / DanceTrack-style data (all pedestrian, conf==1) must be passed through unchanged, so existing
+        parity is preserved."""
         ground_truth = {
             1: _frame([1, 2], [[0, 0, 10, 10], [50, 50, 10, 10]], [1.0, 1.0], [1, 1]),
         }

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -27,17 +27,16 @@ VIDEO_COMPRESSION_TOLERANCE = 5
 def create_frame(index: int) -> np.ndarray:
     """Create a test frame with deterministic pixel values for verification.
 
-    Each frame has all pixels set to the same value derived from the index.
-    The value is calculated as index * VALUE_MULTIPLIER (clamped to 255).
+    Each frame has all pixels set to the same value derived from the index. The value is calculated as index *
+    VALUE_MULTIPLIER (clamped to 255).
 
-    We use VALUE_MULTIPLIER=40 to spread values apart (0, 40, 80, 120, ...)
-    because video codecs like mp4v use lossy compression that can alter
-    pixel values by small amounts. Adjacent values like 0, 1, 2, 3 would
-    become indistinguishable after compression, but 0, 40, 80, 120 remain
-    clearly distinguishable even with compression artifacts.
+    We use VALUE_MULTIPLIER=40 to spread values apart (0, 40, 80, 120, ...) because video codecs like mp4v use lossy
+    compression that can alter pixel values by small amounts. Adjacent values like 0, 1, 2, 3 would become
+    indistinguishable after compression, but 0, 40, 80, 120 remain clearly distinguishable even with compression
+    artifacts.
 
-    For lossless formats (PNG, JPG with quality=100), exact matching works.
-    For video files, use expected_frame_value() with a tolerance check.
+    For lossless formats (PNG, JPG with quality=100), exact matching works. For video files, use expected_frame_value()
+    with a tolerance check.
     """
     pixel_value = min(index * VALUE_MULTIPLIER, 255)
     return np.full((FRAME_HEIGHT, FRAME_WIDTH, 3), pixel_value, dtype=np.uint8)

--- a/tests/motion/test_estimator.py
+++ b/tests/motion/test_estimator.py
@@ -20,9 +20,8 @@ def _noise_frame(height: int, width: int, seed: int) -> np.ndarray:
 def test_motion_estimator_survives_resolution_change() -> None:
     """A frame size change mid-stream returns a transformation instead of crashing.
 
-    calcOpticalFlowPyrLK asserts both frames share the same size, so when a
-    source renegotiates resolution between two consecutive frames the estimator
-    must re-sync the reference frame rather than crash.
+    calcOpticalFlowPyrLK asserts both frames share the same size, so when a source renegotiates resolution between two
+    consecutive frames the estimator must re-sync the reference frame rather than crash.
     """
     estimator = MotionEstimator()
     estimator.update(_noise_frame(480, 640, seed=1))
@@ -48,9 +47,8 @@ def test_motion_estimator_recovers_after_resolution_change() -> None:
 def test_motion_estimator_resets_frame_on_resolution_change() -> None:
     """A resolution change re-baselines instead of carrying stale-scale coordinates.
 
-    The accumulated homography lives in the previous resolution's pixel space,
-    so returning it after a size change would hand back coordinates in the wrong
-    scale. The estimator must reset the reference frame to identity.
+    The accumulated homography lives in the previous resolution's pixel space, so returning it after a size change would
+    hand back coordinates in the wrong scale. The estimator must reset the reference frame to identity.
     """
     estimator = MotionEstimator()
     estimator.update(_noise_frame(480, 640, seed=1))

--- a/tests/tune/test_tuner.py
+++ b/tests/tune/test_tuner.py
@@ -398,7 +398,7 @@ class TestTunerRun:
         assert set(best.keys()) == expected_keys
 
     def test_run_calls_tracker_reset_per_sequence(self, tmp_path: Path) -> None:
-        """reset() must be called once per sequence per trial."""
+        """Reset() must be called once per sequence per trial."""
         from trackers import SORTTracker
 
         reset_calls: list[int] = []

--- a/tests/utils/test_cmc.py
+++ b/tests/utils/test_cmc.py
@@ -118,11 +118,9 @@ def test_cmc_survives_resolution_change(
 ) -> None:
     """No CMC method crashes when the frame size changes mid-stream.
 
-    A source that renegotiates resolution (e.g. an RTSP camera after a
-    reconnect, or switching clips without a reset) feeds consecutive frames of
-    different sizes. sparseOptFlow feeds both into calcOpticalFlowPyrLK, which
-    asserts they share the same size, so it used to crash; the others already
-    coped. Every method must return a finite affine matrix.
+    A source that renegotiates resolution (e.g. an RTSP camera after a reconnect, or switching clips without a reset)
+    feeds consecutive frames of different sizes. sparseOptFlow feeds both into calcOpticalFlowPyrLK, which asserts they
+    share the same size, so it used to crash; the others already coped. Every method must return a finite affine matrix.
     """
     rng = np.random.default_rng(0)
     small = rng.integers(0, 255, (480, 640, 3), dtype=np.uint8)
@@ -137,7 +135,7 @@ def test_cmc_survives_resolution_change(
 
 
 def test_cmc_sparse_optflow_returns_identity_on_resolution_change() -> None:
-    """sparseOptFlow re-inits and returns identity when the frame size changes.
+    """SparseOptFlow re-inits and returns identity when the frame size changes.
 
     This is the guarded path: the cached previous frame no longer matches the
     new frame size, so the optical-flow step is skipped for that frame.

--- a/tests/utils/test_converters.py
+++ b/tests/utils/test_converters.py
@@ -18,7 +18,7 @@ from trackers.utils.converters import (
 
 
 class TestXYWHConversion:
-    """xyxy ↔ xywh conversions and round-trip."""
+    """Xyxy ↔ xywh conversions and round-trip."""
 
     @pytest.mark.parametrize(
         ("xyxy", "expected"),
@@ -71,14 +71,14 @@ class TestXYWHConversion:
         ],
     )
     def test_roundtrip(self, xyxy: np.ndarray) -> None:
-        """xyxy → xywh → xyxy round-trip recovers the original box without drift."""
+        """Xyxy → xywh → xyxy round-trip recovers the original box without drift."""
         xywh = xyxy_to_xywh(xyxy)
         recovered = xywh_to_xyxy(xywh)
         np.testing.assert_array_almost_equal(recovered, xyxy, decimal=6)
 
 
 class TestXCYCSRConversion:
-    """xyxy ↔ xcycsr (center-x, center-y, scale, aspect) conversions and round-trip."""
+    """Xyxy ↔ xcycsr (center-x, center-y, scale, aspect) conversions and round-trip."""
 
     @pytest.mark.parametrize(
         ("xyxy", "expected"),
@@ -258,13 +258,13 @@ class TestXCYCSRConversion:
         ],
     )
     def test_roundtrip(self, xyxy: np.ndarray) -> None:
-        """xyxy → xcycsr → xyxy round-trip recovers the original 1-D box."""
+        """Xyxy → xcycsr → xyxy round-trip recovers the original 1-D box."""
         xcycsr = xyxy_to_xcycsr(xyxy)
         recovered = xcycsr_to_xyxy(xcycsr)
         np.testing.assert_array_almost_equal(recovered, xyxy, decimal=5)
 
     def test_roundtrip_2d(self) -> None:
-        """xyxy → xcycsr → xyxy round-trip preserves the original 2-D shape."""
+        """Xyxy → xcycsr → xyxy round-trip preserves the original 2-D shape."""
         xyxy = np.array([[0.0, 0.0, 10.0, 10.0]])
         xcycsr = xyxy_to_xcycsr(xyxy)
         recovered = xcycsr_to_xyxy(xcycsr)
@@ -272,7 +272,7 @@ class TestXCYCSRConversion:
         np.testing.assert_array_almost_equal(recovered, xyxy, decimal=5)
 
     def test_roundtrip_degenerate_is_lossy(self) -> None:
-        """xyxy → xcycsr → xyxy is lossy for zero-area boxes; asserts the known result."""
+        """Xyxy → xcycsr → xyxy is lossy for zero-area boxes; asserts the known result."""
         xyxy = np.array([0.0, 0.0, 10.0, 0.0])
         xcycsr = xyxy_to_xcycsr(xyxy)
         recovered = xcycsr_to_xyxy(xcycsr)

--- a/tests/utils/test_iou.py
+++ b/tests/utils/test_iou.py
@@ -192,10 +192,9 @@ class TestIoUVariantsAgainstTorchvision:
     ) -> None:
         """Validate variant-vs-reference parity across shared geometric scenarios.
 
-        `upper_bound` is used only for cases where the original tests expected
-        negative scores for non-overlapping boxes (GIoU/DIoU/CIoU).
-        BIoU is intentionally excluded from this check because buffered IoU is
-        IoU-like (non-negative) and can be zero or positive for such cases.
+        `upper_bound` is used only for cases where the original tests expected negative scores for non-overlapping boxes
+        (GIoU/DIoU/CIoU). BIoU is intentionally excluded from this check because buffered IoU is IoU-like (non-negative)
+        and can be zero or positive for such cases.
         """
         result = ours.compute(boxes_1, boxes_2)
         expected = ref_or_baseline(boxes_1, boxes_2)
@@ -402,9 +401,8 @@ class TestNormalizeForFusion:
     def test_output_in_unit_range_over_random_batch(self, metric: BaseIoU) -> None:
         """normalize_for_fusion must map similarities into [0, 1] for score fusion.
 
-        CIoU's aspect-ratio penalty drives raw scores below -1, so the naive
-        ``(x + 1) / 2`` shift (without clamping) yields negatives that corrupt
-        ``_fuse_score``. The other variants already lie in [0, 1] post-shift.
+        CIoU's aspect-ratio penalty drives raw scores below -1, so the naive ``(x + 1) / 2`` shift (without clamping)
+        yields negatives that corrupt ``_fuse_score``. The other variants already lie in [0, 1] post-shift.
         """
         rng = np.random.default_rng(103)
         xy = rng.uniform(0, 500, size=(100, 2))

--- a/tests/utils/test_motion_models.py
+++ b/tests/utils/test_motion_models.py
@@ -125,9 +125,8 @@ NEAR_NOMINAL_FRAME_STEPS = [
 def test_build_Q_returns_baseline_for_near_nominal_frame_step(frame_step: float) -> None:
     """A step off 1.0 by real clock error still counts as one nominal frame.
 
-    Compared bit for bit rather than with ``approx``: an approximate check would
-    pass on the rebuilt DWNA matrix this guards against, which differs from the
-    configured Q by two orders of magnitude on the position block.
+    Compared bit for bit rather than with ``approx``: an approximate check would pass on the rebuilt DWNA matrix this
+    guards against, which differs from the configured Q by two orders of magnitude on the position block.
     """
     baseline = np.diag([16.0, 81.0, 16.0, 81.0, 0.25, 1.2656, 0.25, 1.2656])
     noise = _noise_8d(baseline)
@@ -270,8 +269,8 @@ def test_build_Q_alternating_nominal_and_gap_steps_leaves_no_stale_state() -> No
 def test_build_Q_recalibrates_within_the_nominal_band() -> None:
     """A near-nominal step returns the *current* reference, not a cached one.
 
-    BoT-SORT refreshes its scale-aware Q on every frame, so the band must track
-    ``calibrate`` rather than pin the matrix seen on the first call.
+    BoT-SORT refreshes its scale-aware Q on every frame, so the band must track ``calibrate`` rather than pin the matrix
+    seen on the first call.
     """
     first = np.eye(8, dtype=np.float64) * 0.01
     noise = _noise_8d(first)
@@ -284,10 +283,9 @@ def test_build_Q_recalibrates_within_the_nominal_band() -> None:
 
 
 def test_build_Q_at_zero_frame_step_zeroes_kinematic_block_only() -> None:
-    """frame_step=0.0 sits outside both tolerance bands: the DWNA kinematic block collapses
-    to all-zero (dt2=dt3=dt4=0), but non-kinematic diagonal entries still come from the
-    one-frame reference Q — this is not a blanket all-zero matrix.
-    """
+    """frame_step=0.0 sits outside both tolerance bands: the DWNA kinematic block collapses to all-zero (dt2=dt3=dt4=0),
+    but non-kinematic diagonal entries still come from the one-frame reference Q — this is not a blanket all-zero
+    matrix."""
     extra = np.ones(7, dtype=np.float64) * 0.01
     extra[3] = 7.5
     noise = ScalableProcessNoise(
@@ -308,10 +306,11 @@ def test_build_Q_at_zero_frame_step_zeroes_kinematic_block_only() -> None:
 
 
 def test_build_Q_at_negative_frame_step_documents_sign_inverted_dwna() -> None:
-    """frame_step=-1.0 is not degenerate like 0.0: dt2=1, dt3=-1, dt4=1 build a real,
-    non-zero, sign-inverted DWNA matrix. This pins current documented behavior rather than
-    guarding a bug — ``build_Q`` does not validate ``frame_step`` and no shipped tracker
-    calls it with a negative step.
+    """frame_step=-1.0 is not degenerate like 0.0: dt2=1, dt3=-1, dt4=1 build a real, non-zero, sign-inverted DWNA
+    matrix.
+
+    This pins current documented behavior rather than guarding a bug — ``build_Q`` does not validate ``frame_step`` and
+    no shipped tracker calls it with a negative step.
     """
     extra = np.ones(7, dtype=np.float64) * 0.01
     extra[3] = 7.5

--- a/tests/utils/test_state_estimators.py
+++ b/tests/utils/test_state_estimators.py
@@ -72,10 +72,9 @@ def test_xcycsr_clamp_velocity_guards_projected_scale_over_frame_step(
 ) -> None:
     """``clamp_velocity`` guards the *projected* scale ``s + frame_step * vs``.
 
-    A negative scale velocity that passes the one-frame check (``s + vs > 0``)
-    used to extrapolate scale below zero over a gap, and ``xcycsr_to_xyxy``
-    then took ``sqrt`` of a negative scale -> NaN boxes. The guard must fire
-    on a non-positive projection and stay out of the way otherwise.
+    A negative scale velocity that passes the one-frame check (``s + vs > 0``) used to extrapolate scale below zero over
+    a gap, and ``xcycsr_to_xyxy`` then took ``sqrt`` of a negative scale -> NaN boxes. The guard must fire on a non-
+    positive projection and stay out of the way otherwise.
     """
     est = XCYCSRStateEstimator(BBOX.copy())
     est.kf.state[2] = 1000.0  # scale (area); s + vs > 0, so the one-frame check passes


### PR DESCRIPTION
This pull request introduces automated docstring formatting to the project by adding `docformatter` to the pre-commit hooks and configuring its behavior in `pyproject.toml`. This ensures that Python docstrings are consistently formatted across the codebase.

**Pre-commit automation:**

* Added the `docformatter` tool to `.pre-commit-config.yaml`, specifying the version, Python interpreter, and required dependencies to automatically format docstrings during pre-commit checks.

**Tool configuration:**

* Configured `docformatter` in `pyproject.toml` to wrap both summaries and descriptions at 120 characters, ensuring consistency in docstring formatting throughout the project.

---

Aligning line length setting for code (already 120) and docs (not set yet)