### PR TITLE
fix(io): order image-directory frames naturally

### DIFF
--- a/src/trackers/io/video.py
+++ b/src/trackers/io/video.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -29,7 +30,8 @@ def frames_from_source(
     Args:
         source: Video file path, RTSP/HTTP stream URL, webcam index, or path to a
             directory containing images (`.jpg`, `.jpeg`, `.png`, `.bmp`, `.tif`,
-            `.tiff`).
+            `.tiff`). Directory entries are ordered naturally, so unpadded numeric
+            names such as `2.jpg` and `10.jpg` are read in numeric order.
 
     Returns:
         Iterator of `(frame_id, frame)` tuples where `frame_id` is 1-based and `frame`
@@ -70,12 +72,32 @@ def _iter_capture_frames(
         cap.release()
 
 
+def _natural_sort_key(path: Path) -> tuple[str | int, ...]:
+    """Build a sort key that orders embedded digit runs by value rather than as text.
+
+    Plain lexicographic sorting puts `10.jpg` before `2.jpg`, which silently feeds an image sequence to a tracker in
+    the wrong temporal order. Splitting the name into alternating text and digit runs and comparing digit runs as
+    integers restores numeric order for unpadded names, while leaving zero-padded and non-numeric names unaffected.
+
+    Args:
+        path: Image file path; only the file name participates in the key.
+
+    Returns:
+        Tuple of alternating text and integer parts. `re.split` with a capturing group always yields text at even
+        positions and digits at odd ones, so keys compare position-wise without mixing types.
+    """
+    return tuple(int(part) if part.isdigit() else part for part in re.split(r"(\d+)", path.name))
+
+
 def _iter_image_folder_frames(
     folder: Path,
     *,
     extensions: frozenset[str] = IMAGE_EXTENSIONS,
 ) -> Iterator[tuple[int, np.ndarray]]:
-    images = sorted(p for p in folder.iterdir() if p.is_file() and p.suffix.lower() in extensions)
+    images = sorted(
+        (p for p in folder.iterdir() if p.is_file() and p.suffix.lower() in extensions),
+        key=_natural_sort_key,
+    )
 
     if not images:
         raise ValueError(f"No supported image files found in directory: {folder}")

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -176,14 +176,15 @@ class TestFramesFromSourceImageDirectory:
         """Names without digits keep plain alphabetical order."""
         directory = tmp_path / "alphabetic"
         directory.mkdir()
-        for index, stem in enumerate(("alpha", "beta", "gamma")):
+        for index, stem in enumerate(("gamma", "alpha", "beta")):
             cv2.imwrite(str(directory / f"{stem}.png"), create_frame(index))
 
         frames = list(frames_from_source(directory))
 
         assert len(frames) == 3
+        expected_indexes = (1, 2, 0)
         for frame_id, frame in frames:
-            assert np.all(frame == expected_frame_value(frame_id - 1))
+            assert np.all(frame == expected_frame_value(expected_indexes[frame_id - 1]))
 
     def test_reads_zero_padded_images_in_order(self, image_directory_factory) -> None:
         num_frames = 7

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -101,6 +101,21 @@ def directory_with_non_image_files(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def directory_with_unpadded_numeric_names(tmp_path: Path) -> Path:
+    """Directory of unpadded numeric image names whose lexicographic order differs from numeric order.
+
+    Names run `1.png` to `11.png`, which sort lexicographically as 1, 10, 11, 2, 3, ... Each frame is filled with a
+    distinct multiple of 20 so no two frames share a pixel value.
+    """
+    directory = tmp_path / "unpadded"
+    directory.mkdir()
+    for index in range(1, 12):
+        frame = np.full((FRAME_HEIGHT, FRAME_WIDTH, 3), index * 20, dtype=np.uint8)
+        cv2.imwrite(str(directory / f"{index}.png"), frame)
+    return directory
+
+
+@pytest.fixture
 def directory_with_corrupted_image(tmp_path: Path) -> Path:
     """Directory with valid images followed by one corrupted image file."""
     directory = tmp_path / "with_corrupt"
@@ -149,7 +164,28 @@ class TestFramesFromSourceVideo:
 
 
 class TestFramesFromSourceImageDirectory:
-    def test_reads_images_in_alphabetical_order(self, image_directory_factory) -> None:
+    def test_reads_unpadded_numeric_names_in_numeric_order(self, directory_with_unpadded_numeric_names) -> None:
+        """Unpadded numeric names are ordered numerically, so `2.png` precedes `10.png`."""
+        frames = list(frames_from_source(directory_with_unpadded_numeric_names))
+
+        assert len(frames) == 11
+        for frame_id, frame in frames:
+            assert np.all(frame == frame_id * 20), f"Frame {frame_id} is out of order"
+
+    def test_reads_non_numeric_names_alphabetically(self, tmp_path: Path) -> None:
+        """Names without digits keep plain alphabetical order."""
+        directory = tmp_path / "alphabetic"
+        directory.mkdir()
+        for index, stem in enumerate(("alpha", "beta", "gamma")):
+            cv2.imwrite(str(directory / f"{stem}.png"), create_frame(index))
+
+        frames = list(frames_from_source(directory))
+
+        assert len(frames) == 3
+        for frame_id, frame in frames:
+            assert np.all(frame == expected_frame_value(frame_id - 1))
+
+    def test_reads_zero_padded_images_in_order(self, image_directory_factory) -> None:
         num_frames = 7
         directory = image_directory_factory(n_frames=num_frames, filename_pattern="{:04d}.png")
         frames = list(frames_from_source(directory))


### PR DESCRIPTION
## Problem

`_iter_image_folder_frames` sorts directory entries lexicographically, so `1.jpg … 10.jpg` is read as 1, 10, 11, 2, 3, … Frames are then numbered sequentially by enumeration, so a temporally shuffled sequence still gets sequential frame ids.

Nothing raises. The tracker receives frames out of order, motion between consecutive frames is nonsense, and every track is garbage — with no indication why.

## When this happens

Only through `frames_from_source` on an image directory — the public API and `trackers track <dir>`. The trigger is unpadded numeric filenames, which is what `ffmpeg -i video.mp4 %d.jpg` produces.

Not reported by anyone, and benchmarking can't hit it: MOT Challenge and DanceTrack frames are zero-padded (6- and 8-digit), and the eval path resolves frames by index through `resolve_mot_frame_path` rather than sorting a listing. But `io/frames.py` already falls back to a plain-int stem — *"Try both, then plain int"* — so unpadded naming is a layout the library expects to meet.

## Fix

Sort on a natural key that compares embedded digit runs as integers. Zero-padded and non-numeric names sort identically under both keys, so benchmark sequences are unaffected.

Mixed-width numeric names get no warning: natural ordering resolves them correctly, so a warning would fire on valid input.

## Tests

- Unpadded `1.png` … `11.png` read in numeric order — fails before the change, where frame 2 returned the contents of `10.png`.
- Non-numeric names keep alphabetical order.
- Zero-padded names still work. Pre-existing test, renamed from `test_reads_images_in_alphabetical_order` since the contract is no longer alphabetical.

`tests/io` + `tests/cli`: 341 passed.
