### PR TITLE
fix(utils): decode batched `xcycsr_to_xyxy` in floating point

### DIFF
--- a/src/trackers/utils/converters.py
+++ b/src/trackers/utils/converters.py
@@ -131,6 +131,9 @@ def xcycsr_to_xyxy(xcycsr: np.ndarray) -> np.ndarray:
 
     Returns:
         Bounding boxes `[x_min, y_min, x_max, y_max]` with same shape as input.
+        Decoding is always performed in floating point: integer input is promoted
+        (``int32``/``int64`` decode to ``float64``), and float input keeps its own
+        precision (``float32`` decodes to ``float32``).
 
     Note:
         When ``scale`` or ``aspect_ratio`` is zero, ``w`` collapses to ``0.0``
@@ -182,7 +185,8 @@ def xcycsr_to_xyxy(xcycsr: np.ndarray) -> np.ndarray:
     # Inner np.where substitutes 1.0 for zero denominators to suppress the
     # eager-evaluation divide-by-zero warning; outer np.where replaces those results with 0.0.
     h = np.where(w != 0, xcycsr[:, 2] / np.where(w != 0, w, 1.0), 0.0)
-    result = np.empty((xcycsr.shape[0], 4), dtype=np.float64)
+    # Decoded values are floats, so promote integers rather than truncate them; float input keeps its precision.
+    result = np.empty((xcycsr.shape[0], 4), dtype=np.result_type(xcycsr.dtype, np.float32))
     result[:, 0] = xcycsr[:, 0] - w * 0.5
     result[:, 1] = xcycsr[:, 1] - h * 0.5
     result[:, 2] = xcycsr[:, 0] + w * 0.5

--- a/src/trackers/utils/converters.py
+++ b/src/trackers/utils/converters.py
@@ -182,7 +182,7 @@ def xcycsr_to_xyxy(xcycsr: np.ndarray) -> np.ndarray:
     # Inner np.where substitutes 1.0 for zero denominators to suppress the
     # eager-evaluation divide-by-zero warning; outer np.where replaces those results with 0.0.
     h = np.where(w != 0, xcycsr[:, 2] / np.where(w != 0, w, 1.0), 0.0)
-    result = np.empty((xcycsr.shape[0], 4), dtype=xcycsr.dtype)
+    result = np.empty((xcycsr.shape[0], 4), dtype=np.float64)
     result[:, 0] = xcycsr[:, 0] - w * 0.5
     result[:, 1] = xcycsr[:, 1] - h * 0.5
     result[:, 2] = xcycsr[:, 0] + w * 0.5

--- a/tests/utils/test_converters.py
+++ b/tests/utils/test_converters.py
@@ -240,6 +240,27 @@ class TestXCYCSRConversion:
         assert result.shape == (1, 4)
         np.testing.assert_array_almost_equal(result[0], np.array([0.0, 0.0, 1.0, 1.0]), decimal=5)
 
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            pytest.param(np.int32, id="int32"),
+            pytest.param(np.int64, id="int64"),
+        ],
+    )
+    def test_xcycsr_to_xyxy_batch_integer_input(self, dtype: type[np.integer]) -> None:
+        """An integer batch decodes at float precision rather than truncating to the input dtype."""
+        xcycsr = np.array([[10, 20, 25, 1]], dtype=dtype)
+        result = xcycsr_to_xyxy(xcycsr)
+        assert result.dtype == np.float64
+        np.testing.assert_array_almost_equal(result, [[7.5, 17.5, 12.5, 22.5]], decimal=5)
+
+    def test_xcycsr_to_xyxy_batch_matches_single_box_for_integer_input(self) -> None:
+        """The batch path agrees with the 1-D path, which has always decoded integers as floats."""
+        xcycsr = np.array([10, 20, 25, 1], dtype=np.int64)
+        batch_result = xcycsr_to_xyxy(xcycsr[None, :])
+        single_result = xcycsr_to_xyxy(xcycsr)
+        np.testing.assert_array_almost_equal(batch_result[0], single_result, decimal=5)
+
     def test_xcycsr_to_xyxy_empty(self) -> None:
         """An empty (0, 4) xcycsr batch returns an empty (0, 4) xyxy batch."""
         xcycsr = np.zeros((0, 4))

--- a/tests/utils/test_converters.py
+++ b/tests/utils/test_converters.py
@@ -241,25 +241,19 @@ class TestXCYCSRConversion:
         np.testing.assert_array_almost_equal(result[0], np.array([0.0, 0.0, 1.0, 1.0]), decimal=5)
 
     @pytest.mark.parametrize(
-        "dtype",
+        ("dtype", "expected_dtype"),
         [
-            pytest.param(np.int32, id="int32"),
-            pytest.param(np.int64, id="int64"),
+            pytest.param(np.int64, np.float64, id="integer-promotes"),
+            pytest.param(np.float32, np.float32, id="float32-preserved"),
         ],
     )
-    def test_xcycsr_to_xyxy_batch_integer_input(self, dtype: type[np.integer]) -> None:
-        """An integer batch decodes at float precision rather than truncating to the input dtype."""
-        xcycsr = np.array([[10, 20, 25, 1]], dtype=dtype)
-        result = xcycsr_to_xyxy(xcycsr)
-        assert result.dtype == np.float64
+    def test_xcycsr_to_xyxy_batch_decodes_in_floating_point(
+        self, dtype: type[np.number], expected_dtype: type[np.floating]
+    ) -> None:
+        """Integer input promotes instead of truncating; float input keeps its own precision."""
+        result = xcycsr_to_xyxy(np.array([[10, 20, 25, 1]], dtype=dtype))
+        assert result.dtype == expected_dtype
         np.testing.assert_array_almost_equal(result, [[7.5, 17.5, 12.5, 22.5]], decimal=5)
-
-    def test_xcycsr_to_xyxy_batch_matches_single_box_for_integer_input(self) -> None:
-        """The batch path agrees with the 1-D path, which has always decoded integers as floats."""
-        xcycsr = np.array([10, 20, 25, 1], dtype=np.int64)
-        batch_result = xcycsr_to_xyxy(xcycsr[None, :])
-        single_result = xcycsr_to_xyxy(xcycsr)
-        np.testing.assert_array_almost_equal(batch_result[0], single_result, decimal=5)
 
     def test_xcycsr_to_xyxy_empty(self) -> None:
         """An empty (0, 4) xcycsr batch returns an empty (0, 4) xyxy batch."""


### PR DESCRIPTION
## Problem

The batched path allocates its output with `dtype=xcycsr.dtype`, but decoding goes through a sqrt and a division, so the values are floats. Writing them into an integer buffer truncates them:

```python
>>> xcycsr_to_xyxy(np.array([[10, 20, 25, 1]]))
array([[ 7, 17, 12, 22]])   # should be 7.5, 17.5, 12.5, 22.5
```

This happens whenever the caller passes an integer array. The 1-D path is unaffected — it builds its result with `np.array(...)`, which infers a float dtype from the values.

It's also the only converter containing a sqrt, so integer input generally decodes to irrational corners (`scale=24, ratio=1` gives `w=4.89897948556636`). No integer dtype can hold the result.

## Fix

Allocate with `np.result_type(xcycsr.dtype, np.float32)`: integers promote to float64, float32 stays float32, float64 is unchanged.

## Impact

No behaviour change for us, nothing in the library passes integer boxes, and no float input changes dtype. It makes the return dtype independent of the input dtype, which this was the only converter not to do. Its defensive in case someone passes integer bboxes,

## Not included

- **1-D paths.** `xyxy_to_xcycsr`'s is on the live tracking path (`tracklet.py:116`, `state_representations.py:240`/`243`) and computes in float32 today; forcing float64 would move Kalman inputs.
- **The other three converters**, which hardcode float64 in their batch paths. Matching them would upcast float32 callers for no benefit.

`tests/utils` + `tests/core`: 925 passed.
