### PR TITLE
docs: restructure nav into Usage/Tuning/Developer/Evaluations tabs

### DIFF
--- a/docs/benchmarking/benchmark-runner.md
+++ b/docs/benchmarking/benchmark-runner.md
@@ -24,12 +24,12 @@ Run a tracker over a complete benchmark test set — MOT17, DanceTrack, SportsMO
 
 ## Step 1 — Get Your Data
 
-| Dataset | Detection format | Layout note |
+| Dataset      | Detection format | Layout note                                                 |
 | ------------ | ---------------- | ----------------------------------------------------------- |
-| `mot17` | `xyxy` | Frame directories use the `<sequence>-FRCNN` suffix. |
-| `dancetrack` | `xyxy` | — |
-| `sportsmot` | `xyxy` | — |
-| `soccernet` | `mot` | Detection filenames follow the SoccerNet naming convention. |
+| `mot17`      | `xyxy`           | Frame directories use the `<sequence>-FRCNN` suffix.        |
+| `dancetrack` | `xyxy`           | —                                                           |
+| `sportsmot`  | `xyxy`           | —                                                           |
+| `soccernet`  | `mot`            | Detection filenames follow the SoccerNet naming convention. |
 
 `mot17` and `sportsmot` can be fetched directly with `trackers download` — see [Download Datasets](download.md). `dancetrack` and `soccernet` aren't downloadable via that command yet; supply your own `detection_root`/`image_root` directories for those two, pointed at in Step 2.
 

--- a/docs/benchmarking/benchmark-runner.md
+++ b/docs/benchmarking/benchmark-runner.md
@@ -1,11 +1,11 @@
 ---
-title: McByte Benchmark Runner — MOT17, SportsMOT, DanceTrack, SoccerNet | Trackers
-description: Run McByte over complete MOT benchmark test sets and write MOTChallenge-format results per sequence with the trackers benchmark mcbyte command.
+title: Benchmark Runner — MOT17, SportsMOT, DanceTrack, SoccerNet | Trackers
+description: Run a tracker over complete MOT benchmark test sets and write MOTChallenge-format results per sequence with the trackers benchmark command.
 ---
 
-# McByte Benchmark Runner
+# Benchmark Runner
 
-Run McByte over a complete benchmark test set — MOT17, DanceTrack, SportsMOT, or SoccerNet-tracking — and write one MOTChallenge-format result file per sequence, step by step.
+Run a tracker over a complete benchmark test set — MOT17, DanceTrack, SportsMOT, or SoccerNet-tracking — and write one MOTChallenge-format result file per sequence, step by step.
 
 **What you'll learn:**
 
@@ -14,22 +14,26 @@ Run McByte over a complete benchmark test set — MOT17, DanceTrack, SportsMOT, 
 - Select one or more datasets to run
 - Read the output layout, including the MOT17 submission files
 
-`trackers benchmark mcbyte` always builds McByte's full SAM + Cutie mask pipeline (`enable_mask_manager=True`), so — unlike the default `McByteTracker()` construction described on the [McByte page](../trackers/mcbyte.md) — both SAM and Cutie must be installed before running this command. See the [optional heavyweight dependencies note](../trackers/mcbyte.md#overview) for install steps.
+`trackers benchmark` is a command group, one subcommand per tracker with a benchmark harness. McByte is the only one available today, so every example below reads `trackers benchmark mcbyte`; the steps and the output layout are the same for any harness added later.
+
+!!! note "McByte specifics"
+
+    `trackers benchmark mcbyte` always builds McByte's full SAM + Cutie mask pipeline (`enable_mask_manager=True`), so — unlike the default `McByteTracker()` construction described on the [McByte page](../trackers/mcbyte.md) — both SAM and Cutie must be installed before running this command. See the [optional heavyweight dependencies note](../trackers/mcbyte.md#overview) for install steps.
 
 ---
 
 ## Step 1 — Get Your Data
 
-| Dataset      | Detection format | Layout note                                                 |
+| Dataset | Detection format | Layout note |
 | ------------ | ---------------- | ----------------------------------------------------------- |
-| `mot17`      | `xyxy`           | Frame directories use the `<sequence>-FRCNN` suffix.        |
-| `dancetrack` | `xyxy`           | —                                                           |
-| `sportsmot`  | `xyxy`           | —                                                           |
-| `soccernet`  | `mot`            | Detection filenames follow the SoccerNet naming convention. |
+| `mot17` | `xyxy` | Frame directories use the `<sequence>-FRCNN` suffix. |
+| `dancetrack` | `xyxy` | — |
+| `sportsmot` | `xyxy` | — |
+| `soccernet` | `mot` | Detection filenames follow the SoccerNet naming convention. |
 
 `mot17` and `sportsmot` can be fetched directly with `trackers download` — see [Download Datasets](download.md). `dancetrack` and `soccernet` aren't downloadable via that command yet; supply your own `detection_root`/`image_root` directories for those two, pointed at in Step 2.
 
-Each sequence is processed independently with a fresh McByte tracker. If a sequence fails, the error is logged and the run continues with the remaining sequences.
+Each sequence is processed independently with a fresh tracker instance. If a sequence fails, the error is logged and the run continues with the remaining sequences.
 
 ---
 
@@ -80,7 +84,7 @@ datasets/dancetrack/test/
     ...
 ```
 
-MOT17, DanceTrack and SportsMOT detections use `frame,x1,y1,x2,y2,confidence` (XYXY). SoccerNet-tracking detections use the original ground-truth MOT layout, `frame,id,left,top,width,height,confidence,...` — the identity column is ignored, since tracker identities are produced by McByte.
+MOT17, DanceTrack and SportsMOT detections use `frame,x1,y1,x2,y2,confidence` (XYXY). SoccerNet-tracking detections use the original ground-truth MOT layout, `frame,id,left,top,width,height,confidence,...` — the identity column is ignored, since identities are produced by the tracker.
 
 ---
 
@@ -125,7 +129,7 @@ Each sequence result is first written to a `.partial` file and only replaces the
 
 ### MOT17 submission files
 
-The MOT17 evaluation server expects one result file per detector name (`FRCNN`, `SDP`, `DPM`). Since McByte is detector-agnostic, `trackers benchmark mcbyte` duplicates each completed sequence's result across all three suffixes under `mot17/submission/`. The remaining MOT17 sequence numbers this run produces no result for are written as empty placeholder files for all three suffixes, so the submission directory always contains the complete set of names.
+The MOT17 evaluation server expects one result file per detector name (`FRCNN`, `SDP`, `DPM`). Since the tracker is detector-agnostic, `trackers benchmark mcbyte` duplicates each completed sequence's result across all three suffixes under `mot17/submission/`. The remaining MOT17 sequence numbers this run produces no result for are written as empty placeholder files for all three suffixes, so the submission directory always contains the complete set of names.
 
 `trackers benchmark mcbyte` writes raw per-sequence result files, not aggregate scores — it doesn't compute HOTA/IDF1/MOTA itself. Score the output with `trackers eval` (see [Evaluate Trackers](evaluate.md)); published McByte numbers already appear on the [Results](results.md) page.
 

--- a/docs/benchmarking/download.md
+++ b/docs/benchmarking/download.md
@@ -27,7 +27,7 @@ Get started by installing the package.
 pip install trackers
 ```
 
-For more options, see the [install guide](install.md).
+For more options, see the [install guide](../guides/install.md).
 
 ---
 
@@ -41,6 +41,8 @@ The table below lists every dataset you can download, along with its splits, ass
 | `sportsmot`  | Sports broadcast tracking with fast motion and similar-looking targets. | `train`, `val`, `test` |        `frames`, `annotations`        |    CC BY 4.0    |
 | `dancetrack` |                             *Coming soon.*                              |           —            |                   —                   |        —        |
 | `soccernet`  |                             *Coming soon.*                              |           —            |                   —                   |        —        |
+
+`dancetrack` and `soccernet` aren't downloadable via `trackers download` yet, but both are already usable with `trackers benchmark mcbyte` if you supply your own detection and frame directories — see [McByte Benchmark Runner](mcbyte-benchmark-runner.md#supported-datasets).
 
 === "CLI"
 

--- a/docs/benchmarking/download.md
+++ b/docs/benchmarking/download.md
@@ -42,7 +42,7 @@ The table below lists every dataset you can download, along with its splits, ass
 | `dancetrack` |                             *Coming soon.*                              |           —            |                   —                   |        —        |
 | `soccernet`  |                             *Coming soon.*                              |           —            |                   —                   |        —        |
 
-`dancetrack` and `soccernet` aren't downloadable via `trackers download` yet, but both are already usable with `trackers benchmark mcbyte` if you supply your own detection and frame directories — see [McByte Benchmark Runner](mcbyte-benchmark-runner.md#supported-datasets).
+`dancetrack` and `soccernet` aren't downloadable via `trackers download` yet, but both are already usable with `trackers benchmark mcbyte` if you supply your own detection and frame directories — see [Benchmark Runner](benchmark-runner.md#step-1-get-your-data).
 
 === "CLI"
 

--- a/docs/benchmarking/evaluate.md
+++ b/docs/benchmarking/evaluate.md
@@ -28,7 +28,7 @@ Get started by installing the package.
 pip install trackers
 ```
 
-For more options, see the [install guide](install.md).
+For more options, see the [install guide](../guides/install.md).
 
 ---
 
@@ -40,7 +40,7 @@ Download ground-truth annotations and detections for MOT17 validation — see th
 
 ## Run Tracking
 
-Feed the pre-computed detections into a tracker and write the results to a file for evaluation. Pass `--detection.mot_file` to provide precomputed MOT detector output and `--output.mot_results` to save the tracker output in MOT format — see the [track guide](track.md) for more on `trackers track`.
+Feed the pre-computed detections into a tracker and write the results to a file for evaluation. Pass `--detection.mot_file` to provide precomputed MOT detector output and `--output.mot_results` to save the tracker output in MOT format — see the [track guide](../guides/track.md) for more on `trackers track`.
 
 ```text
 trackers track \

--- a/docs/benchmarking/mcbyte-benchmark-runner.md
+++ b/docs/benchmarking/mcbyte-benchmark-runner.md
@@ -3,31 +3,22 @@ title: McByte Benchmark Runner — MOT17, SportsMOT, DanceTrack, SoccerNet | Tra
 description: Run McByte over complete MOT benchmark test sets and write MOTChallenge-format results per sequence with the trackers benchmark mcbyte command.
 ---
 
-# McByte Benchmarks
+# McByte Benchmark Runner
 
-Run McByte over a complete benchmark test set — MOT17, DanceTrack, SportsMOT, or SoccerNet-tracking — and write one MOTChallenge-format result file per sequence.
+Run McByte over a complete benchmark test set — MOT17, DanceTrack, SportsMOT, or SoccerNet-tracking — and write one MOTChallenge-format result file per sequence, step by step.
 
 **What you'll learn:**
 
+- Get detection/frame data in place, downloaded or self-supplied
 - Point the command at your detection and frame directories
 - Select one or more datasets to run
 - Read the output layout, including the MOT17 submission files
 
----
-
-## Install
-
-Get started by installing the package.
-
-```text
-pip install trackers
-```
-
-`trackers benchmark mcbyte` always builds McByte's full SAM + Cutie mask pipeline (`enable_mask_manager=True`), so — unlike the default `McByteTracker()` construction described on the [McByte page](../trackers/mcbyte.md) — both SAM and Cutie must be installed before running this command. See the [optional heavyweight dependencies note](../trackers/mcbyte.md#overview) for install steps. For more general install options, see the [install guide](install.md).
+`trackers benchmark mcbyte` always builds McByte's full SAM + Cutie mask pipeline (`enable_mask_manager=True`), so — unlike the default `McByteTracker()` construction described on the [McByte page](../trackers/mcbyte.md) — both SAM and Cutie must be installed before running this command. See the [optional heavyweight dependencies note](../trackers/mcbyte.md#overview) for install steps.
 
 ---
 
-## Supported Datasets
+## Step 1 — Get Your Data
 
 | Dataset      | Detection format | Layout note                                                 |
 | ------------ | ---------------- | ----------------------------------------------------------- |
@@ -36,11 +27,13 @@ pip install trackers
 | `sportsmot`  | `xyxy`           | —                                                           |
 | `soccernet`  | `mot`            | Detection filenames follow the SoccerNet naming convention. |
 
+`mot17` and `sportsmot` can be fetched directly with `trackers download` — see [Download Datasets](download.md). `dancetrack` and `soccernet` aren't downloadable via that command yet; supply your own `detection_root`/`image_root` directories for those two, pointed at in Step 2.
+
 Each sequence is processed independently with a fresh McByte tracker. If a sequence fails, the error is logged and the run continues with the remaining sequences.
 
 ---
 
-## Configure Dataset Roots
+## Step 2 — Configure Dataset Roots
 
 Every dataset needs a `detection_root` (one detection file per sequence) and an `image_root` (one frame directory per sequence). Neither has a built-in value — supply both per run, either through a `--config` file or inline as JSON with `--dataset_roots`.
 
@@ -69,28 +62,6 @@ Every dataset needs a `detection_root` (one detection file per sequence) and an 
     trackers benchmark mcbyte --config run.yaml
     ```
 
----
-
-## Select Datasets
-
-Pass `--dataset` as a list to choose which datasets to run. Omit it to run every dataset in the table above.
-
-```text
-trackers benchmark mcbyte --dataset=[mot17,soccernet] --device=cuda
-```
-
-A bare repeated `--dataset` overwrites the previous value — use `--dataset+` to append instead:
-
-```text
-trackers benchmark mcbyte --dataset+ mot17 --dataset+ soccernet
-```
-
-As with every `trackers` subcommand, hyphens and underscores are interchangeable (`--cmc-downscale` and `--cmc_downscale` are the same option), and every boolean flag has a `--no_` negation, e.g. `--no_enable_cmc`.
-
----
-
-## Expected Directory Layout
-
 `detection_root` holds one detection `.txt` file per sequence:
 
 ```text
@@ -113,7 +84,25 @@ MOT17, DanceTrack and SportsMOT detections use `frame,x1,y1,x2,y2,confidence` (X
 
 ---
 
-## Output
+## Step 3 — Select Datasets
+
+Pass `--dataset` as a list to choose which datasets to run. Omit it to run every dataset from Step 1's table.
+
+```text
+trackers benchmark mcbyte --dataset=[mot17,soccernet] --device=cuda
+```
+
+A bare repeated `--dataset` overwrites the previous value — use `--dataset+` to append instead:
+
+```text
+trackers benchmark mcbyte --dataset+ mot17 --dataset+ soccernet
+```
+
+As with every `trackers` subcommand, hyphens and underscores are interchangeable (`--cmc-downscale` and `--cmc_downscale` are the same option), and every boolean flag has a `--no_` negation, e.g. `--no_enable_cmc`.
+
+---
+
+## Step 4 — Run and Read the Output
 
 Results are written under `--output_root`, in one timestamped directory per run (`<timestamp>__isolation` or `<timestamp>__no_isolation`, reflecting `--enable_isolated_mask_matching`), with one subdirectory per dataset and a `run.log` capturing progress and failures.
 
@@ -137,6 +126,8 @@ Each sequence result is first written to a `.partial` file and only replaces the
 ### MOT17 submission files
 
 The MOT17 evaluation server expects one result file per detector name (`FRCNN`, `SDP`, `DPM`). Since McByte is detector-agnostic, `trackers benchmark mcbyte` duplicates each completed sequence's result across all three suffixes under `mot17/submission/`. The remaining MOT17 sequence numbers this run produces no result for are written as empty placeholder files for all three suffixes, so the submission directory always contains the complete set of names.
+
+`trackers benchmark mcbyte` writes raw per-sequence result files, not aggregate scores — it doesn't compute HOTA/IDF1/MOTA itself. Score the output with `trackers eval` (see [Evaluate Trackers](evaluate.md)); published McByte numbers already appear on the [Results](results.md) page.
 
 ---
 

--- a/docs/benchmarking/methodology.md
+++ b/docs/benchmarking/methodology.md
@@ -1,0 +1,18 @@
+---
+title: Benchmark Methodology | Trackers
+description: How Trackers' benchmark results are produced — detection sources, tuning procedure, and train/validation/test split usage.
+---
+
+# Methodology
+
+### Detections
+
+Each dataset uses one of two detection sources: oracle detections (ground-truth bounding boxes provided by the dataset) or model detections (produced by a YOLOX detector following the ByteTrack procedure). The source is noted per dataset on the [Results](results.md) page.
+
+### Tuning
+
+Best parameters per tracker and dataset were found via grid search (SORT, ByteTrack, OC-SORT, BoT-SORT) or Optuna (`n_trials=100`, objective HOTA, trial 0 = defaults for C-BIoU), selecting the configuration with the highest HOTA on the tune split. McByte is not tuned here: defaults with mask-conditioned association enabled are reported, matching the [McByte](../trackers/mcbyte.md) page (source: [PR #513](https://github.com/roboflow/trackers/pull/513)). Tuning and evaluation always use separate data splits to reflect real-world usage:
+
+- Train + validation + test: tune on validation, report on test.
+- Train + validation: tune on train, report on validation.
+- Train + test: tune on train, report on test.

--- a/docs/benchmarking/results.md
+++ b/docs/benchmarking/results.md
@@ -9,7 +9,7 @@ This page shows head-to-head performance of SORT, ByteTrack, OC-SORT, BoT-SORT, 
 
 !!! info "Benchmark version"
 
-    Results use **trackers v2.3.0** (released 2026-03-16). Detections are from YOLOX (MOT17, SportsMOT, DanceTrack) or ground-truth oracle boxes (SoccerNet). Parameters were tuned via grid search on held-out splits. See [Methodology](#methodology) for details.
+    Results use **trackers v2.3.0** (released 2026-03-16). Detections are from YOLOX (MOT17, SportsMOT, DanceTrack) or ground-truth oracle boxes (SoccerNet). Parameters were tuned via grid search on held-out splits. See [Methodology](methodology.md) for details.
 
 !!! note "Benchmark methodology"
 
@@ -272,7 +272,7 @@ Long sequences with dense interactions and partial occlusions. Tests long-term I
 
 !!! note "SoccerNet buffer ordering exception"
 
-    This config uses `buffer_ratio_first: 0.68 > buffer_ratio_second: 0.50`, which reverses the general `b1 < b2` recommendation in the [C-BIoU docs](cbiou.md#buffer-ordering). Optuna found this ordering yields higher HOTA on SoccerNet's dense, long-sequence scenarios. On most other datasets the `b1 < b2` default applies.
+    This config uses `buffer_ratio_first: 0.68 > buffer_ratio_second: 0.50`, which reverses the general `b1 < b2` recommendation in the [C-BIoU docs](../trackers/cbiou.md#buffer-ordering). Optuna found this ordering yields higher HOTA on SoccerNet's dense, long-sequence scenarios. On most other datasets the `b1 < b2` default applies.
 
 ## [DanceTrack](https://arxiv.org/abs/2111.14690)
 
@@ -361,21 +361,7 @@ Group dancing tracking with uniform appearance, diverse motions, and extreme art
 
 !!! note "DanceTrack buffer ordering exception"
 
-    This config uses `buffer_ratio_first: 0.12 > buffer_ratio_second: 0.10`, which reverses the general `b1 < b2` recommendation in the [C-BIoU docs](cbiou.md#buffer-ordering). Optuna found this ordering on DanceTrack's validation split; the margin (0.02) is small and the `b1 < b2` default applies on most other datasets.
-
-## Methodology
-
-### Detections
-
-Each dataset uses one of two detection sources: oracle detections (ground-truth bounding boxes provided by the dataset) or model detections (produced by a YOLOX detector following the ByteTrack procedure). The source is noted per dataset above.
-
-### Tuning
-
-Best parameters per tracker and dataset were found via grid search (SORT, ByteTrack, OC-SORT, BoT-SORT) or Optuna (`n_trials=100`, objective HOTA, trial 0 = defaults for C-BIoU), selecting the configuration with the highest HOTA on the tune split. McByte is not tuned here: defaults with mask-conditioned association enabled are reported, matching the [McByte](mcbyte.md) page (source: [PR #513](https://github.com/roboflow/trackers/pull/513)). Tuning and evaluation always use separate data splits to reflect real-world usage:
-
-- Train + validation + test: tune on validation, report on test.
-- Train + validation: tune on train, report on validation.
-- Train + test: tune on train, report on test.
+    This config uses `buffer_ratio_first: 0.12 > buffer_ratio_second: 0.10`, which reverses the general `b1 < b2` recommendation in the [C-BIoU docs](../trackers/cbiou.md#buffer-ordering). Optuna found this ordering on DanceTrack's validation split; the margin (0.02) is small and the `b1 < b2` default applies on most other datasets.
 
 ## When to Use Each Tracker
 
@@ -387,9 +373,9 @@ Best parameters per tracker and dataset were found via grid search (SORT, ByteTr
 
 **BoT-SORT** is the choice when camera ego-motion is strong and you need the most stable identities. It extends ByteTrack with camera motion compensation (CMC) and confidence-aware association, which reduces ID switches on panning or handheld footage. Use BoT-SORT for sports broadcasts, drone video, or any scene where the camera moves frequently. The CMC overhead is small relative to the detector, so the trade-off favors identity stability over raw speed.
 
-**C-BIoU** targets fast or irregular motion when you want buffered, cascaded geometric matching without camera motion compensation. In these benchmarks it leads on SoccerNet when tuned, and reaches the highest tuned IDF1 and MOTA on DanceTrack among the motion-only trackers. Use C-BIoU when BoT-SORT-style association is a good fit but CMC is unavailable or harmful, or when plain IoU matching is too strict. See [C-BIoU](cbiou.md) for buffer scales **b1** and **b2**.
+**C-BIoU** targets fast or irregular motion when you want buffered, cascaded geometric matching without camera motion compensation. In these benchmarks it leads on SoccerNet when tuned, and reaches the highest tuned IDF1 and MOTA on DanceTrack among the motion-only trackers. Use C-BIoU when BoT-SORT-style association is a good fit but CMC is unavailable or harmful, or when plain IoU matching is too strict. See [C-BIoU](../trackers/cbiou.md) for buffer scales **b1** and **b2**.
 
-**McByte** is the choice when you want the highest identity stability and can afford optional SAM/Cutie mask dependencies. It extends BoT-SORT-style association with temporally propagated segmentation masks as an extra matching cue, requiring no per-video tuning. Reported against Trackers' BoT-SORT baseline (without re-identification) at default parameters, McByte improves HOTA and IDF1 on all four datasets in this comparison, with the largest gain on DanceTrack. Use McByte when identity consistency matters more than raw throughput or dependency footprint. See [McByte](mcbyte.md) for setup and the mask-conditioning parameters.
+**McByte** is the choice when you want the highest identity stability and can afford optional SAM/Cutie mask dependencies. It extends BoT-SORT-style association with temporally propagated segmentation masks as an extra matching cue, requiring no per-video tuning. Reported against Trackers' BoT-SORT baseline (without re-identification) at default parameters, McByte improves HOTA and IDF1 on all four datasets in this comparison, with the largest gain on DanceTrack. Use McByte when identity consistency matters more than raw throughput or dependency footprint. See [McByte](../trackers/mcbyte.md) for setup and the mask-conditioning parameters.
 
 ## Metric Definitions
 

--- a/docs/details.md
+++ b/docs/details.md
@@ -6,7 +6,7 @@ description: Learn about Roboflow Trackers — who built it, how to cite it, whe
 
 ## What is Roboflow Trackers?
 
-Roboflow Trackers is an open-source Python library that provides clean-room implementations of leading multi-object tracking (MOT) algorithms: [SORT](../trackers/sort.md), [ByteTrack](../trackers/bytetrack.md), [OC-SORT](../trackers/ocsort.md), and [BoT-SORT](../trackers/botsort.md). The library is designed to plug into any object detection model through the [supervision](https://github.com/roboflow/supervision) library, giving you a single `tracker.update(detections)` call to add tracking to an existing detection pipeline.
+Roboflow Trackers is an open-source Python library that provides clean-room implementations of leading multi-object tracking (MOT) algorithms: [SORT](trackers/sort.md), [ByteTrack](trackers/bytetrack.md), [OC-SORT](trackers/ocsort.md), and [BoT-SORT](trackers/botsort.md). The library is designed to plug into any object detection model through the [supervision](https://github.com/roboflow/supervision) library, giving you a single `tracker.update(detections)` call to add tracking to an existing detection pipeline.
 
 Every algorithm is implemented from scratch following the original papers, with a shared interface and consistent parameter naming. The library ships with built-in evaluation tools for HOTA, IDF1, and MOTA metrics, a CLI for running trackers on video files, and dataset download utilities for standard MOT benchmarks.
 
@@ -33,7 +33,7 @@ If you run into a bug, have a feature request, or need help with integration:
 
 - **GitHub Issues** — open an issue on the [trackers repository](https://github.com/roboflow/trackers/issues) for bug reports and feature requests.
 - **Discord** — join the [Roboflow Discord server](https://discord.gg/GbfgXGJ8Bk) for real-time help and community discussion.
-- **Documentation** — browse the [Guides](install.md) and [API Reference](../api/trackers.md) sections of this site.
+- **Documentation** — browse the [Guides](guides/install.md) and [API Reference](api/trackers.md) sections of this site.
 
 ## Contributing
 
@@ -45,7 +45,7 @@ Contributions are welcome. To get started:
 4. Run `pre-commit run --all-files` to check formatting, linting, and type checks.
 5. Open a pull request against the `develop` branch.
 
-See the [contributing guidelines](../contributing.md) for full details on code style, commit conventions, and the review process.
+See the [contributing guidelines](contributing.md) for full details on code style, commit conventions, and the review process.
 
 ## License
 
@@ -65,7 +65,7 @@ If you use Roboflow Trackers in academic work or publications, please cite the l
 }
 ```
 
-For citations of specific tracking algorithms, see the Reference section on each tracker page: [SORT](../trackers/sort.md#reference), [ByteTrack](../trackers/bytetrack.md#reference), [OC-SORT](../trackers/ocsort.md#reference).
+For citations of specific tracking algorithms, see the Reference section on each tracker page: [SORT](trackers/sort.md#reference), [ByteTrack](trackers/bytetrack.md#reference), [OC-SORT](trackers/ocsort.md#reference).
 
 ## Learn More About Roboflow
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -86,7 +86,7 @@ pip install trackers
     <tr>
       <td><code>trackers benchmark mcbyte</code></td>
       <td>Run McByte over complete benchmark test sets and write MOTChallenge-format results.</td>
-      <td><a href="../../benchmarking/benchmark-runner/#cli-reference">Benchmark Runner guide</a></td>
+      <td><a href="../benchmarking/benchmark-runner.md#cli-reference">Benchmark Runner guide</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -86,7 +86,7 @@ pip install trackers
     <tr>
       <td><code>trackers benchmark mcbyte</code></td>
       <td>Run McByte over complete benchmark test sets and write MOTChallenge-format results.</td>
-      <td><a href="mcbyte-benchmark.md#cli-reference">McByte Benchmarks guide</a></td>
+      <td><a href="mcbyte-benchmark-runner.md#cli-reference">McByte Benchmark Runner guide</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -86,7 +86,7 @@ pip install trackers
     <tr>
       <td><code>trackers benchmark mcbyte</code></td>
       <td>Run McByte over complete benchmark test sets and write MOTChallenge-format results.</td>
-      <td><a href="../benchmarking/benchmark-runner.md#cli-reference">Benchmark Runner guide</a></td>
+      <td><a href="../../benchmarking/benchmark-runner/#cli-reference">Benchmark Runner guide</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -46,22 +46,22 @@ pip install trackers
     <tr>
       <td><code>trackers track</code></td>
       <td>Run a tracker on a video, webcam, RTSP stream, or image directory.</td>
-      <td><a href="track.md#cli-reference">Track guide</a></td>
+      <td><a href="../track/#cli-reference">Track guide</a></td>
     </tr>
     <tr>
       <td><code>trackers eval</code></td>
       <td>Score tracker output against ground truth with CLEAR, HOTA, and Identity metrics.</td>
-      <td><a href="evaluate.md#cli-reference">Evaluate guide</a></td>
+      <td><a href="../../benchmarking/evaluate/#cli-reference">Evaluate guide</a></td>
     </tr>
     <tr>
       <td><code>trackers download</code></td>
       <td>Download MOT benchmark datasets — MOT17 and SportsMOT.</td>
-      <td><a href="download.md#cli-reference">Download guide</a></td>
+      <td><a href="../../benchmarking/download/#cli-reference">Download guide</a></td>
     </tr>
     <tr>
       <td><code>trackers tune</code></td>
       <td>Search tracker hyperparameters with Optuna.</td>
-      <td><a href="tune.md#cli-reference">Tune guide</a></td>
+      <td><a href="../tune/#cli-reference">Tune guide</a></td>
     </tr>
     <tr>
       <td><code>trackers inspect sam</code></td>
@@ -86,7 +86,7 @@ pip install trackers
     <tr>
       <td><code>trackers benchmark mcbyte</code></td>
       <td>Run McByte over complete benchmark test sets and write MOTChallenge-format results.</td>
-      <td><a href="mcbyte-benchmark-runner.md#cli-reference">McByte Benchmark Runner guide</a></td>
+      <td><a href="../../benchmarking/benchmark-runner/#cli-reference">Benchmark Runner guide</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/guides/detection-quality.md
+++ b/docs/guides/detection-quality.md
@@ -44,7 +44,7 @@ We pick three models that span a wide accuracy range on COCO, from a lightweight
 
 ## Download Data
 
-Download the MOT17 validation split (frames for detection, annotations for evaluation) — see the [download guide](download.md) for the full command and available options.
+Download the MOT17 validation split (frames for detection, annotations for evaluation) — see the [download guide](../benchmarking/download.md) for the full command and available options.
 
 ---
 

--- a/docs/guides/iou.md
+++ b/docs/guides/iou.md
@@ -256,7 +256,7 @@ Left: IoU. Right: BIoU. Notice how ID switches happen when fast players temporar
 
 We evaluate how much each variant changes performance across datasets. For each `(dataset, tracker)` pair, we keep the `state_estimator` with the highest **IoU HOTA** on the evaluation split, then report mean `ΔHOTA = HOTA(variant) − HOTA(IoU)` over trackers (same split; thresholds tuned per experiment).
 
-For more information on the datasets, see: [dataset comparison](../trackers/comparison.md).
+For more information on the datasets, see: [dataset comparison](../benchmarking/results.md).
 
 <style>
   .iou-variant-figure {

--- a/docs/guides/tune.md
+++ b/docs/guides/tune.md
@@ -95,7 +95,7 @@ Use MOT format lines:
 <frame>,<id>,<bb_left>,<bb_top>,<bb_width>,<bb_height>,<conf>,<x>,<y>,<z>
 ```
 
-For detections, use `id=-1`. For more details on the format and evaluation workflow, see the [evaluation guide](evaluate.md).
+For detections, use `id=-1`. For more details on the format and evaluation workflow, see the [evaluation guide](../benchmarking/evaluate.md).
 
 ---
 

--- a/docs/hooks/schema_inject.py
+++ b/docs/hooks/schema_inject.py
@@ -306,7 +306,7 @@ def on_page_context(context, page, config, nav):  # type: ignore[no-untyped-def]
         )
 
     # ── Dataset JSON-LD (comparison page only) ──
-    if page.file.src_path == "trackers/comparison.md":
+    if page.file.src_path == "benchmarking/results.md":
         datasets = []
         for ds in _BENCHMARK_DATASETS:
             datasets.append(

--- a/docs/hooks/schema_inject.py
+++ b/docs/hooks/schema_inject.py
@@ -305,7 +305,7 @@ def on_page_context(context, page, config, nav):  # type: ignore[no-untyped-def]
             breadcrumbs, ensure_ascii=False, indent=2
         )
 
-    # ── Dataset JSON-LD (comparison page only) ──
+    # ── Dataset JSON-LD (benchmarking results page only) ──
     if page.file.src_path == "benchmarking/results.md":
         datasets = []
         for ds in _BENCHMARK_DATASETS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ MOT17-13-FRCNN                60.488  58.651  69.884
 COMBINED                      47.406  50.355  56.600
 ```
 
-For the full evaluation workflow, see the [evaluation guide](guides/evaluate.md).
+For the full evaluation workflow, see the [evaluation guide](benchmarking/evaluate.md).
 
 ---
 
@@ -122,7 +122,7 @@ Clean, modular implementations of leading trackers. All HOTA scores use default 
 |  [OC-SORT](https://arxiv.org/abs/2203.14360)  |          Observation-centric recovery for lost tracks.          |    61.9    |      71.7      |      78.4      |      54.1       |
 | [BoT-SORT](https://arxiv.org/abs/2206.14651)  |                   Camera motion compensation                    |  **63.7**  |    **73.8**    |    **84.5**    |    **57.8**     |
 
-For detailed benchmarks and tuned configurations, see the [tracker comparison](trackers/comparison.md).
+For detailed benchmarks and tuned configurations, see the [tracker comparison](benchmarking/results.md).
 
 Trackers also ships [McByte](trackers/mcbyte.md), a mask-conditioned tracker that extends BoT-SORT-style association with temporally propagated SAM/Cutie segmentation masks as an extra matching cue. It requires optional heavyweight dependencies (`torch`, SAM, Cutie) not installed by default — see the [McByte docs](trackers/mcbyte.md) for setup and benchmark numbers.
 
@@ -143,7 +143,7 @@ trackers download --name mot17 \
 |   `mot17`   |    Pedestrian tracking with crowded scenes and frequent occlusions.     | `train`, `val`, `test` | `frames`, `annotations`, `detections` | CC BY-NC-SA 3.0 |
 | `sportsmot` | Sports broadcast tracking with fast motion and similar-looking targets. | `train`, `val`, `test` |        `frames`, `annotations`        |    CC BY 4.0    |
 
-For more download options, see the [download guide](guides/download.md).
+For more download options, see the [download guide](benchmarking/download.md).
 
 ---
 
@@ -205,7 +205,7 @@ Object detection finds and classifies objects in a single image frame. Multi-obj
 
 **Which tracker should I use?**
 
-Start with ByteTrack — out of the box, it performs best across two out of four benchmarks in our evaluation and handles variable-confidence detectors well, while providing real time latency. Use SORT if speed or device constraints require the lightest possible tracker. Use OC-SORT when camera motion is significant or objects follow non-linear paths. See the [tracker comparison](trackers/comparison.md) for benchmark scores.
+Start with ByteTrack — out of the box, it performs best across two out of four benchmarks in our evaluation and handles variable-confidence detectors well, while providing real time latency. Use SORT if speed or device constraints require the lightest possible tracker. Use OC-SORT when camera motion is significant or objects follow non-linear paths. See the [tracker comparison](benchmarking/results.md) for benchmark scores.
 
 **Do I need a specific detector?**
 
@@ -213,8 +213,8 @@ No. Roboflow Trackers works with any detector that outputs `supervision.Detectio
 
 **What MOT datasets does the library support?**
 
-MOT17 and SportsMOT are supported for download and evaluation. Use `trackers download <dataset>` to pull frames, annotations, and pre-computed detections in one command. DanceTrack and SoccerNet-tracking support is coming soon. See the [download guide](guides/download.md) for asset options.
+MOT17 and SportsMOT are supported for download and evaluation. Use `trackers download <dataset>` to pull frames, annotations, and pre-computed detections in one command. DanceTrack and SoccerNet-tracking support is coming soon. See the [download guide](benchmarking/download.md) for asset options.
 
 **How do I evaluate my tracker?**
 
-Run `trackers eval` against a directory of ground-truth MOT-format text files. The evaluation pipeline computes HOTA, IDF1, and MOTA and prints a per-sequence and combined score table. See the [evaluation guide](guides/evaluate.md) for the full workflow.
+Run `trackers eval` against a directory of ground-truth MOT-format text files. The evaluation pipeline computes HOTA, IDF1, and MOTA and prints a per-sequence and combined score table. See the [evaluation guide](benchmarking/evaluate.md) for the full workflow.

--- a/docs/trackers/botsort.md
+++ b/docs/trackers/botsort.md
@@ -11,7 +11,7 @@ BoT-SORT extends [ByteTrack](bytetrack.md) with camera motion compensation (CMC)
 
 ## How does BoT-SORT compare to other trackers?
 
-For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](comparison.md) page.
+For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](../benchmarking/results.md) page.
 
 |  Dataset  | HOTA | IDF1 | MOTA |
 | :-------: | :--: | :--: | :--: |

--- a/docs/trackers/bytetrack.md
+++ b/docs/trackers/bytetrack.md
@@ -12,7 +12,7 @@ ByteTrack builds on the same Kalman filter plus Hungarian algorithm framework as
 
 ## How does ByteTrack compare to other trackers?
 
-For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](comparison.md) page.
+For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](../benchmarking/results.md) page.
 
 |  Dataset  | HOTA | IDF1 | MOTA |
 | :-------: | :--: | :--: | :--: |

--- a/docs/trackers/cbiou.md
+++ b/docs/trackers/cbiou.md
@@ -12,7 +12,7 @@ C-BIoU builds on the same tracking pipeline as [ByteTrack](bytetrack.md) but rep
 
 ## How does C-BIoU compare to other trackers?
 
-For comparisons with other trackers, plus default and tuned parameters, see the [tracker comparison](comparison.md) page.
+For comparisons with other trackers, plus default and tuned parameters, see the [tracker comparison](../benchmarking/results.md) page.
 
 |  Dataset   | HOTA | IDF1 | MOTA |
 | :--------: | :--: | :--: | :--: |

--- a/docs/trackers/mcbyte.md
+++ b/docs/trackers/mcbyte.md
@@ -18,7 +18,7 @@ McByte was originally developed by [Tomasz Stańczyk](https://www.linkedin.com/i
 
 ## How does McByte compare to other trackers?
 
-For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](comparison.md) page.
+For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](../benchmarking/results.md) page.
 
 The per-dataset results below compare McByte (mask-conditioned association enabled) against BoT-SORT without re-identification — the baseline association pipeline McByte builds on — using default parameters for both trackers, with no dataset-specific tuning.
 
@@ -233,7 +233,7 @@ To run McByte over a complete benchmark test set (MOT17, DanceTrack, SportsMOT, 
 trackers benchmark mcbyte --dataset=[mot17,soccernet] --device=cuda
 ```
 
-See the [McByte Benchmarks guide](../guides/mcbyte-benchmark.md) for how to supply dataset paths and read the CLI reference.
+See the [McByte Benchmark Runner guide](../benchmarking/mcbyte-benchmark-runner.md) for how to supply dataset paths and read the CLI reference.
 
 ## Reference
 

--- a/docs/trackers/mcbyte.md
+++ b/docs/trackers/mcbyte.md
@@ -233,7 +233,7 @@ To run McByte over a complete benchmark test set (MOT17, DanceTrack, SportsMOT, 
 trackers benchmark mcbyte --dataset=[mot17,soccernet] --device=cuda
 ```
 
-See the [McByte Benchmark Runner guide](../benchmarking/mcbyte-benchmark-runner.md) for how to supply dataset paths and read the CLI reference.
+See the [Benchmark Runner guide](../benchmarking/benchmark-runner.md) for how to supply dataset paths and read the CLI reference.
 
 ## Reference
 

--- a/docs/trackers/ocsort.md
+++ b/docs/trackers/ocsort.md
@@ -12,7 +12,7 @@ OC-SORT remains Simple, Online, and Real-Time like ([SORT](sort.md)) but improve
 
 ## How does OC-SORT compare to other trackers?
 
-For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](comparison.md) page.
+For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](../benchmarking/results.md) page.
 
 |  Dataset  | HOTA | IDF1 | MOTA |
 | :-------: | :--: | :--: | :--: |

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -12,7 +12,7 @@ SORT is a classic online, tracking-by-detection method that predicts object moti
 
 ## How does SORT compare to other trackers?
 
-For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](comparison.md) page.
+For comparisons with other trackers, plus dataset context and evaluation details, see the [tracker comparison](../benchmarking/results.md) page.
 
 |  Dataset  | HOTA | IDF1 | MOTA |
 | :-------: | :--: | :--: | :--: |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,7 +110,7 @@ plugins:
         learn/download.md: benchmarking/download.md
         learn/evaluate.md: benchmarking/evaluate.md
         learn/tune.md: guides/tune.md
-        learn/mcbyte-benchmark.md: benchmarking/mcbyte-benchmark-runner.md
+        learn/mcbyte-benchmark.md: benchmarking/benchmark-runner.md
         learn/inspect.md: guides/inspect.md
         learn/detection-quality.md: guides/detection-quality.md
         learn/state-estimators.md: guides/state-estimators.md
@@ -118,8 +118,9 @@ plugins:
         learn/about.md: details.md
         guides/download.md: benchmarking/download.md
         guides/evaluate.md: benchmarking/evaluate.md
-        guides/mcbyte-benchmark.md: benchmarking/mcbyte-benchmark-runner.md
-        benchmarking/mcbyte-benchmark.md: benchmarking/mcbyte-benchmark-runner.md
+        guides/mcbyte-benchmark.md: benchmarking/benchmark-runner.md
+        benchmarking/mcbyte-benchmark.md: benchmarking/benchmark-runner.md
+        benchmarking/mcbyte-benchmark-runner.md: benchmarking/benchmark-runner.md
         guides/about.md: details.md
         trackers/comparison.md: benchmarking/results.md
   - git-revision-date-localized:
@@ -165,7 +166,7 @@ nav:
   - Evaluations:
     - Download Datasets: benchmarking/download.md
     - Benchmark Trackers: benchmarking/evaluate.md
-    - McByte Benchmark Runner: benchmarking/mcbyte-benchmark-runner.md
+    - Benchmark Runner: benchmarking/benchmark-runner.md
     - Results: benchmarking/results.md
     - Methodology: benchmarking/methodology.md
   - Trackers:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,15 +107,21 @@ plugins:
         learn/cli.md: guides/cli.md
         learn/cli-migration.md: guides/migration_cli.md
         learn/dynamic-frame-rate.md: guides/dynamic-frame-rate.md
-        learn/download.md: guides/download.md
-        learn/evaluate.md: guides/evaluate.md
+        learn/download.md: benchmarking/download.md
+        learn/evaluate.md: benchmarking/evaluate.md
         learn/tune.md: guides/tune.md
-        learn/mcbyte-benchmark.md: guides/mcbyte-benchmark.md
+        learn/mcbyte-benchmark.md: benchmarking/mcbyte-benchmark-runner.md
         learn/inspect.md: guides/inspect.md
         learn/detection-quality.md: guides/detection-quality.md
         learn/state-estimators.md: guides/state-estimators.md
         learn/iou.md: guides/iou.md
-        learn/about.md: guides/about.md
+        learn/about.md: details.md
+        guides/download.md: benchmarking/download.md
+        guides/evaluate.md: benchmarking/evaluate.md
+        guides/mcbyte-benchmark.md: benchmarking/mcbyte-benchmark-runner.md
+        benchmarking/mcbyte-benchmark.md: benchmarking/mcbyte-benchmark-runner.md
+        guides/about.md: details.md
+        trackers/comparison.md: benchmarking/results.md
   - git-revision-date-localized:
       enable_creation_date: true
       type: iso_date
@@ -143,29 +149,32 @@ plugins:
 nav:
   - Home:
     - Quickstart: index.md
-  - Guides:
+    - Details: details.md
+  - Usage:
     - Install Trackers: guides/install.md
     - Track Objects: guides/track.md
     - CLI Reference: guides/cli.md
+  - Tuning:
     - Dynamic Frame Rate: guides/dynamic-frame-rate.md
-    - Download Datasets: guides/download.md
-    - Evaluate Trackers: guides/evaluate.md
-    - Tune Trackers: guides/tune.md
-    - McByte Benchmarks: guides/mcbyte-benchmark.md
-    - Inspect Mask Pipeline: guides/inspect.md
     - Detection Quality Matters: guides/detection-quality.md
-    - State Estimators: guides/state-estimators.md
+    - Tune Trackers: guides/tune.md
     - IoU Variants: guides/iou.md
-    - About: guides/about.md
+    - State Estimators: guides/state-estimators.md
+  - Developer:
+    - Inspect Mask Pipeline: guides/inspect.md
+  - Evaluations:
+    - Download Datasets: benchmarking/download.md
+    - Benchmark Trackers: benchmarking/evaluate.md
+    - McByte Benchmark Runner: benchmarking/mcbyte-benchmark-runner.md
+    - Results: benchmarking/results.md
+    - Methodology: benchmarking/methodology.md
   - Trackers:
-    - Comparison: trackers/comparison.md
     - SORT: trackers/sort.md
     - ByteTrack: trackers/bytetrack.md
     - OC-SORT: trackers/ocsort.md
     - BoT-SORT: trackers/botsort.md
     - C-BIoU: trackers/cbiou.md
     - McByte: trackers/mcbyte.md
-
   - API Reference:
     - Trackers: api/trackers.md
     - Motion: api/motion.md


### PR DESCRIPTION
Split guides into task-based top-level tabs, moved benchmarking-related pages under a new Evaluations tab with redirects, merged about.md into a Home-tab Details page, and pruned the McByte benchmark runner page into a step-by-step CLI walkthrough with cross-links to Download and Results.
