### PR TITLE
feat(cli): expose full tracker registry surface

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -93,7 +93,7 @@ pip install trackers
 
 For a narrative walkthrough of `track`, `eval`, `download`, or `tune`, see their own guides linked above. For `inspect`, see the [Inspect the Mask Pipeline guide](inspect.md) for worked examples — the flag tables below cover the full surface of each subcommand.
 
-Every `trackers` subcommand accepts `--config <file>` to load arguments from a YAML file, and hyphens and underscores are interchangeable in flag names (`--cmc-downscale` and `--cmc_downscale` are the same option). Boolean flags gain a negated `--no_<name>` counterpart.
+Every `trackers` subcommand accepts `--config <file>` to load arguments from a YAML file, and hyphens and underscores are interchangeable in flag names (`--cmc-downscale` and `--cmc_downscale` are the same option). Boolean flags gain a negated `--no_<name>` counterpart. A nested option group (e.g. `--tracker.mask.*`) exposes a `.help` sub-command — `--tracker.mask.help` lists that group's fields without printing the rest of `--help`.
 
 ---
 

--- a/docs/guides/migration_cli.md
+++ b/docs/guides/migration_cli.md
@@ -29,7 +29,7 @@ Every boolean option is a pair: `--show.boxes` turns it on, `--show.no_boxes` tu
 
 This covers ungrouped options too — `--display` / `--no_display`, `--no_enqueue_defaults` on `tune`, `--no_list_available` on `download`.
 
-The algorithm and its parameters share one group, mirroring `--detection.model` and the rest of the detection options. `--tracker sort` is shorthand for `--tracker.name sort`; both spellings are supported and neither warns.
+The algorithm and its parameters share one group, mirroring `--detection.model` and the rest of the detection options. `--tracker sort` is shorthand for `--tracker.name sort`; both spellings are supported and neither warns. `tune` accepts the same two spellings for its own `--tracker.name` group — `tune --tracker sort` and `tune --tracker.name sort` are identical, though `tune` has no `--tracker.<param>` group of its own (its per-run overrides are `--fixed_params` and `search_space`). This also changes the `--config` YAML shape for `tune`: a flat `tracker: sort` key no longer parses — use `tracker: {name: sort}`, matching `track`'s config shape.
 
 Tracker parameters are the exception: they default to `None`, meaning "leave the tracker's own default alone", so they take an explicit value and have no negative half. Develop's bare `--tracker.enable_cmc` flag turned camera motion compensation **off**, since the parameter itself defaults to `True`, so the bare spelling still maps to `--tracker.enable_cmc=false` and warns. Prefer `--tracker.enable_cmc true` or `--tracker.enable_cmc false`; they say what they do. The same applies to `--tracker.instant_first_frame_activation`.
 
@@ -84,6 +84,12 @@ Tracker parameter names abbreviate their standard leading token on the command l
 | `--tracker.iou`                                     | `--tracker.iou_variant`                         |
 
 These short forms are **CLI aliases only**. The Python constructor keywords are unchanged, so `ByteTrackTracker(minimum_iou_threshold=0.3)` stays correct, and so do `tune --fixed_params`, each tracker's `search_space` keys, and the "Valid parameters" list printed on a `search_space` error. A consequence worth knowing: `tune` reports the long parameter names, so its output cannot be pasted verbatim into a `track` command — abbreviate the leading `minimum_` or `maximum_` token first.
+
+### mcbyte mask settings
+
+`mcbyte`'s mask pipeline configuration (`McByteMaskConfig` — SAM/Cutie device, checkpoints, Hydra config) is one more exact-name rename: it appears on the command line as `--tracker.mask.*`, not `--tracker.mask_config.*`. Unlike the `minimum_`/`maximum_` prefixes above, this is not a deprecation alias — `mask_config` never shipped under its Python name on any CLI release, so there is nothing to warn about and no legacy spelling to migrate from. Run `trackers track --tracker.mask.help` for the full sub-option list.
+
+Note this differs from `trackers inspect mcbyte`, whose own comparison-only `--mask.*` group is a peer of `--sequence.*` and `--cmc.*` rather than nested under a tracker selector — see the [Inspect the Mask Pipeline guide](inspect.md).
 
 ## Hyphens and underscores
 

--- a/docs/guides/track.md
+++ b/docs/guides/track.md
@@ -330,7 +330,7 @@ See the [Dynamic Frame Rate guide](dynamic-frame-rate.md) for when to enable it,
 
 ## CLI Reference
 
-All arguments accepted by the `trackers track` command.
+The commonly used arguments accepted by the `trackers track` command. `--tracker.*` is generated from the tracker registry, so it also carries parameters specific to one algorithm (`cbiou`'s buffer ratios, `botsort`/`mcbyte`'s camera motion compensation, `mcbyte`'s mask pipeline) that this table does not enumerate. Run `trackers track --help` for the complete, always-current set, and `trackers track --tracker.mask.help` for the mcbyte mask sub-options.
 
 <table>
   <colgroup>
@@ -420,6 +420,26 @@ All arguments accepted by the `trackers track` command.
       <td><code>--tracker.iou_variant</code></td>
       <td>IoU similarity metric for data association. Options: <code>iou</code>, <code>giou</code>, <code>diou</code>, <code>ciou</code>, <code>biou</code>. Applies to all trackers.</td>
       <td><code>iou</code></td>
+    </tr>
+    <tr>
+      <td><code>--tracker.enable_cmc</code></td>
+      <td>Camera motion compensation toggle. <code>botsort</code> and <code>mcbyte</code> only.</td>
+      <td><code>true</code></td>
+    </tr>
+    <tr>
+      <td><code>--tracker.state_estimator_class</code></td>
+      <td>State estimator used by newly created tracks, given as a dotted class path (e.g. <code>trackers.utils.state_representations.XCYCWHStateEstimator</code>).</td>
+      <td><code>XCYCWHStateEstimator</code></td>
+    </tr>
+    <tr>
+      <td><code>--tracker.enable_mask_manager</code></td>
+      <td>Enable McByte's SAM + Cutie mask pipeline. <code>mcbyte</code> only; see <code>--tracker.mask.*</code> below.</td>
+      <td><code>false</code></td>
+    </tr>
+    <tr>
+      <td><code>--tracker.mask.*</code></td>
+      <td>Backend settings for the mcbyte mask pipeline — SAM/Cutie device and checkpoints. Run <code>trackers track --tracker.mask.help</code> for the full sub-option list.</td>
+      <td>—</td>
     </tr>
     <tr>
       <td><code>--display</code></td>

--- a/src/trackers/cli/_legacy.py
+++ b/src/trackers/cli/_legacy.py
@@ -30,7 +30,7 @@ from trackers.cli._parser import (
     _raise_for_detection_source_conflict,
     _target_for_option,
 )
-from trackers.cli.track import TrackerOptions, _abbreviated_tracker_parameters
+from trackers.cli.track import TrackerOptions, _abbreviate_parameter_name, _abbreviated_tracker_parameters
 from trackers.core.base import BaseTracker
 
 # Release that introduced this batch of CLI deprecations, and the one that drops
@@ -104,6 +104,13 @@ def _develop_store_false_tracker_flags() -> frozenset[str]:
     Booleans defaulting to ``False`` are excluded: develop's ``store_true`` flag
     and an explicit ``true`` already agree, so no rewrite is owed.
 
+    The membership test and the emitted flag both use the CLI spelling
+    (:func:`_abbreviate_parameter_name`), not the raw registry name: a
+    boolean parameter behind an abbreviated or renamed CLI field (none
+    today, but nothing guarantees that stays true) would otherwise fail the
+    ``option_fields`` check under its unabbreviated name and never end up in
+    the returned set.
+
     Returns:
         Option strings whose bare form must be rewritten to an explicit ``false``.
     """
@@ -114,8 +121,9 @@ def _develop_store_false_tracker_flags() -> frozenset[str]:
         if tracker_info is None:
             continue
         for parameter_name, parameter in tracker_info.parameters.items():
-            if parameter.param_type is bool and parameter.default_value and parameter_name in option_fields:
-                flags.add(f"--tracker.{parameter_name}")
+            cli_name = _abbreviate_parameter_name(parameter_name)
+            if parameter.param_type is bool and parameter.default_value and cli_name in option_fields:
+                flags.add(f"--tracker.{cli_name}")
     return frozenset(flags)
 
 
@@ -214,8 +222,12 @@ def _translate_legacy_args(args: list[str]) -> list[str]:
 
     subcommand = args[subcommand_index]
     command_args = args[subcommand_index + 1 :]
-    if subcommand == "track":
+    if subcommand in ("track", "tune"):
+        # Both subcommands expose a ``--tracker.name`` group, so both accept
+        # the ``--tracker <id>`` shorthand. ``tune`` has no tracker-parameter
+        # booleans, so only ``track`` needs the develop bare-flag rewrite.
         command_args = _expand_tracker_shorthand(command_args)
+    if subcommand == "track":
         command_args = _translate_develop_boolean_flags(command_args)
     command_args = _translate_legacy_list_args(subcommand, command_args)
     legacy_arguments = _LEGACY_ARGUMENTS[subcommand]

--- a/src/trackers/cli/track.py
+++ b/src/trackers/cli/track.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 import sys
 import warnings
 from contextlib import nullcontext, suppress
-from dataclasses import asdict, dataclass, fields
+from dataclasses import dataclass, fields, make_dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, get_type_hints
 
 import numpy as np
 import supervision as sv
@@ -22,7 +22,7 @@ import supervision as sv
 from trackers import frames_from_source
 from trackers.cli._annotate import COLOR_PALETTE as _COLOR_PALETTE
 from trackers.cli._progress import _classify_source, _SourceInfo, _TrackingProgress
-from trackers.core.base import BaseTracker
+from trackers.core.base import BaseTracker, ParameterInfo
 from trackers.io.mot import _mot_frame_to_detections, _MOTOutput, load_mot_file
 from trackers.io.paths import _resolve_video_output_path, _validate_output_path
 from trackers.io.video import _DEFAULT_OUTPUT_FPS, _DisplayWindow, _VideoOutput
@@ -120,65 +120,20 @@ class ShowOptions:
     trajectories: bool = False
 
 
-@dataclass
-class TrackerOptions:
-    """Optional tracker-specific parameters.
-
-    Union of parameters across all registered trackers; each tracker only
-    receives the keys it knows about. Fields left as ``None`` are dropped
-    before instantiation so the tracker's own defaults apply.
-
-    CLI names abbreviate the standard leading token only — ``minimum_`` becomes
-    ``min_`` and ``maximum_`` becomes ``max_``. Domain words such as
-    ``threshold`` stay spelled out. The Python keyword names are unchanged;
-    :func:`_init_tracker` maps the short CLI name back to the long keyword.
-
-    Attributes:
-        name: Tracking algorithm ID. Discoverable via
-            ``BaseTracker._registered_trackers()``. ``--tracker <id>`` is the
-            shorthand spelling of ``--tracker.name <id>``.
-        lost_track_buffer: Frames to keep a lost track before discarding.
-        frame_rate: Source frame rate for time-based logic.
-        track_activation_threshold: Detection score needed to spawn a track.
-        min_consecutive_frames: Consecutive matches to confirm a track.
-        min_iou_threshold: IoU threshold for SORT/OC-SORT association.
-        min_iou_threshold_first_assoc: BoT-SORT first-stage IoU.
-        min_iou_threshold_second_assoc: BoT-SORT second-stage IoU.
-        min_iou_threshold_unconfirmed_assoc: BoT-SORT unconfirmed IoU.
-        high_conf_det_threshold: High-confidence detection threshold.
-        direction_consistency_weight: OC-SORT direction consistency weight.
-        delta_t: OC-SORT velocity delta horizon.
-        enable_cmc: BoT-SORT camera motion compensation toggle.
-        cmc_method: BoT-SORT CMC method name.
-        cmc_downscale: BoT-SORT CMC downscale factor.
-        instant_first_frame_activation: BoT-SORT first-frame activation toggle.
-        iou_variant: IoU similarity metric for data association. One of
-            ``iou`` (standard), ``giou``, ``diou``, ``ciou``, ``biou``.
-            Applies to all trackers. Defaults to ``iou``.
-    """
-
-    name: str = DEFAULT_TRACKER
-    lost_track_buffer: int | None = None
-    frame_rate: float | None = None
-    track_activation_threshold: float | None = None
-    min_consecutive_frames: int | None = None
-    min_iou_threshold: float | None = None
-    min_iou_threshold_first_assoc: float | None = None
-    min_iou_threshold_second_assoc: float | None = None
-    min_iou_threshold_unconfirmed_assoc: float | None = None
-    high_conf_det_threshold: float | None = None
-    direction_consistency_weight: float | None = None
-    delta_t: int | None = None
-    enable_cmc: bool | None = None
-    cmc_method: str | None = None
-    cmc_downscale: int | None = None
-    instant_first_frame_activation: bool | None = None
-    iou_variant: str | None = None
-
-
 # Standard leading tokens abbreviated on the CLI, mapping long Python prefix to
 # short CLI prefix. Domain words (``threshold``, ``consecutive``) stay in full.
 _CLI_PARAMETER_ABBREVIATIONS = {"minimum_": "min_", "maximum_": "max_"}
+
+# Exact-name CLI renames, checked before the prefix rule above. ``mask_config``
+# never shipped under its Python name on any CLI release, so unlike the
+# prefixes it carries no deprecation alias — see `_abbreviated_tracker_parameters`.
+_CLI_PARAMETER_RENAMES = {"mask_config": "mask"}
+_CLI_PARAMETER_RENAMES_REVERSED = {short: long for long, short in _CLI_PARAMETER_RENAMES.items()}
+
+# Tracker registry parameters that never reach the CLI. ``mask_manager`` takes
+# a live ``MaskManager`` instance, not a value a command line can express;
+# ``enable_mask_manager`` is its CLI-facing switch.
+_EXCLUDED_TRACKER_PARAMETERS = frozenset({"mask_manager"})
 
 
 def _abbreviate_parameter_name(name: str) -> str:
@@ -188,14 +143,19 @@ def _abbreviate_parameter_name(name: str) -> str:
         name: Python keyword name (e.g. ``minimum_iou_threshold``).
 
     Returns:
-        Abbreviated CLI name, or ``name`` unchanged when no prefix applies.
+        Renamed or abbreviated CLI name, or ``name`` unchanged when neither
+        rule applies.
 
     Examples:
         >>> _abbreviate_parameter_name("minimum_iou_threshold")
         'min_iou_threshold'
+        >>> _abbreviate_parameter_name("mask_config")
+        'mask'
         >>> _abbreviate_parameter_name("lost_track_buffer")
         'lost_track_buffer'
     """
+    if name in _CLI_PARAMETER_RENAMES:
+        return _CLI_PARAMETER_RENAMES[name]
     for long_prefix, short_prefix in _CLI_PARAMETER_ABBREVIATIONS.items():
         if name.startswith(long_prefix):
             return f"{short_prefix}{name.removeprefix(long_prefix)}"
@@ -208,28 +168,137 @@ def _expand_parameter_name(name: str) -> str:
     Inverse of :func:`_abbreviate_parameter_name`.
 
     Args:
-        name: Abbreviated CLI name (e.g. ``min_iou_threshold``).
+        name: Abbreviated or renamed CLI name (e.g. ``min_iou_threshold``).
 
     Returns:
-        Python keyword name, or ``name`` unchanged when no prefix applies.
+        Python keyword name, or ``name`` unchanged when neither rule applies.
 
     Examples:
         >>> _expand_parameter_name("min_iou_threshold")
         'minimum_iou_threshold'
+        >>> _expand_parameter_name("mask")
+        'mask_config'
         >>> _expand_parameter_name("lost_track_buffer")
         'lost_track_buffer'
     """
+    if name in _CLI_PARAMETER_RENAMES_REVERSED:
+        return _CLI_PARAMETER_RENAMES_REVERSED[name]
     for long_prefix, short_prefix in _CLI_PARAMETER_ABBREVIATIONS.items():
         if name.startswith(short_prefix):
             return f"{long_prefix}{name.removeprefix(short_prefix)}"
     return name
 
 
+def _tracker_parameter_union() -> list[tuple[str, ParameterInfo, Any]]:
+    """Collect every CLI-eligible parameter across the tracker registry.
+
+    Trackers are visited in :func:`BaseTracker._registered_trackers` order,
+    each tracker's own parameters in ``__init__`` order. The first tracker to
+    define a given name provides its description and annotation, so a
+    parameter shared by several trackers (e.g. ``lost_track_buffer``) is not
+    duplicated.
+
+    Returns:
+        ``(python_name, parameter_info, annotation)`` triples. The annotation
+        comes from :func:`typing.get_type_hints` rather than
+        ``parameter_info.param_type``, which is normalized for argparse and
+        would collapse ``type[BaseStateEstimator]`` to ``abc.ABCMeta`` and a
+        ``Literal`` to ``str``.
+    """
+    seen: dict[str, tuple[ParameterInfo, Any]] = {}
+    for tracker_id in BaseTracker._registered_trackers():
+        info = BaseTracker._lookup_tracker(tracker_id)
+        if info is None:
+            continue
+        hints = get_type_hints(info.tracker_class.__init__)
+        for name, parameter_info in info.parameters.items():
+            if name in _EXCLUDED_TRACKER_PARAMETERS or name in seen:
+                continue
+            seen[name] = (parameter_info, hints[name])
+    return [(name, parameter_info, annotation) for name, (parameter_info, annotation) in seen.items()]
+
+
+def _build_tracker_options() -> type:
+    """Generate the ``TrackerOptions`` dataclass from the tracker registry.
+
+    Union of parameters across all registered trackers; each tracker only
+    receives the keys it knows about (:func:`_init_tracker` drops the rest).
+    Every field defaults to ``None`` so an unset option leaves the tracker's
+    own default alone. CLI names abbreviate the standard leading token only —
+    ``minimum_`` becomes ``min_`` and ``maximum_`` becomes ``max_`` — plus the
+    one exact-name rename, ``mask_config`` to ``mask``; the Python keyword
+    names are unchanged, and :func:`_init_tracker` maps a short CLI name back
+    to its long keyword.
+
+    Generating this from the registry means a newly registered tracker
+    parameter is reachable from the CLI without a manual edit here.
+
+    Returns:
+        A dataclass equivalent to a hand-written ``@dataclass class
+        TrackerOptions``, with a per-field ``Attributes:`` docstring section
+        jsonargparse reads for ``--help`` text.
+    """
+    field_specs: list[tuple[str, Any, Any]] = [("name", str, DEFAULT_TRACKER)]
+    doc_lines = [
+        "Optional tracker-specific parameters.",
+        "",
+        "Union of parameters across all registered trackers; each tracker only",
+        "receives the keys it knows about. Fields left as ``None`` are dropped",
+        "before instantiation so the tracker's own defaults apply. Generated",
+        "from the tracker registry, so a newly registered tracker parameter is",
+        "reachable from the CLI without a manual edit here.",
+        "",
+        "CLI names abbreviate the standard leading token only — ``minimum_``",
+        "becomes ``min_`` and ``maximum_`` becomes ``max_`` — plus one",
+        "exact-name rename, ``mask_config`` to ``mask``. The Python keyword",
+        "names are unchanged; :func:`_init_tracker` maps the short CLI name",
+        "back to the long keyword.",
+        "",
+        "Attributes:",
+        "    name: Tracking algorithm ID. Discoverable via",
+        "        ``BaseTracker._registered_trackers()``. ``--tracker <id>`` is the",
+        "        shorthand spelling of ``--tracker.name <id>``.",
+    ]
+    for python_name, parameter_info, annotation in _tracker_parameter_union():
+        cli_name = _abbreviate_parameter_name(python_name)
+        # ``annotation | None`` rather than ``typing.Optional[annotation]``: a
+        # generic alias such as ``type[BaseStateEstimator]`` supports ``|``
+        # directly, and an annotation already optional (``McByteMaskConfig |
+        # None``) collapses back to itself instead of double-wrapping.
+        field_specs.append((cli_name, annotation | None, None))
+        doc_lines.append(f"    {cli_name}: {parameter_info.description}")
+    field_specs.append(("iou_variant", str | None, None))
+    doc_lines.append(
+        "    iou_variant: IoU similarity metric for data association. One of "
+        "``iou`` (standard), ``giou``, ``diou``, ``ciou``, ``biou``. Applies "
+        "to all trackers. Defaults to ``iou``."
+    )
+
+    cls = make_dataclass("TrackerOptions", field_specs)
+    cls.__module__ = __name__
+    cls.__doc__ = "\n".join(doc_lines)
+    return cls
+
+
+# Not guarded by ``if TYPE_CHECKING`` — jsonargparse's own parameter resolver
+# walks this module's source for ``track_command`` and treats a
+# ``TYPE_CHECKING`` branch as taken the same way a type checker does, which
+# would make it resolve ``tracker`` as ``Any`` and silently stop validating or
+# instantiating ``--config`` values for that group. A single unconditional
+# assignment keeps that resolution correct; the `# type: ignore[valid-type]`
+# comments where ``TrackerOptions`` is used as an annotation cover the mypy
+# cost instead (see :func:`_build_tracker_options`).
+TrackerOptions = _build_tracker_options()
+
+
 def _abbreviated_tracker_parameters() -> dict[str, str]:
     """Map every abbreviated :class:`TrackerOptions` field to its former CLI name.
 
     Derived from the dataclass fields so the deprecation aliases in the CLI
-    entry point cannot drift from the option definitions.
+    entry point cannot drift from the option definitions. The exact-name
+    ``mask`` rename is excluded: ``mask_config`` never shipped under its
+    Python name on any CLI release, so warning that it is deprecated would be
+    a lie.
 
     Returns:
         Mapping of long (deprecated) name to short (current) name.
@@ -240,6 +309,8 @@ def _abbreviated_tracker_parameters() -> dict[str, str]:
     """
     renamed = {}
     for field in fields(TrackerOptions):
+        if field.name in _CLI_PARAMETER_RENAMES_REVERSED:
+            continue
         expanded = _expand_parameter_name(field.name)
         if expanded != field.name:
             renamed[expanded] = field.name
@@ -250,7 +321,7 @@ def track_command(
     source: str | None = None,
     detection: DetectionOptions | None = None,
     filters: FilterOptions | None = None,
-    tracker: TrackerOptions | None = None,
+    tracker: TrackerOptions | None = None,  # type: ignore[valid-type]
     output: OutputOptions | None = None,
     display: bool = False,
     show: ShowOptions | None = None,
@@ -560,18 +631,84 @@ def _run_model(model: AnyModel, frame: np.ndarray, confidence: float) -> sv.Dete
     return dets
 
 
-def _init_tracker(params: TrackerOptions | None) -> BaseTracker:
+def _tracker_options_as_dict(params: TrackerOptions | None) -> dict[str, Any]:  # type: ignore[valid-type]
+    """Return ``params`` as a shallow field-name-to-value mapping.
+
+    Deliberately not :func:`dataclasses.asdict`: that recurses into nested
+    dataclass fields such as ``mask``, handing the tracker a plain ``dict``
+    instead of the ``McByteMaskConfig`` instance it expects.
+
+    Args:
+        params: Tracker selection and parameter overrides, or ``None``.
+
+    Returns:
+        One entry per field, values unconverted.
+    """
+    if params is None:
+        return {}
+    return {f.name: getattr(params, f.name) for f in fields(params)}
+
+
+def _resolve_tracker_kwargs(raw: dict[str, Any], accepted: set[str]) -> tuple[dict[str, Any], list[str]]:
+    """Split parsed CLI overrides into tracker kwargs and unsupported names.
+
+    Abbreviated CLI names are resolved back to their tracker ``__init__``
+    keyword before the membership check, so ``min_iou_threshold`` reaches the
+    tracker as ``minimum_iou_threshold`` and ``mask`` as ``mask_config``.
+    Without that step a renamed CLI option would silently fail the membership
+    test and leave the tracker on its own default.
+
+    Args:
+        raw: Parsed ``TrackerOptions`` fields, ``name`` and ``iou_variant``
+            already removed.
+        accepted: Parameter names the selected tracker's ``__init__`` accepts.
+
+    Returns:
+        ``(kwargs, dropped)`` — forwarded keyword arguments, and the CLI names
+        of overrides the selected tracker does not accept.
+    """
+    kwargs: dict[str, Any] = {}
+    dropped: list[str] = []
+    for name, value in raw.items():
+        if value is None:
+            continue
+        keyword = name if name in accepted else _expand_parameter_name(name)
+        if keyword in accepted:
+            kwargs[keyword] = value
+        else:
+            dropped.append(name)
+    return kwargs, dropped
+
+
+def _warn_dropped_tracker_overrides(tracker_id: str, dropped: list[str]) -> None:
+    """Warn once per CLI override the selected tracker silently ignored.
+
+    Every :class:`TrackerOptions` field defaults to ``None``, so a non-``None``
+    value absent from the tracker's accepted parameters means the user set an
+    option this tracker does not support — most consequently the mcbyte
+    mask settings, where a dropped override reads as "masks enabled" while the
+    tracker silently ran without them.
+
+    Args:
+        tracker_id: Selected tracker's registry ID.
+        dropped: CLI names of overrides the tracker does not accept.
+    """
+    for name in dropped:
+        warnings.warn(
+            f"Tracker '{tracker_id}' does not support --tracker.{name}; it will be ignored.",
+            UserWarning,
+            stacklevel=3,
+        )
+
+
+def _init_tracker(params: TrackerOptions | None) -> BaseTracker:  # type: ignore[valid-type]
     """Create a tracker instance from the registry.
 
     ``params.name`` selects the algorithm; every other field is a parameter
     override. Only fields the chosen tracker accepts are forwarded; ``None``
-    values are always dropped so the tracker's own defaults apply.
-
-    Abbreviated CLI names are resolved back to their tracker ``__init__``
-    keyword before the forwarding check, so ``min_iou_threshold`` reaches the
-    tracker as ``minimum_iou_threshold``. Without that step a renamed CLI
-    option would silently fail the membership test and leave the tracker on its
-    own default. ``iou_variant`` is the same kind of alias for ``iou``.
+    values are always dropped so the tracker's own defaults apply. A non-
+    ``None`` value the chosen tracker does not accept is dropped with a
+    warning rather than silently, via :func:`_warn_dropped_tracker_overrides`.
 
     Args:
         params: Tracker selection and parameter overrides.
@@ -582,7 +719,7 @@ def _init_tracker(params: TrackerOptions | None) -> BaseTracker:
     Raises:
         ValueError: If ``params.name`` is not registered.
     """
-    raw = asdict(params) if params is not None else {}
+    raw = _tracker_options_as_dict(params)
     tracker_id = raw.pop("name", DEFAULT_TRACKER)
     info = BaseTracker._lookup_tracker(tracker_id)
     if info is None:
@@ -591,13 +728,8 @@ def _init_tracker(params: TrackerOptions | None) -> BaseTracker:
 
     iou_variant = raw.pop("iou_variant", None)
     accepted = set(info.parameters)
-    kwargs = {}
-    for name, value in raw.items():
-        if value is None:
-            continue
-        keyword = name if name in accepted else _expand_parameter_name(name)
-        if keyword in accepted:
-            kwargs[keyword] = value
+    kwargs, dropped = _resolve_tracker_kwargs(raw, accepted)
+    _warn_dropped_tracker_overrides(tracker_id, dropped)
     if iou_variant is not None:
         if "iou" in accepted:
             kwargs["iou"] = variant_from_name(iou_variant)

--- a/src/trackers/cli/track.py
+++ b/src/trackers/cli/track.py
@@ -210,11 +210,14 @@ def _tracker_parameter_union() -> list[tuple[str, ParameterInfo, Any]]:
         info = BaseTracker._lookup_tracker(tracker_id)
         if info is None:
             continue
-        hints = get_type_hints(info.tracker_class.__init__)
+        try:
+            hints = get_type_hints(info.tracker_class.__init__)
+        except Exception:
+            hints = {}
         for name, parameter_info in info.parameters.items():
             if name in _EXCLUDED_TRACKER_PARAMETERS or name in seen:
                 continue
-            seen[name] = (parameter_info, hints[name])
+            seen[name] = (parameter_info, hints.get(name, parameter_info.param_type))
     return [(name, parameter_info, annotation) for name, (parameter_info, annotation) in seen.items()]
 
 

--- a/src/trackers/cli/tune.py
+++ b/src/trackers/cli/tune.py
@@ -11,11 +11,31 @@ from __future__ import annotations
 
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 
+@dataclass
+class TrackerSelection:
+    """Tracking algorithm selection for ``tune``.
+
+    A minimal, one-field counterpart to
+    :class:`trackers.cli.track.TrackerOptions` — tune has no per-parameter CLI
+    surface (that is what ``fixed_params`` and ``search_space`` are for), so
+    only the algorithm selector needs a nested group.
+
+    Attributes:
+        name: Tracker ID to tune (e.g. ``bytetrack``, ``sort``, ``ocsort``).
+            Discoverable via ``BaseTracker._registered_trackers()``.
+            ``--tracker <id>`` is the shorthand spelling of
+            ``--tracker.name <id>``, matching ``trackers track``.
+    """
+
+    name: str
+
+
 def tune_command(
-    tracker: str,
+    tracker: TrackerSelection,
     gt_dir: Path,
     detections_dir: Path,
     objective: str = "HOTA",
@@ -32,7 +52,7 @@ def tune_command(
     """Tune tracker hyperparameters using Optuna.
 
     Args:
-        tracker: Tracker ID to tune (e.g. ``bytetrack``, ``sort``, ``ocsort``).
+        tracker: Tracking algorithm selection.
         gt_dir: Directory of ground-truth MOT files.
         detections_dir: Directory of pre-computed detection files in MOT flat
             format (one ``{seq}.txt`` per sequence).
@@ -63,7 +83,7 @@ def tune_command(
 
     try:
         tuner = Tuner(
-            tracker_id=tracker,
+            tracker_id=tracker.name,
             gt_dir=gt_dir,
             detections_dir=detections_dir,
             metrics=metrics,
@@ -86,7 +106,7 @@ def tune_command(
         print(f"Error during tuning: {e}", file=sys.stderr)
         return 1
 
-    print(f"\nBest parameters for {tracker}:")
+    print(f"\nBest parameters for {tracker.name}:")
     for name, value in best_params.items():
         print(f"  {name}: {value}")
     if tuner.study is not None:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -743,7 +743,7 @@ class TestBooleanOptionSyntax:
         [
             pytest.param(
                 tune_command,
-                ["--no_enqueue_defaults", "--tracker", "sort", "--gt_dir", "gt", "--detections_dir", "det"],
+                ["--no_enqueue_defaults", "--tracker.name", "sort", "--gt_dir", "gt", "--detections_dir", "det"],
                 "enqueue_defaults",
                 id="tune",
             ),
@@ -853,6 +853,60 @@ class TestTrackerChoices:
         assert parsed.tracker.name == DEFAULT_TRACKER
 
 
+class TestGeneratedTrackerOptions:
+    """``TrackerOptions`` is generated from the registry — verify what that buys."""
+
+    def test_mask_config_nests_under_tracker_mask(self) -> None:
+        """``mask_config`` is the one exact-name rename, spelled ``mask``."""
+        parser = _CLIParser(exit_on_error=False)
+        parser.add_function_arguments(track_command)
+        options = {option for action in parser._actions for option in action.option_strings}
+
+        assert "--tracker.mask" in options
+        assert "--tracker.mask.help" in options
+        assert "--tracker.mask_config" not in options
+
+    def test_nested_mask_field_parses_and_instantiates(self) -> None:
+        """A ``--tracker.mask.*`` sub-option reaches a real ``McByteMaskConfig``."""
+        from trackers.core.mcbyte.tracker import McByteMaskConfig
+
+        parser = _CLIParser(exit_on_error=False)
+        parser.add_function_arguments(track_command)
+
+        parsed = parser.instantiate_classes(
+            parser.parse_args(["--tracker.name", "mcbyte", "--tracker.mask.cutie_mem_every", "7"])
+        )
+
+        assert isinstance(parsed.tracker.mask, McByteMaskConfig)
+        assert parsed.tracker.mask.cutie_mem_every == 7
+
+    def test_class_path_parameter_resolves_to_the_class(self) -> None:
+        """``state_estimator_class`` takes a dotted class path, not a string."""
+        from trackers.utils.state_representations import XCYCWHStateEstimator
+
+        parser = _CLIParser(exit_on_error=False)
+        parser.add_function_arguments(track_command)
+
+        parsed = parser.instantiate_classes(
+            parser.parse_args(
+                [
+                    "--tracker.state_estimator_class",
+                    "trackers.utils.state_representations.XCYCWHStateEstimator",
+                ]
+            )
+        )
+
+        assert parsed.tracker.state_estimator_class is XCYCWHStateEstimator
+
+    def test_literal_parameter_rejects_an_unknown_choice(self) -> None:
+        """``cmc_method``'s ``Literal`` annotation becomes CLI-enforced choices."""
+        parser = _CLIParser(exit_on_error=False)
+        parser.add_function_arguments(track_command)
+
+        with pytest.raises(ArgumentError):
+            parser.parse_args(["--tracker.cmc_method", "not_a_real_method"])
+
+
 class TestTrackerShorthand:
     """``--tracker <id>`` stays the short spelling of ``--tracker.name <id>``."""
 
@@ -888,6 +942,38 @@ class TestTrackerShorthand:
         parser = _CLIParser(exit_on_error=False)
         parser.add_function_arguments(track_command)
         args = _translate_legacy_args(["track", "--tracker", "ocsort"])
+
+        parsed = parser.instantiate_classes(parser.parse_args(args[1:]))
+
+        assert parsed.tracker.name == "ocsort"
+
+
+class TestTuneTrackerShorthand:
+    """``tune`` accepts the same two tracker spellings as ``track``."""
+
+    def test_shorthand_expands_to_the_name_field(self) -> None:
+        """``--tracker <id>`` expands to ``--tracker.name <id>`` for tune too."""
+        assert _translate_legacy_args(["tune", "--tracker", "sort"]) == ["tune", "--tracker.name", "sort"]
+
+    def test_shorthand_does_not_warn(self) -> None:
+        """``--tracker`` is a supported spelling, not a deprecated one."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            assert _translate_legacy_args(["tune", "--tracker", "sort"]) == ["tune", "--tracker.name", "sort"]
+
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            pytest.param(["--tracker", "ocsort"], id="shorthand"),
+            pytest.param(["--tracker.name", "ocsort"], id="explicit"),
+        ],
+    )
+    def test_both_spellings_parse_into_tracker_selection(self, arguments: list[str]) -> None:
+        """Shorthand and explicit spellings both populate the tracker selector."""
+        parser = _CLIParser(exit_on_error=False)
+        parser.add_function_arguments(tune_command)
+        required = ["--gt_dir", "gt", "--detections_dir", "det"]
+        args = _translate_legacy_args(["tune", *arguments, *required])
 
         parsed = parser.instantiate_classes(parser.parse_args(args[1:]))
 

--- a/tests/cli/test_track.py
+++ b/tests/cli/test_track.py
@@ -14,15 +14,19 @@ import pytest
 import supervision as sv
 
 from trackers.cli.track import (
+    _EXCLUDED_TRACKER_PARAMETERS,
     ShowOptions,
     TrackerOptions,
     _abbreviate_parameter_name,
+    _abbreviated_tracker_parameters,
     _expand_parameter_name,
     _format_labels,
     _init_annotators,
     _init_tracker,
     _resolve_class_filter,
     _resolve_track_id_filter,
+    _resolve_tracker_kwargs,
+    _tracker_options_as_dict,
 )
 from trackers.core.base import BaseTracker
 
@@ -257,20 +261,92 @@ class TestTrackerParameterAbbreviations:
 
         assert getattr(tracker, keyword) == pytest.approx(value)
 
-    def test_every_option_field_maps_to_a_known_tracker_parameter(self) -> None:
-        """No TrackerOptions field can be dropped silently by _init_tracker."""
+    def test_registry_parameters_map_bidirectionally_to_option_fields(self) -> None:
+        """TrackerOptions fields and the registry union agree in both directions.
+
+        The old version of this test only checked that every ``TrackerOptions``
+        field mapped to a known registry parameter — sufficient for a
+        hand-maintained dataclass, but vacuous once the fields are generated
+        from that same registry. The reverse direction is what actually
+        guards against drift: a newly registered tracker parameter that never
+        made it into the generated dataclass.
+        """
         # ``name`` selects the tracker and ``iou_variant`` aliases ``iou``;
-        # neither is forwarded to the constructor under its own field name.
+        # neither is a registry parameter under its own field name. Walking
+        # ``.items()`` rather than the dict directly matters: it is the
+        # override that drops ``iou`` (see ``TrackerParameters.items``),
+        # matching what ``_tracker_parameter_union`` itself iterates over.
         accepted = {"name", "iou_variant"}
+        registry_names: set[str] = set()
         for tracker_id in BaseTracker._registered_trackers():
             info = BaseTracker._lookup_tracker(tracker_id)
             assert info is not None
-            accepted.update(info.parameters)
+            registry_names.update(name for name, _ in info.parameters.items())
+        accepted.update(registry_names)
 
-        unmatched = [
-            field.name
-            for field in fields(TrackerOptions)
-            if field.name not in accepted and _expand_parameter_name(field.name) not in accepted
+        option_fields = {field.name for field in fields(TrackerOptions)}
+
+        unmatched_fields = [
+            name for name in option_fields if name not in accepted and _expand_parameter_name(name) not in accepted
+        ]
+        unmatched_registry_names = [
+            name
+            for name in registry_names
+            if name not in _EXCLUDED_TRACKER_PARAMETERS and _abbreviate_parameter_name(name) not in option_fields
         ]
 
-        assert unmatched == []
+        assert unmatched_fields == []
+        assert unmatched_registry_names == []
+
+    def test_abbreviation_round_trips_for_every_registry_parameter(self) -> None:
+        """Every registry parameter's CLI name expands back to its Python name."""
+        for tracker_id in BaseTracker._registered_trackers():
+            info = BaseTracker._lookup_tracker(tracker_id)
+            assert info is not None
+            for python_name, _ in info.parameters.items():
+                if python_name in _EXCLUDED_TRACKER_PARAMETERS:
+                    continue
+                cli_name = _abbreviate_parameter_name(python_name)
+                assert _expand_parameter_name(cli_name) == python_name
+
+    def test_mask_rename_is_not_listed_as_a_deprecation(self) -> None:
+        """``mask_config`` never shipped under its Python name, so it is not deprecated.
+
+        Pins the deliberate exclusion in ``_abbreviated_tracker_parameters``: warning that ``--tracker.mask_config`` is
+        deprecated would be a lie, since no released CLI ever exposed that spelling.
+        """
+        assert "mask_config" not in _abbreviated_tracker_parameters()
+
+    def test_mask_field_reaches_the_tracker_as_a_dataclass_not_a_dict(self) -> None:
+        """``mask`` is forwarded intact, not flattened by ``dataclasses.asdict``.
+
+        Regression guard for the bug ``_init_tracker`` had before it stopped using ``asdict``: that call recurses into
+        nested dataclass fields, so ``mask`` would have reached ``McByteTracker`` as a plain ``dict`` instead of the
+        ``McByteMaskConfig`` instance it requires.
+        """
+        from trackers.core.mcbyte.tracker import McByteMaskConfig
+
+        mask_config = McByteMaskConfig(cutie_mem_every=7)
+        options = TrackerOptions(name="mcbyte", mask=mask_config)
+
+        raw = _tracker_options_as_dict(options)
+        assert raw["mask"] is mask_config
+
+        info = BaseTracker._lookup_tracker("mcbyte")
+        assert info is not None
+        kwargs, dropped = _resolve_tracker_kwargs(
+            {k: v for k, v in raw.items() if k not in ("name", "iou_variant")},
+            set(info.parameters),
+        )
+
+        assert dropped == []
+        assert kwargs["mask_config"] is mask_config
+
+    def test_unsupported_override_is_dropped_with_a_warning(self) -> None:
+        """A field the selected tracker does not accept warns instead of vanishing."""
+        options = TrackerOptions(name="sort", min_mask_coverage=0.3)
+
+        with pytest.warns(UserWarning, match=r"sort.*--tracker\.min_mask_coverage"):
+            tracker = _init_tracker(options)
+
+        assert not hasattr(tracker, "minimum_mask_coverage")

--- a/tests/cli/test_tune.py
+++ b/tests/cli/test_tune.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from trackers.cli.tune import tune_command
+from trackers.cli.tune import TrackerSelection, tune_command
 
 
 class TestTune:
@@ -24,7 +24,7 @@ class TestTune:
         gt_dir.mkdir()
         det_dir = tmp_path / "det"
         det_dir.mkdir()
-        result = tune_command("nonexistent_tracker_xyz", gt_dir, det_dir)
+        result = tune_command(TrackerSelection(name="nonexistent_tracker_xyz"), gt_dir, det_dir)
         assert result == 1
 
     def test_returns_1_on_missing_files(self, tmp_path: Path) -> None:
@@ -34,7 +34,7 @@ class TestTune:
         det_dir = tmp_path / "det"
         det_dir.mkdir()
         # bytetrack is registered; empty det_dir → FileNotFoundError via Tuner
-        result = tune_command("bytetrack", gt_dir, det_dir)
+        result = tune_command(TrackerSelection(name="bytetrack"), gt_dir, det_dir)
         assert result == 1
 
     def test_returns_1_on_import_error(self, tmp_path: Path) -> None:
@@ -45,7 +45,7 @@ class TestTune:
             "trackers.tune.Tuner",
             side_effect=ImportError("optuna is required"),
         ):
-            result = tune_command("bytetrack", gt_dir, det_dir)
+            result = tune_command(TrackerSelection(name="bytetrack"), gt_dir, det_dir)
         assert result == 1
 
     def test_returns_0_on_success(self, tmp_path: Path) -> None:
@@ -56,7 +56,7 @@ class TestTune:
         mock_tuner.run.return_value = {"high_thresh": 0.6}
         mock_tuner.study = None
         with patch("trackers.tune.Tuner", return_value=mock_tuner):
-            result = tune_command("bytetrack", gt_dir, det_dir)
+            result = tune_command(TrackerSelection(name="bytetrack"), gt_dir, det_dir)
         assert result == 0
 
     def test_writes_json_output_on_success(self, tmp_path: Path) -> None:
@@ -69,7 +69,7 @@ class TestTune:
         mock_tuner.run.return_value = best
         mock_tuner.study = None
         with patch("trackers.tune.Tuner", return_value=mock_tuner):
-            result = tune_command("bytetrack", gt_dir, det_dir, output=output_path)
+            result = tune_command(TrackerSelection(name="bytetrack"), gt_dir, det_dir, output=output_path)
         assert result == 0
         assert output_path.exists()
         assert json.loads(output_path.read_text()) == best
@@ -86,7 +86,7 @@ class TestTune:
             patch("trackers.tune.Tuner", return_value=mock_tuner),
             patch.object(Path, "write_text", side_effect=OSError("permission denied")),
         ):
-            result = tune_command("bytetrack", gt_dir, det_dir, output=output_path)
+            result = tune_command(TrackerSelection(name="bytetrack"), gt_dir, det_dir, output=output_path)
         assert result == 1
 
     def test_returns_1_on_tuner_run_exception(self, tmp_path: Path) -> None:
@@ -96,7 +96,7 @@ class TestTune:
         mock_tuner = MagicMock()
         mock_tuner.run.side_effect = RuntimeError("optimization failed")
         with patch("trackers.tune.Tuner", return_value=mock_tuner):
-            result = tune_command("bytetrack", gt_dir, det_dir)
+            result = tune_command(TrackerSelection(name="bytetrack"), gt_dir, det_dir)
         assert result == 1
 
 


### PR DESCRIPTION
- TrackerOptions in track.py is now generated from the tracker registry (make_dataclass over _tracker_parameter_union, annotated via get_type_hints) instead of hand-maintained, so all 26 registry parameters are reachable and a newly registered one needs no manual edit here
- mask_config is a new exact-name CLI rename to mask (--tracker.mask.*), excluded from the deprecation-alias table since it never shipped under the old spelling
- _init_tracker replaces dataclasses.asdict with a shallow field copy (_tracker_options_as_dict) so nested dataclass fields like mask reach the tracker intact instead of flattened to a dict, and now warns via _warn_dropped_tracker_overrides when a set option the selected tracker doesn't accept is silently dropped
- tune_command's first parameter is now a TrackerSelection dataclass, so tune accepts --tracker.name alongside --tracker, matching track; _translate_legacy_args expands the --tracker shorthand for tune too
- _develop_store_false_tracker_flags compares registry names via _abbreviate_parameter_name instead of raw names, so it stays correct if a boolean parameter is ever abbreviated
- tests and docs (cli.md, track.md, migration_cli.md) updated for the generated option surface, the mask rename, and tune's new tracker spelling
