### PR TITLE
fix(io): reject unusable frame numbers and unscorable ground truth

### DIFF
--- a/src/trackers/eval/evaluate.py
+++ b/src/trackers/eval/evaluate.py
@@ -58,7 +58,9 @@ def evaluate_mot_sequence(
 
     Raises:
         FileNotFoundError: If `gt_path` or `tracker_path` does not exist.
-        ValueError: If an unsupported metric family is requested.
+        ValueError: If an unsupported metric family is requested, or if the
+            ground-truth file contains no scored rows once ignored and
+            non-pedestrian rows are filtered out.
 
     Examples:
         >>> from trackers.eval import evaluate_mot_sequence  # doctest: +SKIP
@@ -94,6 +96,14 @@ def evaluate_mot_sequence(
 
     # Prepare sequence (compute IoU, remap IDs)
     seq_data = _prepare_mot_sequence(gt_data, tracker_data)
+
+    if gt_data and seq_data.num_gt_dets == 0:
+        raise ValueError(
+            f"Ground truth file has no scored ground-truth rows: {gt_path}. Only pedestrian-class (1) rows "
+            "marked for consideration are scored, mirroring TrackEval, and every row was dropped by that "
+            "filter. Note that tracker files written by this library record class -1, so tracker output "
+            "cannot be reused as ground truth."
+        )
 
     # Compute metrics
     clear_metrics: CLEARMetrics | None = None

--- a/src/trackers/io/mot.py
+++ b/src/trackers/io/mot.py
@@ -156,7 +156,8 @@ def load_mot_file(path: str | Path) -> dict[int, _MOTFrameData]:
 
     Raises:
         FileNotFoundError: If the file does not exist.
-        ValueError: If the file is empty or has invalid format.
+        ValueError: If the file is empty, has invalid format, or contains a
+            frame number that is not a whole number greater than zero.
 
     Examples:
         >>> from trackers import load_mot_file  # doctest: +SKIP
@@ -207,9 +208,17 @@ def load_mot_file(path: str | Path) -> dict[int, _MOTFrameData]:
                 )
 
             try:
-                frame = int(float(row[0]))
+                frame_number = float(row[0])
             except ValueError as e:
                 raise ValueError(f"Invalid frame number in {path}: {row[0]}") from e
+
+            # Consumers walk frames with `range(1, num_frames + 1)`, so anything outside that
+            # domain would be loaded here and then silently never evaluated.
+            if not frame_number.is_integer():
+                raise ValueError(f"Frame numbers must be whole numbers in {path}, got {row[0]} in row: {row}")
+            frame = int(frame_number)
+            if frame < 1:
+                raise ValueError(f"MOT frame numbers are 1-based, got {frame} in {path} in row: {row}")
 
             if frame not in frame_data:
                 frame_data[frame] = []

--- a/tests/eval/test_evaluate.py
+++ b/tests/eval/test_evaluate.py
@@ -101,3 +101,43 @@ class TestEvaluateMOTSequence:
         json_str = result.json()
         assert "HOTA" in json_str
         assert "DetA" in json_str
+
+
+class TestEvaluateMOTSequenceUnscorableGroundTruth:
+    """Ground truth that filters down to nothing is reported instead of scored as zeros.
+
+    Only pedestrian-class (1) rows marked for consideration are scored, mirroring TrackEval. Ground truth whose rows are
+    all dropped by that filter cannot produce a meaningful score, and returning zeros looks like a tracker that found
+    nothing rather than a ground-truth file the evaluator cannot use.
+    """
+
+    def test_tracker_output_used_as_ground_truth_raises(self, tmp_path: Path) -> None:
+        """Files written by `_MOTOutput` carry class -1, so they cannot be reused as ground truth."""
+        gt_path = tmp_path / "gt.txt"
+        tracker_path = tmp_path / "tracker.txt"
+        gt_path.write_text("1,1,100,200,50,60,0.9000,-1,-1,-1\n2,1,105,205,50,60,0.9000,-1,-1,-1\n")
+        tracker_path.write_text("1,10,102,202,50,60,0.9,1\n2,10,107,207,50,60,0.9,1\n")
+
+        with pytest.raises(ValueError, match="no scored ground-truth"):
+            evaluate_mot_sequence(gt_path=gt_path, tracker_path=tracker_path)
+
+    def test_all_ignored_ground_truth_raises(self, tmp_path: Path) -> None:
+        """Ground truth where every row is marked ignored (confidence 0) is also unscorable."""
+        gt_path = tmp_path / "gt.txt"
+        tracker_path = tmp_path / "tracker.txt"
+        gt_path.write_text("1,1,100,200,50,60,0,1\n2,1,105,205,50,60,0,1\n")
+        tracker_path.write_text("1,10,102,202,50,60,0.9,1\n")
+
+        with pytest.raises(ValueError, match="no scored ground-truth"):
+            evaluate_mot_sequence(gt_path=gt_path, tracker_path=tracker_path)
+
+    def test_partially_filtered_ground_truth_is_scored(self, tmp_path: Path) -> None:
+        """A file keeping at least one scored row evaluates normally."""
+        gt_path = tmp_path / "gt.txt"
+        tracker_path = tmp_path / "tracker.txt"
+        gt_path.write_text("1,1,100,200,50,60,1,1\n1,2,150,250,40,50,1,8\n")
+        tracker_path.write_text("1,10,102,202,50,60,0.9,1\n")
+
+        result = evaluate_mot_sequence(gt_path=gt_path, tracker_path=tracker_path)
+
+        assert result.CLEAR is not None

--- a/tests/io/test_mot.py
+++ b/tests/io/test_mot.py
@@ -6,10 +6,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
-from trackers.io.mot import _MOTFrameData, _prepare_mot_sequence
+from trackers.io.mot import _MOTFrameData, _prepare_mot_sequence, load_mot_file
 
 
 def _frame(
@@ -25,6 +27,55 @@ def _frame(
         confidences=np.array(confidences, dtype=np.float64),
         classes=np.array(classes, dtype=np.intp),
     )
+
+
+def _write_mot_file(path: Path, *rows: str) -> Path:
+    """Write raw MOT rows to `path` and return it."""
+    path.write_text("\n".join(rows) + "\n")
+    return path
+
+
+class TestLoadMotFileFrameValidation:
+    """Frame numbers must be 1-based whole numbers.
+
+    Every consumer walks frames with `range(1, num_frames + 1)`, so a row on frame 0 or a negative frame is loaded and
+    then never evaluated. Truncating a fractional frame silently moves a detection to a different frame. Both are
+    rejected rather than accepted and quietly dropped.
+    """
+
+    @pytest.mark.parametrize(
+        "frame",
+        [
+            pytest.param("0", id="zero"),
+            pytest.param("-3", id="negative"),
+        ],
+    )
+    def test_rejects_nonpositive_frame(self, tmp_path: Path, frame: str) -> None:
+        """A frame below 1 is rejected instead of being loaded and never evaluated."""
+        path = _write_mot_file(tmp_path / "gt.txt", f"{frame},1,10,10,20,20,1,1")
+
+        with pytest.raises(ValueError, match="1-based"):
+            load_mot_file(path)
+
+    def test_rejects_fractional_frame(self, tmp_path: Path) -> None:
+        """A fractional frame is rejected instead of being truncated onto another frame."""
+        path = _write_mot_file(tmp_path / "gt.txt", "1.7,1,10,10,20,20,1,1")
+
+        with pytest.raises(ValueError, match="whole number"):
+            load_mot_file(path)
+
+    def test_accepts_integral_float_frame(self, tmp_path: Path) -> None:
+        """A frame written as a float with no fractional part is still valid."""
+        path = _write_mot_file(tmp_path / "gt.txt", "1.0,1,10,10,20,20,1,1")
+
+        assert list(load_mot_file(path)) == [1]
+
+    def test_reports_offending_row(self, tmp_path: Path) -> None:
+        """The error names the file and the offending row so the bad line can be found."""
+        path = _write_mot_file(tmp_path / "gt.txt", "1,1,10,10,20,20,1,1", "0,2,30,30,20,20,1,1")
+
+        with pytest.raises(ValueError, match=r"gt\.txt"):
+            load_mot_file(path)
 
 
 class TestMotDistractorPreprocessing:


### PR DESCRIPTION
## Problem

Two ways MOT input is accepted and then silently produces wrong numbers.

**Frame numbers.** `load_mot_file` accepts any parsable frame number. Every consumer walks frames with `range(1, num_frames + 1)`, so rows on frame 0 or a negative frame are loaded and then never evaluated. `int(float(...))` also quietly truncates a fractional frame onto a different frame.

**Unscorable ground truth.** Only pedestrian-class (1) rows marked for consideration are scored, mirroring TrackEval. Ground truth where every row fails that filter evaluates to a clean run of zeros — indistinguishable from a tracker that found nothing.

The common way to hit the second one: reusing tracker output as ground truth. Tracker files record class `-1`, so every row is filtered out and the whole benchmark reports zeros.

## Fix

- `load_mot_file` rejects frame numbers that are not whole numbers greater than zero, naming the file and the offending row. Frames written as floats with no fractional part (`1.0`) stay valid.
- `evaluate_mot_sequence` raises when ground truth has no scored rows, pointing at the file and explaining the class filter.

## Tests

- Frame `0`, `-3` and `1.7` are rejected; `1.0` still loads; the error names the file.
- Tracker output reused as ground truth raises, as does all-ignored ground truth.
- Ground truth keeping at least one scored row evaluates normally.

`tests/io`, `tests/eval` and `tests/tune` pass at 141.

## Decisions worth review

**The writer is left alone.** `_MOTOutput` keeps writing class `-1`, because TrackEval tracker files carry no class either — the writer is correct and the error explains the mismatch. The alternative was emitting class `1` so round-tripping silently works; that seemed worse than a clear error. Easy to flip if you disagree.

**The guard is in `evaluate_mot_sequence`, not `_prepare_mot_sequence`.** An individual all-distractor frame is legitimate, and existing tests pin the primitive's TrackEval-mirroring behaviour of returning zero scored rows. Raising there would have broken that contract.

Made with [Cursor](https://cursor.com)