### PR TITLE
Add McByte usage notebook

### DIFF
--- a/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
@@ -85,7 +85,7 @@
             "source": [
                 "## Track from CLI\n",
                 "\n",
-                "The `trackers` library provides a convenient command-line interface (CLI) for running detection and tracking without writing Python. This first example uses McByte's lightweight default configuration: clear-match locking and IoU association without SAM or Cutie.\n",
+                "The `trackers` library provides a convenient command-line interface (CLI) for running detection and tracking without writing Python. This first example uses McByte's lightweight default configuration: clear-match locking and IoU association without SAM or Cutie. It filters detections to the `person` class so each rider receives one clean track instead of separate, overlapping rider and motorcycle tracks.\n",
                 "\n",
                 "The first run downloads the RF-DETR checkpoint, so it takes longer than later runs. For all options, visit the [Track from CLI documentation](https://trackers.roboflow.com/develop/guides/track/)."
             ],
@@ -104,6 +104,7 @@
                 "    --overwrite \\\n",
                 "    --model rfdetr-medium \\\n",
                 "    --model.confidence 0.2 \\\n",
+                "    --classes person \\\n",
                 "    --tracker mcbyte \\\n",
                 "    --show-trajectories"
             ],
@@ -225,7 +226,7 @@
             "source": [
                 "### Run detection + tracking\n",
                 "\n",
-                "McByte receives the detections and an RGB copy of every frame. It returns the same `sv.Detections` structure with a stable `tracker_id` assigned to each active track."
+                "As in the CLI example, keep only `person` detections so each rider produces one track. McByte receives those detections and an RGB copy of every frame, then returns the same `sv.Detections` structure with a stable `tracker_id` assigned to each active track."
             ],
             "id": "86279a3f"
         },
@@ -237,6 +238,7 @@
                 "\n",
                 "CONFIDENCE_THRESHOLD = 0.2\n",
                 "NMS_THRESHOLD = 0.3\n",
+                "PERSON_CLASS_ID = 0\n",
                 "\n",
                 "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-2.mp4\"\n",
                 "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-2-mcbyte.mp4\"\n",
@@ -247,6 +249,7 @@
                 "    detections = result.to_supervision()\n",
                 "    detections = detections[detections.confidence >= CONFIDENCE_THRESHOLD]\n",
                 "    detections = detections.with_nms(threshold=NMS_THRESHOLD)\n",
+                "    detections = detections[detections.class_id == PERSON_CLASS_ID]\n",
                 "\n",
                 "    frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)\n",
                 "    detections = tracker.update(detections, frame=frame_rgb)\n",

--- a/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
@@ -1,330 +1,341 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "[![Roboflow Notebooks](https://media.roboflow.com/notebooks/template/bannertest2-2.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672932710194)](https://github.com/roboflow/notebooks)\n",
-        "\n",
-        "# How to Track Objects with RF-DETR and McByte Tracker\n",
-        "\n",
-        "McByte extends BoT-SORT-style tracking with segmentation masks. It first locks clear IoU matches, then uses masks initialized by Segment Anything (SAM) and propagated by Cutie to resolve ambiguous associations. This extra visual evidence helps preserve identities through occlusion and crowded scenes without training on your video. McByte can also run without masks, but this notebook enables the complete mask-conditioned pipeline."
-      ],
-      "id": "3f9c70af"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Setup\n",
-        "\n",
-        "### Check GPU availability\n",
-        "\n",
-        "Let's make sure that we have access to a GPU. We can use the `nvidia-smi` command to do that. If no GPU appears, navigate to `Runtime` → `Change runtime type` → `Hardware accelerator`, select a GPU, and click `Save`.\n",
-        "\n",
-        "McByte's SAM and Cutie models are compute-intensive, so a GPU runtime is strongly recommended."
-      ],
-      "id": "7131bc63"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "!nvidia-smi"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "bfc06f33"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Install dependencies\n",
-        "\n",
-        "The `mask` extra installs the optional SAM and Cutie dependencies used by McByte. The `detection` extra installs the model runner used for RF-DETR inference.\n",
-        "\n",
-        "You may see dependency conflict warnings in Google Colab. This is expected for the preinstalled Colab environment and does not affect this notebook."
-      ],
-      "id": "dffd00d2"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "!pip install -q \"trackers[detection,mask]==2.6.0\""
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "37eaef2b"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Download example data\n",
-        "\n",
-        "Download two example videos for testing. You can use these or replace them with your own videos."
-      ],
-      "id": "3f71b556"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-1.mp4\n",
-        "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-2.mp4"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "6b2734ea"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Track from CLI\n",
-        "\n",
-        "The `trackers` library provides a convenient command-line interface (CLI) for running detection and tracking without writing Python. Here we select McByte, enable its mask manager, and ask SAM and Cutie to run on the GPU.\n",
-        "\n",
-        "The first run downloads the RF-DETR, SAM, and Cutie checkpoints, so it takes longer than later runs. For all options, visit the [Track from CLI documentation](https://trackers.roboflow.com/develop/learn/track/)."
-      ],
-      "id": "35f7cb51"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-1.mp4\"\n",
-        "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-1-mcbyte.mp4\"\n",
-        "\n",
-        "!trackers track \\\n",
-        "    --source {SOURCE_VIDEO_PATH} \\\n",
-        "    --output.video {TARGET_VIDEO_PATH} \\\n",
-        "    --output.overwrite true \\\n",
-        "    --detection.model rfdetr-medium \\\n",
-        "    --detection.confidence 0.2 \\\n",
-        "    --tracker mcbyte \\\n",
-        "    --tracker.enable_mask_manager true \\\n",
-        "    --tracker.mask.device cuda \\\n",
-        "    --show.trajectories true"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "4d6e5fff"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-1-mcbyte-compressed.mp4\"\n",
-        "\n",
-        "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "8d5aa515"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "from IPython.display import Video\n",
-        "\n",
-        "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "7891800f"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Track from Python\n",
-        "\n",
-        "### Initialize the detector and tracker\n",
-        "\n",
-        "`enable_mask_manager=True` turns on McByte's complete SAM + Cutie pipeline. Passing the frame to `tracker.update(...)` is essential: McByte needs it to initialize and propagate masks and to compensate for camera motion."
-      ],
-      "id": "daac8c34"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "from inference_models import AutoModel\n",
-        "from trackers import McByteMaskConfig, McByteTracker\n",
-        "\n",
-        "model = AutoModel.from_pretrained(\"rfdetr-medium\", device=\"cuda\")\n",
-        "tracker = McByteTracker(\n",
-        "    enable_mask_manager=True,\n",
-        "    mask_config=McByteMaskConfig(device=\"cuda\"),\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "c992864e"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Configure annotators\n",
-        "\n",
-        "Coloring boxes, labels, and trajectories by track ID makes identity changes easy to spot."
-      ],
-      "id": "b3833e9f"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "import supervision as sv\n",
-        "\n",
-        "color = sv.ColorPalette.from_hex(\n",
-        "    [\n",
-        "        \"#ffff00\", \"#ff9b00\", \"#ff8080\", \"#ff66b2\", \"#ff66ff\", \"#b266ff\",\n",
-        "        \"#9999ff\", \"#3399ff\", \"#66ffff\", \"#33ff99\", \"#66ff66\", \"#99ff00\",\n",
-        "    ]\n",
-        ")\n",
-        "\n",
-        "box_annotator = sv.BoxAnnotator(\n",
-        "    color=color,\n",
-        "    color_lookup=sv.ColorLookup.TRACK,\n",
-        ")\n",
-        "label_annotator = sv.LabelAnnotator(\n",
-        "    color=color,\n",
-        "    color_lookup=sv.ColorLookup.TRACK,\n",
-        "    text_color=sv.Color.BLACK,\n",
-        "    text_scale=0.8,\n",
-        ")\n",
-        "trace_annotator = sv.TraceAnnotator(\n",
-        "    color=color,\n",
-        "    color_lookup=sv.ColorLookup.TRACK,\n",
-        "    thickness=2,\n",
-        "    trace_length=100,\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "493e1007"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Run detection + tracking\n",
-        "\n",
-        "McByte receives both the detections and the original frame on every callback. It returns the same `sv.Detections` structure with a stable `tracker_id` assigned to each active track."
-      ],
-      "id": "86279a3f"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "CONFIDENCE_THRESHOLD = 0.2\n",
-        "NMS_THRESHOLD = 0.3\n",
-        "\n",
-        "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-2.mp4\"\n",
-        "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-2-mcbyte.mp4\"\n",
-        "\n",
-        "\n",
-        "def callback(frame, frame_index):\n",
-        "    result = model(frame)[0]\n",
-        "    detections = result.to_supervision()\n",
-        "    detections = detections[detections.confidence >= CONFIDENCE_THRESHOLD]\n",
-        "    detections = detections.with_nms(threshold=NMS_THRESHOLD)\n",
-        "    detections = tracker.update(detections, frame=frame)\n",
-        "\n",
-        "    labels = [f\"#{tracker_id}\" for tracker_id in detections.tracker_id]\n",
-        "    annotated_frame = frame.copy()\n",
-        "    annotated_frame = box_annotator.annotate(annotated_frame, detections)\n",
-        "    annotated_frame = trace_annotator.annotate(annotated_frame, detections)\n",
-        "    annotated_frame = label_annotator.annotate(\n",
-        "        annotated_frame,\n",
-        "        detections,\n",
-        "        labels=labels,\n",
-        "    )\n",
-        "    return annotated_frame\n",
-        "\n",
-        "\n",
-        "tracker.reset()\n",
-        "sv.process_video(\n",
-        "    source_path=SOURCE_VIDEO_PATH,\n",
-        "    target_path=TARGET_VIDEO_PATH,\n",
-        "    callback=callback,\n",
-        "    show_progress=True,\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "bafe3ad2"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Display result"
-      ],
-      "id": "c719d01b"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-2-mcbyte-compressed.mp4\"\n",
-        "\n",
-        "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "8d9fc98b"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "from IPython.display import Video\n",
-        "\n",
-        "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
-      ],
-      "id": "c77f8b97",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "You just combined the McByte tracker with an RF-DETR detector. Nice work!\n",
-        "\n",
-        "McByte can also run without SAM and Cutie by constructing `McByteTracker()` with its default settings. That lightweight mode keeps clear-match locking and IoU association, but mask evidence is what gives McByte its distinctive advantage in ambiguous scenes.\n",
-        "\n",
-        "Trackers makes it easy to mix and match multi-object tracking algorithms with your favorite detection backends, including Inference, Ultralytics, and Transformers.\n",
-        "\n",
-        "Ready to go deeper? Explore McByte's mask conditioning and configuration options in the trackers [Documentation](https://trackers.roboflow.com/develop/trackers/mcbyte/) or dive into the code on [GitHub](https://github.com/roboflow/trackers).\n",
-        "\n",
-        "Got feedback or ideas? Open an issue on [GitHub Issues](https://github.com/roboflow/trackers/issues)."
-      ],
-      "id": "7457695e"
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "gpuType": "L4",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3f9c70af",
+   "metadata": {},
+   "source": [
+    "[![Roboflow Notebooks](https://media.roboflow.com/notebooks/template/bannertest2-2.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672932710194)](https://github.com/roboflow/notebooks)\n",
+    "\n",
+    "# How to Track Objects with RF-DETR and McByte Tracker\n",
+    "\n",
+    "McByte extends BoT-SORT-style tracking with segmentation masks. It first locks clear IoU matches, then uses masks initialized by Segment Anything (SAM) and propagated by Cutie to resolve ambiguous associations. This extra visual evidence helps preserve identities through occlusion and crowded scenes without training on your video. McByte can also run without masks, but this notebook enables the complete mask-conditioned pipeline."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "7131bc63",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "### Check GPU availability\n",
+    "\n",
+    "Let's make sure that we have access to a GPU. We can use the `nvidia-smi` command to do that. If no GPU appears, navigate to `Runtime` → `Change runtime type` → `Hardware accelerator`, select a GPU, and click `Save`.\n",
+    "\n",
+    "McByte's SAM and Cutie models are compute-intensive, so a GPU runtime is strongly recommended."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfc06f33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!nvidia-smi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dffd00d2",
+   "metadata": {},
+   "source": [
+    "### Install dependencies\n",
+    "\n",
+    "The `mask` extra installs the optional SAM and Cutie dependencies used by McByte. The `detection` extra installs the model runner used for RF-DETR inference.\n",
+    "\n",
+    "You may see dependency conflict warnings in Google Colab. This is expected for the preinstalled Colab environment and does not affect this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37eaef2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q \"trackers[detection,mask]==2.6.0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f71b556",
+   "metadata": {},
+   "source": [
+    "### Download example data\n",
+    "\n",
+    "Download two example videos for testing. You can use these or replace them with your own videos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b2734ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-1.mp4\n",
+    "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-2.mp4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35f7cb51",
+   "metadata": {},
+   "source": [
+    "## Track from CLI\n",
+    "\n",
+    "The `trackers` library provides a convenient command-line interface (CLI) for running detection and tracking without writing Python. Here we select McByte, enable its mask manager, and ask SAM and Cutie to run on the GPU.\n",
+    "\n",
+    "The first run downloads the RF-DETR, SAM, and Cutie checkpoints, so it takes longer than later runs. For all options, visit the [Track from CLI documentation](https://trackers.roboflow.com/develop/learn/track/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d6e5fff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-1.mp4\"\n",
+    "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-1-mcbyte.mp4\"\n",
+    "\n",
+    "!trackers track \\\n",
+    "    --source {SOURCE_VIDEO_PATH} \\\n",
+    "    --output.video {TARGET_VIDEO_PATH} \\\n",
+    "    --output.overwrite true \\\n",
+    "    --detection.model rfdetr-medium \\\n",
+    "    --detection.confidence 0.2 \\\n",
+    "    --tracker mcbyte \\\n",
+    "    --tracker.enable_mask_manager true \\\n",
+    "    --tracker.mask.device cuda \\\n",
+    "    --show.trajectories true"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d5aa515",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-1-mcbyte-compressed.mp4\"\n",
+    "\n",
+    "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7891800f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Video\n",
+    "\n",
+    "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "daac8c34",
+   "metadata": {},
+   "source": [
+    "## Track from Python\n",
+    "\n",
+    "### Initialize the detector and tracker\n",
+    "\n",
+    "`enable_mask_manager=True` turns on McByte's complete SAM + Cutie pipeline. Passing the frame to `tracker.update(...)` is essential: McByte needs it to initialize and propagate masks and to compensate for camera motion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c992864e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from inference_models import AutoModel\n",
+    "\n",
+    "from trackers import McByteMaskConfig, McByteTracker\n",
+    "\n",
+    "model = AutoModel.from_pretrained(\"rfdetr-medium\", device=\"cuda\")\n",
+    "tracker = McByteTracker(\n",
+    "    enable_mask_manager=True,\n",
+    "    mask_config=McByteMaskConfig(device=\"cuda\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3833e9f",
+   "metadata": {},
+   "source": [
+    "### Configure annotators\n",
+    "\n",
+    "Coloring boxes, labels, and trajectories by track ID makes identity changes easy to spot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "493e1007",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import supervision as sv\n",
+    "\n",
+    "color = sv.ColorPalette.from_hex(\n",
+    "    [\n",
+    "        \"#ffff00\",\n",
+    "        \"#ff9b00\",\n",
+    "        \"#ff8080\",\n",
+    "        \"#ff66b2\",\n",
+    "        \"#ff66ff\",\n",
+    "        \"#b266ff\",\n",
+    "        \"#9999ff\",\n",
+    "        \"#3399ff\",\n",
+    "        \"#66ffff\",\n",
+    "        \"#33ff99\",\n",
+    "        \"#66ff66\",\n",
+    "        \"#99ff00\",\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "box_annotator = sv.BoxAnnotator(\n",
+    "    color=color,\n",
+    "    color_lookup=sv.ColorLookup.TRACK,\n",
+    ")\n",
+    "label_annotator = sv.LabelAnnotator(\n",
+    "    color=color,\n",
+    "    color_lookup=sv.ColorLookup.TRACK,\n",
+    "    text_color=sv.Color.BLACK,\n",
+    "    text_scale=0.8,\n",
+    ")\n",
+    "trace_annotator = sv.TraceAnnotator(\n",
+    "    color=color,\n",
+    "    color_lookup=sv.ColorLookup.TRACK,\n",
+    "    thickness=2,\n",
+    "    trace_length=100,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86279a3f",
+   "metadata": {},
+   "source": [
+    "### Run detection + tracking\n",
+    "\n",
+    "McByte receives both the detections and the original frame on every callback. It returns the same `sv.Detections` structure with a stable `tracker_id` assigned to each active track."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bafe3ad2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CONFIDENCE_THRESHOLD = 0.2\n",
+    "NMS_THRESHOLD = 0.3\n",
+    "\n",
+    "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-2.mp4\"\n",
+    "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-2-mcbyte.mp4\"\n",
+    "\n",
+    "\n",
+    "def callback(frame, frame_index):\n",
+    "    result = model(frame)[0]\n",
+    "    detections = result.to_supervision()\n",
+    "    detections = detections[detections.confidence >= CONFIDENCE_THRESHOLD]\n",
+    "    detections = detections.with_nms(threshold=NMS_THRESHOLD)\n",
+    "    detections = tracker.update(detections, frame=frame)\n",
+    "\n",
+    "    labels = [f\"#{tracker_id}\" for tracker_id in detections.tracker_id]\n",
+    "    annotated_frame = frame.copy()\n",
+    "    annotated_frame = box_annotator.annotate(annotated_frame, detections)\n",
+    "    annotated_frame = trace_annotator.annotate(annotated_frame, detections)\n",
+    "    annotated_frame = label_annotator.annotate(\n",
+    "        annotated_frame,\n",
+    "        detections,\n",
+    "        labels=labels,\n",
+    "    )\n",
+    "    return annotated_frame\n",
+    "\n",
+    "\n",
+    "tracker.reset()\n",
+    "sv.process_video(\n",
+    "    source_path=SOURCE_VIDEO_PATH,\n",
+    "    target_path=TARGET_VIDEO_PATH,\n",
+    "    callback=callback,\n",
+    "    show_progress=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c719d01b",
+   "metadata": {},
+   "source": [
+    "### Display result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d9fc98b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-2-mcbyte-compressed.mp4\"\n",
+    "\n",
+    "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c77f8b97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Video\n",
+    "\n",
+    "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7457695e",
+   "metadata": {},
+   "source": [
+    "You just combined the McByte tracker with an RF-DETR detector. Nice work!\n",
+    "\n",
+    "McByte can also run without SAM and Cutie by constructing `McByteTracker()` with its default settings. That lightweight mode keeps clear-match locking and IoU association, but mask evidence is what gives McByte its distinctive advantage in ambiguous scenes.\n",
+    "\n",
+    "Trackers makes it easy to mix and match multi-object tracking algorithms with your favorite detection backends, including Inference, Ultralytics, and Transformers.\n",
+    "\n",
+    "Ready to go deeper? Explore McByte's mask conditioning and configuration options in the trackers [Documentation](https://trackers.roboflow.com/develop/trackers/mcbyte/) or dive into the code on [GitHub](https://github.com/roboflow/trackers).\n",
+    "\n",
+    "Got feedback or ideas? Open an issue on [GitHub Issues](https://github.com/roboflow/trackers/issues)."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "L4",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
@@ -1,341 +1,343 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "3f9c70af",
-   "metadata": {},
-   "source": [
-    "[![Roboflow Notebooks](https://media.roboflow.com/notebooks/template/bannertest2-2.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672932710194)](https://github.com/roboflow/notebooks)\n",
-    "\n",
-    "# How to Track Objects with RF-DETR and McByte Tracker\n",
-    "\n",
-    "McByte extends BoT-SORT-style tracking with segmentation masks. It first locks clear IoU matches, then uses masks initialized by Segment Anything (SAM) and propagated by Cutie to resolve ambiguous associations. This extra visual evidence helps preserve identities through occlusion and crowded scenes without training on your video. McByte can also run without masks, but this notebook enables the complete mask-conditioned pipeline."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7131bc63",
-   "metadata": {},
-   "source": [
-    "## Setup\n",
-    "\n",
-    "### Check GPU availability\n",
-    "\n",
-    "Let's make sure that we have access to a GPU. We can use the `nvidia-smi` command to do that. If no GPU appears, navigate to `Runtime` → `Change runtime type` → `Hardware accelerator`, select a GPU, and click `Save`.\n",
-    "\n",
-    "McByte's SAM and Cutie models are compute-intensive, so a GPU runtime is strongly recommended."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bfc06f33",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!nvidia-smi"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dffd00d2",
-   "metadata": {},
-   "source": [
-    "### Install dependencies\n",
-    "\n",
-    "The `mask` extra installs the optional SAM and Cutie dependencies used by McByte. The `detection` extra installs the model runner used for RF-DETR inference.\n",
-    "\n",
-    "You may see dependency conflict warnings in Google Colab. This is expected for the preinstalled Colab environment and does not affect this notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37eaef2b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install -q \"trackers[detection,mask]==2.6.0\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3f71b556",
-   "metadata": {},
-   "source": [
-    "### Download example data\n",
-    "\n",
-    "Download two example videos for testing. You can use these or replace them with your own videos."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6b2734ea",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-1.mp4\n",
-    "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-2.mp4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "35f7cb51",
-   "metadata": {},
-   "source": [
-    "## Track from CLI\n",
-    "\n",
-    "The `trackers` library provides a convenient command-line interface (CLI) for running detection and tracking without writing Python. Here we select McByte, enable its mask manager, and ask SAM and Cutie to run on the GPU.\n",
-    "\n",
-    "The first run downloads the RF-DETR, SAM, and Cutie checkpoints, so it takes longer than later runs. For all options, visit the [Track from CLI documentation](https://trackers.roboflow.com/develop/learn/track/)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4d6e5fff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-1.mp4\"\n",
-    "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-1-mcbyte.mp4\"\n",
-    "\n",
-    "!trackers track \\\n",
-    "    --source {SOURCE_VIDEO_PATH} \\\n",
-    "    --output.video {TARGET_VIDEO_PATH} \\\n",
-    "    --output.overwrite true \\\n",
-    "    --detection.model rfdetr-medium \\\n",
-    "    --detection.confidence 0.2 \\\n",
-    "    --tracker mcbyte \\\n",
-    "    --tracker.enable_mask_manager true \\\n",
-    "    --tracker.mask.device cuda \\\n",
-    "    --show.trajectories true"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8d5aa515",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-1-mcbyte-compressed.mp4\"\n",
-    "\n",
-    "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7891800f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import Video\n",
-    "\n",
-    "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "daac8c34",
-   "metadata": {},
-   "source": [
-    "## Track from Python\n",
-    "\n",
-    "### Initialize the detector and tracker\n",
-    "\n",
-    "`enable_mask_manager=True` turns on McByte's complete SAM + Cutie pipeline. Passing the frame to `tracker.update(...)` is essential: McByte needs it to initialize and propagate masks and to compensate for camera motion."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c992864e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from inference_models import AutoModel\n",
-    "\n",
-    "from trackers import McByteMaskConfig, McByteTracker\n",
-    "\n",
-    "model = AutoModel.from_pretrained(\"rfdetr-medium\", device=\"cuda\")\n",
-    "tracker = McByteTracker(\n",
-    "    enable_mask_manager=True,\n",
-    "    mask_config=McByteMaskConfig(device=\"cuda\"),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b3833e9f",
-   "metadata": {},
-   "source": [
-    "### Configure annotators\n",
-    "\n",
-    "Coloring boxes, labels, and trajectories by track ID makes identity changes easy to spot."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "493e1007",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import supervision as sv\n",
-    "\n",
-    "color = sv.ColorPalette.from_hex(\n",
-    "    [\n",
-    "        \"#ffff00\",\n",
-    "        \"#ff9b00\",\n",
-    "        \"#ff8080\",\n",
-    "        \"#ff66b2\",\n",
-    "        \"#ff66ff\",\n",
-    "        \"#b266ff\",\n",
-    "        \"#9999ff\",\n",
-    "        \"#3399ff\",\n",
-    "        \"#66ffff\",\n",
-    "        \"#33ff99\",\n",
-    "        \"#66ff66\",\n",
-    "        \"#99ff00\",\n",
-    "    ]\n",
-    ")\n",
-    "\n",
-    "box_annotator = sv.BoxAnnotator(\n",
-    "    color=color,\n",
-    "    color_lookup=sv.ColorLookup.TRACK,\n",
-    ")\n",
-    "label_annotator = sv.LabelAnnotator(\n",
-    "    color=color,\n",
-    "    color_lookup=sv.ColorLookup.TRACK,\n",
-    "    text_color=sv.Color.BLACK,\n",
-    "    text_scale=0.8,\n",
-    ")\n",
-    "trace_annotator = sv.TraceAnnotator(\n",
-    "    color=color,\n",
-    "    color_lookup=sv.ColorLookup.TRACK,\n",
-    "    thickness=2,\n",
-    "    trace_length=100,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "86279a3f",
-   "metadata": {},
-   "source": [
-    "### Run detection + tracking\n",
-    "\n",
-    "McByte receives both the detections and the original frame on every callback. It returns the same `sv.Detections` structure with a stable `tracker_id` assigned to each active track."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bafe3ad2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "CONFIDENCE_THRESHOLD = 0.2\n",
-    "NMS_THRESHOLD = 0.3\n",
-    "\n",
-    "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-2.mp4\"\n",
-    "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-2-mcbyte.mp4\"\n",
-    "\n",
-    "\n",
-    "def callback(frame, frame_index):\n",
-    "    result = model(frame)[0]\n",
-    "    detections = result.to_supervision()\n",
-    "    detections = detections[detections.confidence >= CONFIDENCE_THRESHOLD]\n",
-    "    detections = detections.with_nms(threshold=NMS_THRESHOLD)\n",
-    "    detections = tracker.update(detections, frame=frame)\n",
-    "\n",
-    "    labels = [f\"#{tracker_id}\" for tracker_id in detections.tracker_id]\n",
-    "    annotated_frame = frame.copy()\n",
-    "    annotated_frame = box_annotator.annotate(annotated_frame, detections)\n",
-    "    annotated_frame = trace_annotator.annotate(annotated_frame, detections)\n",
-    "    annotated_frame = label_annotator.annotate(\n",
-    "        annotated_frame,\n",
-    "        detections,\n",
-    "        labels=labels,\n",
-    "    )\n",
-    "    return annotated_frame\n",
-    "\n",
-    "\n",
-    "tracker.reset()\n",
-    "sv.process_video(\n",
-    "    source_path=SOURCE_VIDEO_PATH,\n",
-    "    target_path=TARGET_VIDEO_PATH,\n",
-    "    callback=callback,\n",
-    "    show_progress=True,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c719d01b",
-   "metadata": {},
-   "source": [
-    "### Display result"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8d9fc98b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-2-mcbyte-compressed.mp4\"\n",
-    "\n",
-    "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c77f8b97",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import Video\n",
-    "\n",
-    "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7457695e",
-   "metadata": {},
-   "source": [
-    "You just combined the McByte tracker with an RF-DETR detector. Nice work!\n",
-    "\n",
-    "McByte can also run without SAM and Cutie by constructing `McByteTracker()` with its default settings. That lightweight mode keeps clear-match locking and IoU association, but mask evidence is what gives McByte its distinctive advantage in ambiguous scenes.\n",
-    "\n",
-    "Trackers makes it easy to mix and match multi-object tracking algorithms with your favorite detection backends, including Inference, Ultralytics, and Transformers.\n",
-    "\n",
-    "Ready to go deeper? Explore McByte's mask conditioning and configuration options in the trackers [Documentation](https://trackers.roboflow.com/develop/trackers/mcbyte/) or dive into the code on [GitHub](https://github.com/roboflow/trackers).\n",
-    "\n",
-    "Got feedback or ideas? Open an issue on [GitHub Issues](https://github.com/roboflow/trackers/issues)."
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "gpuType": "L4",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "[![Roboflow Notebooks](https://media.roboflow.com/notebooks/template/bannertest2-2.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672932710194)](https://github.com/roboflow/notebooks)\n",
+                "\n",
+                "# How to Track Objects with RF-DETR and McByte Tracker\n",
+                "\n",
+                "McByte extends BoT-SORT-style tracking with segmentation masks. It first locks clear IoU matches, then uses masks initialized by Segment Anything (SAM) and propagated by Cutie to resolve ambiguous associations. This extra visual evidence helps preserve identities through occlusion and crowded scenes without training on your video. McByte can also run without masks, but this notebook enables the complete mask-conditioned pipeline."
+            ],
+            "id": "3f9c70af"
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Setup\n",
+                "\n",
+                "### Check GPU availability\n",
+                "\n",
+                "Let's make sure that we have access to a GPU. We can use the `nvidia-smi` command to do that. If no GPU appears, navigate to `Runtime` → `Change runtime type` → `Hardware accelerator`, select a GPU, and click `Save`.\n",
+                "\n",
+                "McByte's SAM and Cutie models are compute-intensive, so a GPU runtime is strongly recommended."
+            ],
+            "id": "7131bc63"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "!nvidia-smi"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "bfc06f33"
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Install dependencies\n",
+                "\n",
+                "The `mask` extra installs the optional SAM and Cutie dependencies used by McByte. The `detection` extra installs the model runner used for RF-DETR inference.\n",
+                "\n",
+                "You may see dependency conflict warnings in Google Colab. This is expected for the preinstalled Colab environment and does not affect this notebook."
+            ],
+            "id": "dffd00d2"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "!pip install -q \"trackers[detection,mask]==2.6.0\""
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "37eaef2b"
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Download example data\n",
+                "\n",
+                "Download two example videos for testing. You can use these or replace them with your own videos."
+            ],
+            "id": "3f71b556"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-1.mp4\n",
+                "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-2.mp4"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "6b2734ea"
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Track from CLI\n",
+                "\n",
+                "The `trackers` library provides a convenient command-line interface (CLI) for running detection and tracking without writing Python. This first example uses McByte's lightweight default configuration: clear-match locking and IoU association without SAM or Cutie.\n",
+                "\n",
+                "The first run downloads the RF-DETR checkpoint, so it takes longer than later runs. For all options, visit the [Track from CLI documentation](https://trackers.roboflow.com/develop/guides/track/)."
+            ],
+            "id": "35f7cb51"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-1.mp4\"\n",
+                "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-1-mcbyte.mp4\"\n",
+                "\n",
+                "!trackers track \\\n",
+                "    --source {SOURCE_VIDEO_PATH} \\\n",
+                "    --output.video {TARGET_VIDEO_PATH} \\\n",
+                "    --output.overwrite true \\\n",
+                "    --detection.model rfdetr-medium \\\n",
+                "    --detection.confidence 0.2 \\\n",
+                "    --tracker mcbyte \\\n",
+                "    --show.trajectories true"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "4d6e5fff"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-1-mcbyte-compressed.mp4\"\n",
+                "\n",
+                "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "8d5aa515"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "from IPython.display import Video\n",
+                "\n",
+                "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "7891800f"
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Track from Python\n",
+                "\n",
+                "### Initialize the detector and tracker\n",
+                "\n",
+                "Now enable McByte's complete SAM + Cutie pipeline. The mask backends expect RGB images, while OpenCV and `sv.process_video` provide BGR frames. In the callback below, detection and annotation use the original BGR frame, and McByte receives an RGB conversion."
+            ],
+            "id": "daac8c34"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "from inference_models import AutoModel\n",
+                "\n",
+                "from trackers import McByteMaskConfig, McByteTracker\n",
+                "\n",
+                "model = AutoModel.from_pretrained(\"rfdetr-medium\", device=\"cuda\")\n",
+                "tracker = McByteTracker(\n",
+                "    enable_mask_manager=True,\n",
+                "    mask_config=McByteMaskConfig(device=\"cuda\"),\n",
+                ")"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "c992864e"
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Configure annotators\n",
+                "\n",
+                "Coloring boxes, labels, and trajectories by track ID makes identity changes easy to spot."
+            ],
+            "id": "b3833e9f"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "import supervision as sv\n",
+                "\n",
+                "color = sv.ColorPalette.from_hex(\n",
+                "    [\n",
+                "        \"#ffff00\",\n",
+                "        \"#ff9b00\",\n",
+                "        \"#ff8080\",\n",
+                "        \"#ff66b2\",\n",
+                "        \"#ff66ff\",\n",
+                "        \"#b266ff\",\n",
+                "        \"#9999ff\",\n",
+                "        \"#3399ff\",\n",
+                "        \"#66ffff\",\n",
+                "        \"#33ff99\",\n",
+                "        \"#66ff66\",\n",
+                "        \"#99ff00\",\n",
+                "    ]\n",
+                ")\n",
+                "\n",
+                "box_annotator = sv.BoxAnnotator(\n",
+                "    color=color,\n",
+                "    color_lookup=sv.ColorLookup.TRACK,\n",
+                ")\n",
+                "label_annotator = sv.LabelAnnotator(\n",
+                "    color=color,\n",
+                "    color_lookup=sv.ColorLookup.TRACK,\n",
+                "    text_color=sv.Color.BLACK,\n",
+                "    text_scale=0.8,\n",
+                ")\n",
+                "trace_annotator = sv.TraceAnnotator(\n",
+                "    color=color,\n",
+                "    color_lookup=sv.ColorLookup.TRACK,\n",
+                "    thickness=2,\n",
+                "    trace_length=100,\n",
+                ")"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "493e1007"
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Run detection + tracking\n",
+                "\n",
+                "McByte receives the detections and an RGB copy of every frame. It returns the same `sv.Detections` structure with a stable `tracker_id` assigned to each active track."
+            ],
+            "id": "86279a3f"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "import cv2\n",
+                "\n",
+                "CONFIDENCE_THRESHOLD = 0.2\n",
+                "NMS_THRESHOLD = 0.3\n",
+                "\n",
+                "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-2.mp4\"\n",
+                "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-2-mcbyte.mp4\"\n",
+                "\n",
+                "\n",
+                "def callback(frame_bgr, frame_index):\n",
+                "    result = model(frame_bgr)[0]\n",
+                "    detections = result.to_supervision()\n",
+                "    detections = detections[detections.confidence >= CONFIDENCE_THRESHOLD]\n",
+                "    detections = detections.with_nms(threshold=NMS_THRESHOLD)\n",
+                "\n",
+                "    frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)\n",
+                "    detections = tracker.update(detections, frame=frame_rgb)\n",
+                "\n",
+                "    labels = [f\"#{tracker_id}\" for tracker_id in detections.tracker_id]\n",
+                "    annotated_frame = frame_bgr.copy()\n",
+                "    annotated_frame = box_annotator.annotate(annotated_frame, detections)\n",
+                "    annotated_frame = trace_annotator.annotate(annotated_frame, detections)\n",
+                "    annotated_frame = label_annotator.annotate(\n",
+                "        annotated_frame,\n",
+                "        detections,\n",
+                "        labels=labels,\n",
+                "    )\n",
+                "    return annotated_frame\n",
+                "\n",
+                "\n",
+                "tracker.reset()\n",
+                "sv.process_video(\n",
+                "    source_path=SOURCE_VIDEO_PATH,\n",
+                "    target_path=TARGET_VIDEO_PATH,\n",
+                "    callback=callback,\n",
+                "    show_progress=True,\n",
+                ")"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "bafe3ad2"
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Display result"
+            ],
+            "id": "c719d01b"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-2-mcbyte-compressed.mp4\"\n",
+                "\n",
+                "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "8d9fc98b"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "from IPython.display import Video\n",
+                "\n",
+                "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
+            ],
+            "execution_count": null,
+            "outputs": [],
+            "id": "c77f8b97"
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "You just combined the McByte tracker with an RF-DETR detector. Nice work!\n",
+                "\n",
+                "McByte can also run without SAM and Cutie by constructing `McByteTracker()` with its default settings. That lightweight mode keeps clear-match locking and IoU association, but mask evidence is what gives McByte its distinctive advantage in ambiguous scenes.\n",
+                "\n",
+                "Trackers makes it easy to mix and match multi-object tracking algorithms with your favorite detection backends, including Inference, Ultralytics, and Transformers.\n",
+                "\n",
+                "Ready to go deeper? Explore McByte's mask conditioning and configuration options in the trackers [Documentation](https://trackers.roboflow.com/develop/trackers/mcbyte/) or dive into the code on [GitHub](https://github.com/roboflow/trackers).\n",
+                "\n",
+                "Got feedback or ideas? Open an issue on [GitHub Issues](https://github.com/roboflow/trackers/issues)."
+            ],
+            "id": "7457695e"
+        }
+    ],
+    "metadata": {
+        "accelerator": "GPU",
+        "colab": {
+            "gpuType": "L4",
+            "provenance": []
+        },
+        "kernelspec": {
+            "display_name": "Python 3",
+            "name": "python3"
+        },
+        "language_info": {
+            "name": "python"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
@@ -1,0 +1,330 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "[![Roboflow Notebooks](https://media.roboflow.com/notebooks/template/bannertest2-2.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672932710194)](https://github.com/roboflow/notebooks)\n",
+        "\n",
+        "# How to Track Objects with RF-DETR and McByte Tracker\n",
+        "\n",
+        "McByte extends BoT-SORT-style tracking with segmentation masks. It first locks clear IoU matches, then uses masks initialized by Segment Anything (SAM) and propagated by Cutie to resolve ambiguous associations. This extra visual evidence helps preserve identities through occlusion and crowded scenes without training on your video. McByte can also run without masks, but this notebook enables the complete mask-conditioned pipeline."
+      ],
+      "id": "3f9c70af"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup\n",
+        "\n",
+        "### Check GPU availability\n",
+        "\n",
+        "Let's make sure that we have access to a GPU. We can use the `nvidia-smi` command to do that. If no GPU appears, navigate to `Runtime` → `Change runtime type` → `Hardware accelerator`, select a GPU, and click `Save`.\n",
+        "\n",
+        "McByte's SAM and Cutie models are compute-intensive, so a GPU runtime is strongly recommended."
+      ],
+      "id": "7131bc63"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!nvidia-smi"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "bfc06f33"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Install dependencies\n",
+        "\n",
+        "The `mask` extra installs the optional SAM and Cutie dependencies used by McByte. The `detection` extra installs the model runner used for RF-DETR inference.\n",
+        "\n",
+        "You may see dependency conflict warnings in Google Colab. This is expected for the preinstalled Colab environment and does not affect this notebook."
+      ],
+      "id": "dffd00d2"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!pip install -q \"trackers[detection,mask]==2.6.0\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "37eaef2b"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Download example data\n",
+        "\n",
+        "Download two example videos for testing. You can use these or replace them with your own videos."
+      ],
+      "id": "3f71b556"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-1.mp4\n",
+        "!wget -q https://storage.googleapis.com/com-roboflow-marketing/supervision/video-examples/bikes-1280x720-2.mp4"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "6b2734ea"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Track from CLI\n",
+        "\n",
+        "The `trackers` library provides a convenient command-line interface (CLI) for running detection and tracking without writing Python. Here we select McByte, enable its mask manager, and ask SAM and Cutie to run on the GPU.\n",
+        "\n",
+        "The first run downloads the RF-DETR, SAM, and Cutie checkpoints, so it takes longer than later runs. For all options, visit the [Track from CLI documentation](https://trackers.roboflow.com/develop/learn/track/)."
+      ],
+      "id": "35f7cb51"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-1.mp4\"\n",
+        "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-1-mcbyte.mp4\"\n",
+        "\n",
+        "!trackers track \\\n",
+        "    --source {SOURCE_VIDEO_PATH} \\\n",
+        "    --output.video {TARGET_VIDEO_PATH} \\\n",
+        "    --output.overwrite true \\\n",
+        "    --detection.model rfdetr-medium \\\n",
+        "    --detection.confidence 0.2 \\\n",
+        "    --tracker mcbyte \\\n",
+        "    --tracker.enable_mask_manager true \\\n",
+        "    --tracker.mask.device cuda \\\n",
+        "    --show.trajectories true"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "4d6e5fff"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-1-mcbyte-compressed.mp4\"\n",
+        "\n",
+        "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "8d5aa515"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from IPython.display import Video\n",
+        "\n",
+        "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "7891800f"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Track from Python\n",
+        "\n",
+        "### Initialize the detector and tracker\n",
+        "\n",
+        "`enable_mask_manager=True` turns on McByte's complete SAM + Cutie pipeline. Passing the frame to `tracker.update(...)` is essential: McByte needs it to initialize and propagate masks and to compensate for camera motion."
+      ],
+      "id": "daac8c34"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from inference_models import AutoModel\n",
+        "from trackers import McByteMaskConfig, McByteTracker\n",
+        "\n",
+        "model = AutoModel.from_pretrained(\"rfdetr-medium\", device=\"cuda\")\n",
+        "tracker = McByteTracker(\n",
+        "    enable_mask_manager=True,\n",
+        "    mask_config=McByteMaskConfig(device=\"cuda\"),\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "c992864e"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Configure annotators\n",
+        "\n",
+        "Coloring boxes, labels, and trajectories by track ID makes identity changes easy to spot."
+      ],
+      "id": "b3833e9f"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import supervision as sv\n",
+        "\n",
+        "color = sv.ColorPalette.from_hex(\n",
+        "    [\n",
+        "        \"#ffff00\", \"#ff9b00\", \"#ff8080\", \"#ff66b2\", \"#ff66ff\", \"#b266ff\",\n",
+        "        \"#9999ff\", \"#3399ff\", \"#66ffff\", \"#33ff99\", \"#66ff66\", \"#99ff00\",\n",
+        "    ]\n",
+        ")\n",
+        "\n",
+        "box_annotator = sv.BoxAnnotator(\n",
+        "    color=color,\n",
+        "    color_lookup=sv.ColorLookup.TRACK,\n",
+        ")\n",
+        "label_annotator = sv.LabelAnnotator(\n",
+        "    color=color,\n",
+        "    color_lookup=sv.ColorLookup.TRACK,\n",
+        "    text_color=sv.Color.BLACK,\n",
+        "    text_scale=0.8,\n",
+        ")\n",
+        "trace_annotator = sv.TraceAnnotator(\n",
+        "    color=color,\n",
+        "    color_lookup=sv.ColorLookup.TRACK,\n",
+        "    thickness=2,\n",
+        "    trace_length=100,\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "493e1007"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Run detection + tracking\n",
+        "\n",
+        "McByte receives both the detections and the original frame on every callback. It returns the same `sv.Detections` structure with a stable `tracker_id` assigned to each active track."
+      ],
+      "id": "86279a3f"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "CONFIDENCE_THRESHOLD = 0.2\n",
+        "NMS_THRESHOLD = 0.3\n",
+        "\n",
+        "SOURCE_VIDEO_PATH = \"/content/bikes-1280x720-2.mp4\"\n",
+        "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-2-mcbyte.mp4\"\n",
+        "\n",
+        "\n",
+        "def callback(frame, frame_index):\n",
+        "    result = model(frame)[0]\n",
+        "    detections = result.to_supervision()\n",
+        "    detections = detections[detections.confidence >= CONFIDENCE_THRESHOLD]\n",
+        "    detections = detections.with_nms(threshold=NMS_THRESHOLD)\n",
+        "    detections = tracker.update(detections, frame=frame)\n",
+        "\n",
+        "    labels = [f\"#{tracker_id}\" for tracker_id in detections.tracker_id]\n",
+        "    annotated_frame = frame.copy()\n",
+        "    annotated_frame = box_annotator.annotate(annotated_frame, detections)\n",
+        "    annotated_frame = trace_annotator.annotate(annotated_frame, detections)\n",
+        "    annotated_frame = label_annotator.annotate(\n",
+        "        annotated_frame,\n",
+        "        detections,\n",
+        "        labels=labels,\n",
+        "    )\n",
+        "    return annotated_frame\n",
+        "\n",
+        "\n",
+        "tracker.reset()\n",
+        "sv.process_video(\n",
+        "    source_path=SOURCE_VIDEO_PATH,\n",
+        "    target_path=TARGET_VIDEO_PATH,\n",
+        "    callback=callback,\n",
+        "    show_progress=True,\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "bafe3ad2"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Display result"
+      ],
+      "id": "c719d01b"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "TARGET_VIDEO_COMPRESSED_PATH = \"/content/bikes-1280x720-2-mcbyte-compressed.mp4\"\n",
+        "\n",
+        "!ffmpeg -y -loglevel error -i {TARGET_VIDEO_PATH} -vcodec libx264 -crf 28 {TARGET_VIDEO_COMPRESSED_PATH}"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "8d9fc98b"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from IPython.display import Video\n",
+        "\n",
+        "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
+      ],
+      "id": "c77f8b97",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "You just combined the McByte tracker with an RF-DETR detector. Nice work!\n",
+        "\n",
+        "McByte can also run without SAM and Cutie by constructing `McByteTracker()` with its default settings. That lightweight mode keeps clear-match locking and IoU association, but mask evidence is what gives McByte its distinctive advantage in ambiguous scenes.\n",
+        "\n",
+        "Trackers makes it easy to mix and match multi-object tracking algorithms with your favorite detection backends, including Inference, Ultralytics, and Transformers.\n",
+        "\n",
+        "Ready to go deeper? Explore McByte's mask conditioning and configuration options in the trackers [Documentation](https://trackers.roboflow.com/develop/trackers/mcbyte/) or dive into the code on [GitHub](https://github.com/roboflow/trackers).\n",
+        "\n",
+        "Got feedback or ideas? Open an issue on [GitHub Issues](https://github.com/roboflow/trackers/issues)."
+      ],
+      "id": "7457695e"
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "L4",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
@@ -85,9 +85,9 @@
       "source": [
         "## Track from CLI\n",
         "\n",
-        "The `trackers` library provides a convenient command-line interface (CLI) for running detection and tracking without writing Python. Here we select McByte, enable its mask manager, and ask SAM and Cutie to run on the GPU.\n",
+        "The `trackers` library provides a convenient command-line interface (CLI) for running detection and tracking without writing Python. This first example uses McByte's lightweight default configuration: clear-match locking and IoU association without SAM or Cutie.\n",
         "\n",
-        "The first run downloads the RF-DETR, SAM, and Cutie checkpoints, so it takes longer than later runs. For all options, visit the [Track from CLI documentation](https://trackers.roboflow.com/develop/learn/track/)."
+        "The first run downloads the RF-DETR checkpoint, so it takes longer than later runs. For all options, visit the [Track from CLI documentation](https://trackers.roboflow.com/develop/guides/track/)."
       ],
       "id": "35f7cb51"
     },
@@ -105,8 +105,6 @@
         "    --detection.model rfdetr-medium \\\n",
         "    --detection.confidence 0.2 \\\n",
         "    --tracker mcbyte \\\n",
-        "    --tracker.enable_mask_manager true \\\n",
-        "    --tracker.mask.device cuda \\\n",
         "    --show.trajectories true"
       ],
       "execution_count": null,
@@ -145,7 +143,7 @@
         "\n",
         "### Initialize the detector and tracker\n",
         "\n",
-        "`enable_mask_manager=True` turns on McByte's complete SAM + Cutie pipeline. Passing the frame to `tracker.update(...)` is essential: McByte needs it to initialize and propagate masks and to compensate for camera motion."
+        "Now enable McByte's complete SAM + Cutie pipeline. The mask backends expect RGB images, while OpenCV and `sv.process_video` provide BGR frames. In the callback below, detection and annotation use the original BGR frame, and McByte receives an RGB conversion."
       ],
       "id": "daac8c34"
     },
@@ -216,7 +214,7 @@
       "source": [
         "### Run detection + tracking\n",
         "\n",
-        "McByte receives both the detections and the original frame on every callback. It returns the same `sv.Detections` structure with a stable `tracker_id` assigned to each active track."
+        "McByte receives the detections and an RGB copy of every frame. It returns the same `sv.Detections` structure with a stable `tracker_id` assigned to each active track."
       ],
       "id": "86279a3f"
     },
@@ -224,6 +222,8 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
+        "import cv2\n",
+        "\n",
         "CONFIDENCE_THRESHOLD = 0.2\n",
         "NMS_THRESHOLD = 0.3\n",
         "\n",
@@ -231,15 +231,17 @@
         "TARGET_VIDEO_PATH = \"/content/bikes-1280x720-2-mcbyte.mp4\"\n",
         "\n",
         "\n",
-        "def callback(frame, frame_index):\n",
-        "    result = model(frame)[0]\n",
+        "def callback(frame_bgr, frame_index):\n",
+        "    result = model(frame_bgr)[0]\n",
         "    detections = result.to_supervision()\n",
         "    detections = detections[detections.confidence >= CONFIDENCE_THRESHOLD]\n",
         "    detections = detections.with_nms(threshold=NMS_THRESHOLD)\n",
-        "    detections = tracker.update(detections, frame=frame)\n",
+        "\n",
+        "    frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)\n",
+        "    detections = tracker.update(detections, frame=frame_rgb)\n",
         "\n",
         "    labels = [f\"#{tracker_id}\" for tracker_id in detections.tracker_id]\n",
-        "    annotated_frame = frame.copy()\n",
+        "    annotated_frame = frame_bgr.copy()\n",
         "    annotated_frame = box_annotator.annotate(annotated_frame, detections)\n",
         "    annotated_frame = trace_annotator.annotate(annotated_frame, detections)\n",
         "    annotated_frame = label_annotator.annotate(\n",
@@ -290,9 +292,9 @@
         "\n",
         "Video(TARGET_VIDEO_COMPRESSED_PATH, embed=True, width=1080)"
       ],
-      "id": "c77f8b97",
       "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "id": "c77f8b97"
     },
     {
       "cell_type": "markdown",

--- a/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-mcbyte-tracker.ipynb
@@ -100,12 +100,12 @@
                 "\n",
                 "!trackers track \\\n",
                 "    --source {SOURCE_VIDEO_PATH} \\\n",
-                "    --output.video {TARGET_VIDEO_PATH} \\\n",
-                "    --output.overwrite true \\\n",
-                "    --detection.model rfdetr-medium \\\n",
-                "    --detection.confidence 0.2 \\\n",
+                "    --output {TARGET_VIDEO_PATH} \\\n",
+                "    --overwrite \\\n",
+                "    --model rfdetr-medium \\\n",
+                "    --model.confidence 0.2 \\\n",
                 "    --tracker mcbyte \\\n",
-                "    --show.trajectories true"
+                "    --show-trajectories"
             ],
             "execution_count": null,
             "outputs": [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a Colab-ready McByte tutorial following the structure and tone of the existing SORT, ByteTrack, and OC-SORT notebooks.

The notebook covers:
- GPU setup and pinned McByte mask dependencies
- RF-DETR + lightweight McByte tracking from the released v2.6.0 CLI
- Person-class filtering for clean, stable rider tracks
- RF-DETR + full mask-conditioned McByte tracking from Python
- Explicit BGR-to-RGB conversion required by SAM/Cutie
- Track-colored boxes, labels, trajectories, and embedded video results

## Type of Change

Documentation update

## Testing

- [x] Executed the exact CLI workflow on all 388 sample-video frames
- [x] Visually reviewed output for annotation clarity, ID stability, box accuracy, and trajectory continuity
- [x] Validated notebook JSON and Python syntax
- [x] Ran repository JSON and Ruff formatting checks
- [ ] Executed the full GPU mask workflow in Colab
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff34c-3694-7e3a-a006-456d866e847c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff34c-3694-7e3a-a006-456d866e847c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

