### PR TITLE
fix(utils): guard Kalman gain against singular innovation covariance

### DIFF
--- a/src/trackers/utils/kalman_filter.py
+++ b/src/trackers/utils/kalman_filter.py
@@ -100,9 +100,9 @@ class KalmanFilter:
 
         If z is None, the state is not updated (prediction only).
 
-        If the innovation covariance is singular — zero measurement noise, or a state covariance that has collapsed
-        after repeated updates — the gain falls back to a pseudo-inverse least-squares solution so the track survives
-        instead of raising.
+        If the innovation covariance is singular — zero measurement noise together with a state covariance that has
+        collapsed after repeated updates — the gain falls back to a pseudo-inverse least-squares solution so the track
+        survives instead of raising.
 
         Args:
             z: Measurement vector (dim_z, 1) or None for no observation.
@@ -127,7 +127,7 @@ class KalmanFilter:
         # Kalman gain: kalman_gain = state_covariance @ observation_mtx.T @ innovation_cov^-1
         # Solved as innovation_cov.T @ kalman_gain.T = PHT.T to avoid forming the explicit inverse.
         try:
-            self.kalman_gain = np.linalg.solve(self.innovation_cov.T, PHT.T).T.astype(np.float64, copy=False)
+            self.kalman_gain = np.linalg.solve(self.innovation_cov.T, PHT.T).T
         except np.linalg.LinAlgError:
             # A singular innovation covariance has no exact solution, so fall back to the
             # least-squares gain instead of killing the track mid-sequence.

--- a/src/trackers/utils/kalman_filter.py
+++ b/src/trackers/utils/kalman_filter.py
@@ -100,6 +100,10 @@ class KalmanFilter:
 
         If z is None, the state is not updated (prediction only).
 
+        If the innovation covariance is singular — zero measurement noise, or a state covariance that has collapsed
+        after repeated updates — the gain falls back to a pseudo-inverse least-squares solution so the track survives
+        instead of raising.
+
         Args:
             z: Measurement vector (dim_z, 1) or None for no observation.
         """
@@ -121,7 +125,13 @@ class KalmanFilter:
         self.innovation_cov = self.observation_mtx @ PHT + self.measurement_noise
 
         # Kalman gain: kalman_gain = state_covariance @ observation_mtx.T @ innovation_cov^-1
-        self.kalman_gain = PHT @ np.linalg.inv(self.innovation_cov)
+        # Solved as innovation_cov.T @ kalman_gain.T = PHT.T to avoid forming the explicit inverse.
+        try:
+            self.kalman_gain = np.linalg.solve(self.innovation_cov.T, PHT.T).T.astype(np.float64, copy=False)
+        except np.linalg.LinAlgError:
+            # A singular innovation covariance has no exact solution, so fall back to the
+            # least-squares gain instead of killing the track mid-sequence.
+            self.kalman_gain = PHT @ np.linalg.pinv(self.innovation_cov)
 
         # State update: state = state + kalman_gain @ innovation
         self.state = self.state + self.kalman_gain @ self.innovation

--- a/tests/utils/test_kalman_filter.py
+++ b/tests/utils/test_kalman_filter.py
@@ -37,3 +37,35 @@ def test_update_with_none_preserves_posterior_as_prior() -> None:
 
     np.testing.assert_allclose(kf.state, state_prior)
     np.testing.assert_allclose(kf.state_covariance, cov_prior)
+
+
+def test_update_survives_singular_innovation_covariance() -> None:
+    """Zero measurement noise with a collapsed state covariance degrades instead of raising."""
+    kf = KalmanFilter(dim_x=2, dim_z=1)
+    kf.state = np.array([[1.0], [0.0]])
+    kf.state_covariance = np.zeros((2, 2))
+    kf.observation_mtx = np.array([[1.0, 0.0]])
+    kf.measurement_noise = np.zeros((1, 1))
+
+    kf.update(np.array([[2.0]]))
+
+    assert np.isfinite(kf.state).all()
+    assert np.isfinite(kf.state_covariance).all()
+    assert np.isfinite(kf.kalman_gain).all()
+
+
+def test_update_gain_matches_textbook_inverse_when_invertible() -> None:
+    """For an invertible innovation covariance the gain still equals ``P @ H.T @ S^-1``."""
+    kf = KalmanFilter(dim_x=2, dim_z=1)
+    kf.state = np.array([[1.0], [0.0]])
+    kf.state_covariance = np.array([[2.0, 0.5], [0.5, 1.0]])
+    kf.observation_mtx = np.array([[1.0, 0.0]])
+    kf.measurement_noise = np.array([[0.3]])
+
+    projected_covariance = kf.state_covariance @ kf.observation_mtx.T
+    innovation_cov = kf.observation_mtx @ projected_covariance + kf.measurement_noise
+    expected_gain = projected_covariance @ np.linalg.inv(innovation_cov)
+
+    kf.update(np.array([[2.0]]))
+
+    np.testing.assert_allclose(kf.kalman_gain, expected_gain, rtol=1e-12, atol=1e-12)


### PR DESCRIPTION
**Fable false positive — closing, not merging.** The problem this guards against cannot happen, and the remaining change buys nothing measurable.

- The premise was that `np.linalg.inv` on the innovation covariance could raise `LinAlgError` and kill a track. It can't: every tracker sets `R` as a positive scaled identity (`kf.measurement_noise * 0.1`, `np.eye(4) * 0.1`, `[2:, 2:] *= 10.0`), so `S = H P Hᵀ + R ⪰ R ≻ 0` stays invertible whatever `P` does — verified with `P` rank-1, `P = 0`, and `P` at 1e-300, where `S` bottoms out at `R` and stays well-conditioned
- The test in this PR had to hand-assign `measurement_noise = np.zeros((1, 1))` to reach the singular branch, i.e. a state no tracker can produce
- It also misses the degradation that is real. `xcycsr_to_xyxy` decodes a non-positive scale as NaN (see `clamp_velocity`), and `solve` does not raise on non-finite input — `S = NaN` returns `[nan nan]` and `S = inf` returns `[0, 0]`, so the guard never fires on the path that actually breaks. Non-finite state is already caught downstream by `BaseIoU.compute()`
- That leaves the `inv` → `solve` swap on its own merits, which do not survive measurement. Accuracy improves but only at machine epsilon — median residual `|K@S − PHT|` 2.67e-15 → 1.78e-15, worst case 4.97e-14 → 5.33e-15 over 2000 realistic cases — roughly 13 orders of magnitude below the sub-pixel precision box tracking cares about. Speed is a wash: 2.680 µs vs 2.577 µs per call at the real 4×4 / 7×4 sizes (best-of-15; single-run timings at this size are noise-dominated and flip direction between trials)
- Not worth editing the Kalman hot path that #296 deliberately optimized for a change nothing downstream can observe

Worth keeping from the investigation: `S` is structurally non-singular given a positive-definite `R`, so no guard is needed there; NaN, not singularity, is the real failure mode on this path.
