### PR TITLE
docs: add McByte row to all Algorithms/Benchmark tables

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,14 +77,17 @@ trackers download mot17 --split val --asset annotations,detections
 
 ## Benchmark Results (HOTA, default parameters)
 
-<!-- BENCH-XREF copy-of: [docs/evaluations/results.md](../docs/evaluations/results.md) mot17/sportsmot/soccernet/dancetrack-default tables, HOTA column only, SORT/ByteTrack/OC-SORT/BoT-SORT rows (no C-BIoU/McByte rows here). Also duplicated in [docs/index.md](../docs/index.md) and [README.md](../README.md). Update results.md first, then mirror all three copies. -->
+<!-- BENCH-XREF copy-of: [docs/evaluations/results.md](../docs/evaluations/results.md) mot17/sportsmot/soccernet/dancetrack-default tables, HOTA column only, SORT/ByteTrack/OC-SORT/BoT-SORT/McByte rows (no C-BIoU row here). Also duplicated in [docs/index.md](../docs/index.md) and [README.md](../README.md). Update results.md first, then mirror all three copies. -->
 
-| Tracker   | MOT17 | SportsMOT | SoccerNet | DanceTrack |
-| --------- | ----- | --------- | --------- | ---------- |
-| SORT      | 58.4  | 70.8      | 81.6      | 47.2       |
-| ByteTrack | 60.1  | 73.0      | 84.0      | 53.3       |
-| OC-SORT   | 61.9  | 71.7      | 78.4      | 54.1       |
-| BoT-SORT  | 63.7  | 73.8      | 84.5      | 57.8       |
+| Tracker   | MOT17    | SportsMOT | SoccerNet | DanceTrack |
+| --------- | -------- | --------- | --------- | ---------- |
+| SORT      | 58.4     | 70.8      | 81.6      | 47.2       |
+| ByteTrack | 60.1     | 73.0      | 84.0      | 53.3       |
+| OC-SORT   | 61.9     | 71.7      | 78.4      | 54.1       |
+| BoT-SORT  | 63.7     | 73.8      | 84.5      | 57.8       |
+| McByte\*  | **64.1** | **76.5**  | **85.0**  | **67.2**   |
+
+\*McByte needs optional heavyweight deps (`torch`, SAM, Cutie), not installed by default. Tops HOTA on all four benchmarks above.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For all CLI options, see the [tracking guide](https://trackers.roboflow.com/deve
 
 Each tracker below is a faithful implementation of its original paper. Pick the one that fits your scene, or run the benchmark to find out which performs best on your data.
 
-<!-- BENCH-XREF copy-of: [docs/evaluations/results.md](docs/evaluations/results.md) mot17/sportsmot/soccernet/dancetrack-default tables, HOTA column only, all 6 rows (SORT/ByteTrack/OC-SORT/BoT-SORT/C-BIoU/McByte). Also duplicated in [docs/index.md](docs/index.md)'s Algorithms table and [.github/copilot-instructions.md](.github/copilot-instructions.md)'s Benchmark Results table (both omit C-BIoU and McByte). Update results.md first, then mirror all three copies. -->
+<!-- BENCH-XREF copy-of: [docs/evaluations/results.md](docs/evaluations/results.md) mot17/sportsmot/soccernet/dancetrack-default tables, HOTA column only, all 6 rows (SORT/ByteTrack/OC-SORT/BoT-SORT/C-BIoU/McByte). Also duplicated in [docs/index.md](docs/index.md)'s Algorithms table and [.github/copilot-instructions.md](.github/copilot-instructions.md)'s Benchmark Results table (both omit C-BIoU). Update results.md first, then mirror all three copies. -->
 
 |                            Algorithm                             |                                   Description                                    | MOT17 HOTA | SportsMOT HOTA | SoccerNet HOTA | DanceTrack HOTA |
 | :--------------------------------------------------------------: | :------------------------------------------------------------------------------: | :--------: | :------------: | :------------: | :-------------: |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 </div>
 
-Keeping track of objects across video frames is one of those problems that sounds simple until you try it — occlusions, fast motion, similar-looking targets, and moving cameras all conspire against you. `trackers` gives you clean, benchmarked implementations of SORT, ByteTrack, OC-SORT, BoT-SORT, and C-BIoU so you can skip the plumbing and focus on your application. It speaks `supervision.Detections` natively, which means it slots into any detector you already use — YOLO, DETR, RT-DETR, or anything else — without glue code. Whether you are a researcher comparing algorithms, an engineer shipping a production pipeline, or a hobbyist building something cool, `trackers` gives you a single consistent interface for all of them. Requires Python ≥ 3.10.
+`trackers` gives you clean-room, benchmarked implementations of SORT, ByteTrack, OC-SORT, BoT-SORT, C-BIoU, and McByte — so occlusions, fast motion, and moving cameras stop being your problem to solve from scratch. It speaks `supervision.Detections` natively, slotting into any detector you already use — YOLO, DETR, RT-DETR, or anything else — without glue code. One consistent interface, whether you're a researcher comparing algorithms, an engineer shipping a production pipeline, or a hobbyist building something cool. Requires Python ≥ 3.10.
 
 ## Why trackers?
 
@@ -83,19 +83,20 @@ For all CLI options, see the [tracking guide](https://trackers.roboflow.com/deve
 
 Each tracker below is a faithful implementation of its original paper. Pick the one that fits your scene, or run the benchmark to find out which performs best on your data.
 
-<!-- BENCH-XREF copy-of: [docs/evaluations/results.md](docs/evaluations/results.md) mot17/sportsmot/soccernet/dancetrack-default tables, HOTA column only, all 5 rows (SORT/ByteTrack/OC-SORT/BoT-SORT/C-BIoU). Also duplicated in [docs/index.md](docs/index.md)'s Algorithms table and [.github/copilot-instructions.md](.github/copilot-instructions.md)'s Benchmark Results table (both omit C-BIoU). Update results.md first, then mirror all three copies. -->
+<!-- BENCH-XREF copy-of: [docs/evaluations/results.md](docs/evaluations/results.md) mot17/sportsmot/soccernet/dancetrack-default tables, HOTA column only, all 6 rows (SORT/ByteTrack/OC-SORT/BoT-SORT/C-BIoU/McByte). Also duplicated in [docs/index.md](docs/index.md)'s Algorithms table and [.github/copilot-instructions.md](.github/copilot-instructions.md)'s Benchmark Results table (both omit C-BIoU and McByte). Update results.md first, then mirror all three copies. -->
 
-|                                                                           Algorithm                                                                           |                           Description                           | MOT17 HOTA | SportsMOT HOTA | SoccerNet HOTA | DanceTrack HOTA |
-| :-----------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------: | :--------: | :------------: | :------------: | :-------------: |
-|                                                           [SORT](https://arxiv.org/abs/1602.00763)                                                            |          Kalman filter + Hungarian matching baseline.           |    58.4    |      70.8      |      81.6      |      47.2       |
-|                                                         [ByteTrack](https://arxiv.org/abs/2110.06864)                                                         | Two-stage association using high and low confidence detections. |    60.1    |      73.0      |      84.0      |      53.3       |
-|                                                          [OC-SORT](https://arxiv.org/abs/2203.14360)                                                          |          Observation-centric recovery for lost tracks.          |    61.9    |      71.7      |      78.4      |      54.1       |
-|                                                         [BoT-SORT](https://arxiv.org/abs/2206.14651)                                                          |                   Camera motion compensation                    |  **63.7**  |    **73.8**    |    **84.5**    |    **57.8**     |
-| [C-BIoU](https://openaccess.thecvf.com/content/WACV2023/papers/Yang_Hard_To_Track_Objects_With_Irregular_Motions_and_Similar_Appearances_WACV_2023_paper.pdf) |  Cascaded buffered IoU matching for fast or irregular motion.   |    63.0    |      73.1      |      82.6      |      56.7       |
+|                            Algorithm                             |                                   Description                                    | MOT17 HOTA | SportsMOT HOTA | SoccerNet HOTA | DanceTrack HOTA |
+| :--------------------------------------------------------------: | :------------------------------------------------------------------------------: | :--------: | :------------: | :------------: | :-------------: |
+|             [SORT](https://arxiv.org/abs/1602.00763)             |                   Kalman filter + Hungarian matching baseline.                   |    58.4    |      70.8      |      81.6      |      47.2       |
+|          [ByteTrack](https://arxiv.org/abs/2110.06864)           |         Two-stage association using high and low confidence detections.          |    60.1    |      73.0      |      84.0      |      53.3       |
+|           [OC-SORT](https://arxiv.org/abs/2203.14360)            |                  Observation-centric recovery for lost tracks.                   |    61.9    |      71.7      |      78.4      |      54.1       |
+|           [BoT-SORT](https://arxiv.org/abs/2206.14651)           |                           Camera motion compensation.                            |    63.7    |      73.8      |      84.5      |      57.8       |
+|            [C-BIoU](https://arxiv.org/abs/2211.14317)            |           Cascaded buffered IoU matching for fast or irregular motion.           |    63.0    |      73.1      |      82.6      |      56.7       |
+| [McByte](https://trackers.roboflow.com/develop/trackers/mcbyte/) | Mask-conditioned tracking — adds propagated SAM/Cutie masks as a matching cue.\* |  **64.1**  |    **76.5**    |    **85.0**    |    **67.2**     |
+
+\*McByte needs optional heavyweight deps (`torch`, SAM, Cutie) not installed by default. It tops HOTA on all four benchmarks above — see the [McByte docs](https://trackers.roboflow.com/develop/trackers/mcbyte/) for setup.
 
 All scores use default parameters on the standard split. See the [tracker comparison](https://trackers.roboflow.com/develop/evaluations/results/) for tuned numbers and methodology.
-
-`trackers` also ships [McByte](https://trackers.roboflow.com/develop/trackers/mcbyte/), a mask-conditioned tracker that extends BoT-SORT-style association with temporally propagated SAM/Cutie segmentation masks as an extra matching cue. It requires optional heavyweight dependencies (`torch`, SAM, Cutie) not installed by default — see the [McByte docs](https://trackers.roboflow.com/develop/trackers/mcbyte/) for setup and benchmark numbers.
 
 ## Evaluate
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -53,17 +53,18 @@ C-BIoU row (mot17/sportsmot/soccernet/dancetrack — the only tracker doc with a
 
 McByte row (mot17/sportsmot/soccernet/dancetrack):
   -> [trackers/mcbyte.md](trackers/mcbyte.md)                  (McByte row, matching benchmark tab, full row)
-  -> [index.md](index.md) FAQ "Which tracker should I use?" answer: "McByte leads every benchmark in our evaluation"
+  -> [index.md](index.md)                                      (Algorithms table, HOTA column only; FAQ "Which tracker should I use?" answer: "McByte leads every benchmark in our evaluation")
+  -> [../README.md](../README.md)                              (Algorithms table, HOTA column only; includes C-BIoU row too)
+  -> [../.github/copilot-instructions.md](../.github/copilot-instructions.md) (Benchmark Results table, HOTA column only)
      — this claim is TRUE only while McByte is bolded-best in all 4 Default tables. Re-verify, don't assume.
 
 ## Structural asymmetries (intentional — do not "fix" by adding rows)
 - docs/trackers/{sort,bytetrack,ocsort,botsort}.md tables cover MOT17/SportsMOT/SoccerNet only, no DanceTrack row.
 - docs/trackers/cbiou.md is the only individual-tracker doc with a DanceTrack row.
-- docs/index.md Algorithms table has 4 tracker rows (SORT/ByteTrack/OC-SORT/BoT-SORT), no C-BIoU/McByte rows.
-- README.md Algorithms table has 5 tracker rows (adds C-BIoU vs index.md), still no McByte row (McByte covered
-  in prose below the table instead, linking to [trackers/mcbyte.md](trackers/mcbyte.md)).
-- .github/copilot-instructions.md Benchmark Results table has 4 tracker rows (SORT/ByteTrack/OC-SORT/BoT-SORT)
-  across all 4 benchmarks, with no C-BIoU/McByte rows.
+- docs/index.md Algorithms table has 5 tracker rows (SORT/ByteTrack/OC-SORT/BoT-SORT/McByte), no C-BIoU row.
+- README.md Algorithms table has 6 tracker rows (SORT/ByteTrack/OC-SORT/BoT-SORT/C-BIoU/McByte).
+- .github/copilot-instructions.md Benchmark Results table has 5 tracker rows (SORT/ByteTrack/OC-SORT/BoT-SORT/McByte)
+  across all 4 benchmarks, with no C-BIoU row.
 - docs/trackers/mcbyte.md reports McByte vs a BoT-SORT baseline only (not vs SORT/ByteTrack/OC-SORT/C-BIoU).
 
 ## Derived prose claims (not raw copies, but stale if the tables move)

--- a/docs/evaluations/results.md
+++ b/docs/evaluations/results.md
@@ -49,7 +49,7 @@ Pedestrian tracking with crowded scenes and frequent occlusions. Strongly tests 
          OC-SORT row   -> docs/trackers/ocsort.md (table), docs/index.md (L13 headline + Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          BoT-SORT row  -> docs/trackers/botsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table), docs/trackers/mcbyte.md (BoT-SORT row, "MOT17" tab)
          C-BIoU row    -> docs/trackers/cbiou.md (table), README.md (Algorithms table)
-         McByte row    -> docs/trackers/mcbyte.md (McByte row, "MOT17" tab), docs/index.md FAQ "leads every benchmark" claim
+         McByte row    -> docs/trackers/mcbyte.md (McByte row, "MOT17" tab), README.md (Algorithms table), docs/index.md FAQ "leads every benchmark" claim
          Change any cell above -> update every listed location + re-check FAQ leader claim still true. -->
 
 === "Tuned"
@@ -143,7 +143,7 @@ Sports broadcast tracking with fast motion, camera pans, and similar-looking tar
          OC-SORT row   -> docs/trackers/ocsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          BoT-SORT row  -> docs/trackers/botsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table), docs/trackers/mcbyte.md (BoT-SORT row, "SportsMOT" tab)
          C-BIoU row    -> docs/trackers/cbiou.md (table), README.md (Algorithms table only)
-         McByte row    -> docs/trackers/mcbyte.md (McByte row, "SportsMOT" tab), docs/index.md FAQ "leads every benchmark" claim
+         McByte row    -> docs/trackers/mcbyte.md (McByte row, "SportsMOT" tab), README.md (Algorithms table), docs/index.md FAQ "leads every benchmark" claim
          Change any cell above -> update every listed location + re-check FAQ leader claim still true. -->
 
 === "Tuned"
@@ -237,7 +237,7 @@ Long sequences with dense interactions and partial occlusions. Tests long-term I
          OC-SORT row   -> docs/trackers/ocsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          BoT-SORT row  -> docs/trackers/botsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table), docs/trackers/mcbyte.md (BoT-SORT row, "SoccerNet" tab)
          C-BIoU row    -> docs/trackers/cbiou.md (table), README.md (Algorithms table only)
-         McByte row    -> docs/trackers/mcbyte.md (McByte row, "SoccerNet" tab), docs/index.md FAQ "leads every benchmark" claim
+         McByte row    -> docs/trackers/mcbyte.md (McByte row, "SoccerNet" tab), README.md (Algorithms table), docs/index.md FAQ "leads every benchmark" claim
          Change any cell above -> update every listed location + re-check FAQ leader claim still true. -->
 
 === "Tuned"
@@ -334,7 +334,7 @@ Group dancing tracking with uniform appearance, diverse motions, and extreme art
          Note: docs/trackers/{sort,bytetrack,ocsort,botsort}.md intentionally have NO DanceTrack row — don't add one, that's existing scope not a gap.
          BoT-SORT row also -> docs/trackers/mcbyte.md (BoT-SORT row, "DanceTrack" tab)
          C-BIoU row    -> docs/trackers/cbiou.md (table, DanceTrack row), README.md (Algorithms table)
-         McByte row    -> docs/trackers/mcbyte.md (McByte row, "DanceTrack" tab), docs/index.md FAQ "leads every benchmark" claim
+         McByte row    -> docs/trackers/mcbyte.md (McByte row, "DanceTrack" tab), README.md (Algorithms table), docs/index.md FAQ "leads every benchmark" claim
          Change any cell above -> update every listed location + re-check FAQ leader claim still true. -->
 
 === "Tuned"

--- a/docs/evaluations/results.md
+++ b/docs/evaluations/results.md
@@ -49,7 +49,7 @@ Pedestrian tracking with crowded scenes and frequent occlusions. Strongly tests 
          OC-SORT row   -> docs/trackers/ocsort.md (table), docs/index.md (L13 headline + Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          BoT-SORT row  -> docs/trackers/botsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table), docs/trackers/mcbyte.md (BoT-SORT row, "MOT17" tab)
          C-BIoU row    -> docs/trackers/cbiou.md (table), README.md (Algorithms table)
-         McByte row    -> docs/trackers/mcbyte.md (McByte row, "MOT17" tab), README.md (Algorithms table), docs/index.md FAQ "leads every benchmark" claim
+         McByte row    -> docs/trackers/mcbyte.md (McByte row, "MOT17" tab), docs/index.md (Algorithms table + FAQ "leads every benchmark" claim), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          Change any cell above -> update every listed location + re-check FAQ leader claim still true. -->
 
 === "Tuned"
@@ -143,7 +143,7 @@ Sports broadcast tracking with fast motion, camera pans, and similar-looking tar
          OC-SORT row   -> docs/trackers/ocsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          BoT-SORT row  -> docs/trackers/botsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table), docs/trackers/mcbyte.md (BoT-SORT row, "SportsMOT" tab)
          C-BIoU row    -> docs/trackers/cbiou.md (table), README.md (Algorithms table only)
-         McByte row    -> docs/trackers/mcbyte.md (McByte row, "SportsMOT" tab), README.md (Algorithms table), docs/index.md FAQ "leads every benchmark" claim
+         McByte row    -> docs/trackers/mcbyte.md (McByte row, "SportsMOT" tab), docs/index.md (Algorithms table + FAQ "leads every benchmark" claim), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          Change any cell above -> update every listed location + re-check FAQ leader claim still true. -->
 
 === "Tuned"
@@ -237,7 +237,7 @@ Long sequences with dense interactions and partial occlusions. Tests long-term I
          OC-SORT row   -> docs/trackers/ocsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          BoT-SORT row  -> docs/trackers/botsort.md (table), docs/index.md (Algorithms table), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table), docs/trackers/mcbyte.md (BoT-SORT row, "SoccerNet" tab)
          C-BIoU row    -> docs/trackers/cbiou.md (table), README.md (Algorithms table only)
-         McByte row    -> docs/trackers/mcbyte.md (McByte row, "SoccerNet" tab), README.md (Algorithms table), docs/index.md FAQ "leads every benchmark" claim
+         McByte row    -> docs/trackers/mcbyte.md (McByte row, "SoccerNet" tab), docs/index.md (Algorithms table + FAQ "leads every benchmark" claim), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          Change any cell above -> update every listed location + re-check FAQ leader claim still true. -->
 
 === "Tuned"
@@ -334,7 +334,7 @@ Group dancing tracking with uniform appearance, diverse motions, and extreme art
          Note: docs/trackers/{sort,bytetrack,ocsort,botsort}.md intentionally have NO DanceTrack row — don't add one, that's existing scope not a gap.
          BoT-SORT row also -> docs/trackers/mcbyte.md (BoT-SORT row, "DanceTrack" tab)
          C-BIoU row    -> docs/trackers/cbiou.md (table, DanceTrack row), README.md (Algorithms table)
-         McByte row    -> docs/trackers/mcbyte.md (McByte row, "DanceTrack" tab), README.md (Algorithms table), docs/index.md FAQ "leads every benchmark" claim
+         McByte row    -> docs/trackers/mcbyte.md (McByte row, "DanceTrack" tab), docs/index.md (Algorithms table + FAQ "leads every benchmark" claim), README.md (Algorithms table), .github/copilot-instructions.md (Benchmark Results table)
          Change any cell above -> update every listed location + re-check FAQ leader claim still true. -->
 
 === "Tuned"

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,18 +117,19 @@ For the full evaluation workflow, see the [evaluation guide](evaluations/evaluat
 
 Clean, modular implementations of leading trackers. All HOTA scores use default parameters.
 
-<!-- BENCH-XREF copy-of: [docs/evaluations/results.md](evaluations/results.md) mot17/sportsmot/soccernet/dancetrack-default tables, HOTA column only, SORT/ByteTrack/OC-SORT/BoT-SORT rows (no C-BIoU/McByte rows here). Also duplicated in [README.md](../README.md)'s Algorithms table (which additionally has a C-BIoU row) and [.github/copilot-instructions.md](../.github/copilot-instructions.md)'s Benchmark Results table. Update results.md first, then mirror all three copies. -->
+<!-- BENCH-XREF copy-of: [docs/evaluations/results.md](evaluations/results.md) mot17/sportsmot/soccernet/dancetrack-default tables, HOTA column only, SORT/ByteTrack/OC-SORT/BoT-SORT/McByte rows (no C-BIoU row here). Also duplicated in [README.md](../README.md)'s Algorithms table (which additionally has a C-BIoU row) and [.github/copilot-instructions.md](../.github/copilot-instructions.md)'s Benchmark Results table. Update results.md first, then mirror all three copies. -->
 
-|                   Algorithm                   |                           Description                           | MOT17 HOTA | SportsMOT HOTA | SoccerNet HOTA | DanceTrack HOTA |
-| :-------------------------------------------: | :-------------------------------------------------------------: | :--------: | :------------: | :------------: | :-------------: |
-|   [SORT](https://arxiv.org/abs/1602.00763)    |          Kalman filter + Hungarian matching baseline.           |    58.4    |      70.8      |      81.6      |      47.2       |
-| [ByteTrack](https://arxiv.org/abs/2110.06864) | Two-stage association using high and low confidence detections. |    60.1    |      73.0      |      84.0      |      53.3       |
-|  [OC-SORT](https://arxiv.org/abs/2203.14360)  |          Observation-centric recovery for lost tracks.          |    61.9    |      71.7      |      78.4      |      54.1       |
-| [BoT-SORT](https://arxiv.org/abs/2206.14651)  |                   Camera motion compensation                    |  **63.7**  |    **73.8**    |    **84.5**    |    **57.8**     |
+|                   Algorithm                   |                               Description                               | MOT17 HOTA | SportsMOT HOTA | SoccerNet HOTA | DanceTrack HOTA |
+| :-------------------------------------------: | :---------------------------------------------------------------------: | :--------: | :------------: | :------------: | :-------------: |
+|   [SORT](https://arxiv.org/abs/1602.00763)    |              Kalman filter + Hungarian matching baseline.               |    58.4    |      70.8      |      81.6      |      47.2       |
+| [ByteTrack](https://arxiv.org/abs/2110.06864) |     Two-stage association using high and low confidence detections.     |    60.1    |      73.0      |      84.0      |      53.3       |
+|  [OC-SORT](https://arxiv.org/abs/2203.14360)  |              Observation-centric recovery for lost tracks.              |    61.9    |      71.7      |      78.4      |      54.1       |
+| [BoT-SORT](https://arxiv.org/abs/2206.14651)  |                       Camera motion compensation.                       |    63.7    |      73.8      |      84.5      |      57.8       |
+|         [McByte](trackers/mcbyte.md)          | Mask-conditioned tracking — adds propagated SAM/Cutie masks as a cue.\* |  **64.1**  |    **76.5**    |    **85.0**    |    **67.2**     |
+
+\*McByte needs optional heavyweight deps (`torch`, SAM, Cutie) not installed by default. It tops HOTA on all four benchmarks above — see the [McByte docs](trackers/mcbyte.md) for setup.
 
 For detailed benchmarks and tuned configurations, see the [tracker comparison](evaluations/results.md).
-
-Trackers also ships [McByte](trackers/mcbyte.md), a mask-conditioned tracker that extends BoT-SORT-style association with temporally propagated SAM/Cutie segmentation masks as an extra matching cue. It requires optional heavyweight dependencies (`torch`, SAM, Cutie) not installed by default — see the [McByte docs](trackers/mcbyte.md) for setup and benchmark numbers.
 
 ---
 


### PR DESCRIPTION
This pull request updates the documentation to consistently include the new McByte tracker and its benchmark results across all relevant tables and references. It also clarifies McByte's requirements and highlights its performance, ensuring that all documentation mirrors the latest evaluation results and tracker lineup.

**Documentation and Benchmark Table Updates:**

* Added McByte to all benchmark tables in `README.md`, `.github/copilot-instructions.md`, and `docs/index.md`, including its HOTA scores for all four benchmarks and a note about its requirements and performance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R99) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L120-R132) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L80-R90)
* Updated benchmark cross-reference comments and table row references to include McByte in all relevant locations, ensuring instructions for mirroring results are accurate and up to date. [[1]](diffhunk://#diff-cd60f0890b5f525c34b4453fe5af21fed145361f437753f954d0473f736498a7L52-R52) [[2]](diffhunk://#diff-cd60f0890b5f525c34b4453fe5af21fed145361f437753f954d0473f736498a7L146-R146) [[3]](diffhunk://#diff-cd60f0890b5f525c34b4453fe5af21fed145361f437753f954d0473f736498a7L240-R240) [[4]](diffhunk://#diff-cd60f0890b5f525c34b4453fe5af21fed145361f437753f954d0473f736498a7L337-R337)

**Content and Wording Improvements:**

* Revised tracker descriptions and table formatting for clarity and consistency, including improved explanations of McByte's capabilities and requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R99) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L120-R132)

These changes ensure that McByte is now fully represented in the documentation, and all benchmark tables and instructions are synchronized across the project.