### PR TITLE
fix(cli): propagate the real source frame rate into the tracker

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 import tempfile
@@ -324,17 +325,17 @@ VIDEO_EXAMPLES = [
 ]
 
 
-def _get_video_info(path: str) -> tuple[float, int]:
-    """Return video duration in seconds and frame count using OpenCV."""
+def _get_video_info(path: str) -> tuple[float, int, float]:
+    """Return video duration in seconds, frame count, and FPS using OpenCV."""
     cap = cv2.VideoCapture(path)
     if not cap.isOpened():
         raise gr.Error("Could not open the uploaded video.")
     fps = cap.get(cv2.CAP_PROP_FPS)
     frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     cap.release()
-    if fps <= 0:
+    if not math.isfinite(fps) or fps <= 0:
         raise gr.Error("Could not determine video frame rate.")
-    return frame_count / fps, frame_count
+    return frame_count / fps, frame_count, fps
 
 
 def _resolve_class_filter(
@@ -403,7 +404,7 @@ def track(
     if video_path is None:
         raise gr.Error("Please upload a video.")
 
-    duration, total_frames = _get_video_info(video_path)
+    duration, total_frames, frame_rate = _get_video_info(video_path)
     if duration > MAX_DURATION_SECONDS:
         raise gr.Error(
             f"Video is {duration:.1f}s long. "
@@ -426,6 +427,7 @@ def track(
             minimum_consecutive_frames=minimum_consecutive_frames,
             minimum_iou_threshold=minimum_iou_threshold,
             high_conf_det_threshold=high_conf_det_threshold,
+            frame_rate=frame_rate,
         )
     else:
         tracker = SORTTracker(
@@ -433,6 +435,7 @@ def track(
             track_activation_threshold=track_activation_threshold,
             minimum_consecutive_frames=minimum_consecutive_frames,
             minimum_iou_threshold=minimum_iou_threshold,
+            frame_rate=frame_rate,
         )
     tracker.reset()
 

--- a/docs/guides/track.md
+++ b/docs/guides/track.md
@@ -410,8 +410,8 @@ Most `--tracker.*` flags default to `null` on the CLI — leaving a flag unset m
     </tr>
     <tr>
       <td><code>--tracker.frame_rate</code></td>
-      <td>Video frame rate used to scale the lost track buffer to time-like behavior. Must be positive.</td>
-      <td><code>null</code> (tracker default)</td>
+      <td>Video frame rate used to scale the lost track buffer to time-like behavior. Must be positive. When unset and the source is a video with a readable FPS, that FPS is used instead of the tracker's own default; sources with no FPS to read (webcam, stream, image directory, or a <code>--detection.mot_file</code>-only run) still fall back to the tracker default.</td>
+      <td><code>null</code> (source FPS if readable, else tracker default)</td>
     </tr>
     <tr>
       <td><code>--tracker.lost_track_buffer</code></td>

--- a/src/trackers/cli/benchmark/mcbyte.py
+++ b/src/trackers/cli/benchmark/mcbyte.py
@@ -110,8 +110,10 @@ the remaining sequences.
 
 from __future__ import annotations
 
+import configparser
 import gc
 import logging
+import math
 import sys
 from dataclasses import dataclass, replace
 from datetime import datetime
@@ -384,6 +386,93 @@ def image_directory(sequence: str, config: DatasetConfig) -> Path:
     return config.image_root / directory_name / "img1"
 
 
+def _read_sequence_frame_rate(
+    image_dir: Path,
+    default: float,
+    *,
+    logger: logging.Logger | None = None,
+    sequence: str = "",
+) -> float:
+    """Read one sequence's real frame rate from its MOTChallenge ``seqinfo.ini``.
+
+    Every official MOTChallenge-format sequence download (MOT17, DanceTrack,
+    SportsMOT, and SoccerNet-tracking all share the convention) ships a
+    ``seqinfo.ini`` file as a sibling of the ``img1`` frame directory, with a
+    ``frameRate`` key under ``[Sequence]``. ``DatasetConfig.frame_rate`` is a
+    single fallback for the whole dataset (30.0 for every entry in
+    :data:`DATASETS`), but real sequences run at a different rate — verified
+    locally against cached sequence downloads: every SportsMOT-val sequence is
+    25 fps and every DanceTrack-val sequence is 20 fps, both consistently
+    ``!= 30``. Reading the real value keeps
+    ``BaseTracker._compute_maximum_frames_without_update``'s lost-track
+    buffer scaling correct for the sequence actually being processed,
+    instead of a rate no real sequence in these datasets uses. It does not
+    affect the Kalman motion model's process noise here: :func:`run_sequence`
+    never passes a timestamp to ``update()``, so the tracker stays in
+    fixed-rate mode and ``trackers.utils.motion_models.build_Q`` keeps using
+    its fixed frame-unit fallback regardless of this value.
+
+    Args:
+        image_dir: Sequence frame directory, as returned by
+            :func:`image_directory` (``.../{sequence}/img1``).
+        default: Value to fall back to when ``seqinfo.ini`` is missing, has no
+            ``[Sequence]`` section, has no ``frameRate`` key, or the key does
+            not parse as a finite positive float.
+        logger: When given (together with ``sequence``), used to warn when a
+            ``seqinfo.ini`` file exists but its ``frameRate`` is unusable —
+            distinct from the unremarkable case of no file at all, this means
+            the sequence shipped bad metadata that silently falls back to
+            ``default``.
+        sequence: Sequence name, used only in the warning message above.
+
+    Returns:
+        The sequence's real frame rate, or ``default``.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as tmp:
+        ...     seq_dir = Path(tmp) / "seq"
+        ...     (seq_dir / "img1").mkdir(parents=True)
+        ...     _ = (seq_dir / "seqinfo.ini").write_text("[Sequence]\\nframeRate=25\\n")
+        ...     _read_sequence_frame_rate(seq_dir / "img1", default=30.0)
+        25.0
+        >>> with tempfile.TemporaryDirectory() as tmp:
+        ...     seq_dir = Path(tmp) / "seq"
+        ...     (seq_dir / "img1").mkdir(parents=True)
+        ...     _read_sequence_frame_rate(seq_dir / "img1", default=30.0)
+        30.0
+    """
+    seqinfo_path = image_dir.parent / "seqinfo.ini"
+    if not seqinfo_path.is_file():
+        return default
+
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(seqinfo_path, encoding="utf-8")
+        frame_rate = parser.getfloat("Sequence", "frameRate")
+    except (configparser.Error, ValueError):
+        if logger is not None:
+            logger.warning(
+                "%s | %s has no usable [Sequence] frameRate; falling back to %.3g",
+                sequence,
+                seqinfo_path,
+                default,
+            )
+        return default
+
+    if not math.isfinite(frame_rate) or frame_rate <= 0:
+        if logger is not None:
+            logger.warning(
+                "%s | %s frameRate=%.3g is not finite/positive; falling back to %.3g",
+                sequence,
+                seqinfo_path,
+                frame_rate,
+                default,
+            )
+        return default
+    return frame_rate
+
+
 def create_tracker(
     *,
     device: str,
@@ -507,8 +596,11 @@ def run_sequence(
 ) -> int:
     """Run one benchmark sequence.
 
-    A fresh tracker is created for the sequence.
-    Results are first written to a temporary `.partial` file,
+    A fresh tracker is created for the sequence, with ``frame_rate`` read from
+    the sequence's own ``seqinfo.ini`` when present (see
+    :func:`_read_sequence_frame_rate`) rather than always using
+    ``config.frame_rate``, since that per-dataset default does not hold for
+    every sequence. Results are first written to a temporary `.partial` file,
     which is replaced by the final MOT result only after successful completion.
 
     Args:
@@ -516,11 +608,14 @@ def run_sequence(
             :func:`cleanup_tracker`.
         detection_file: Path to the sequence's detection ``.txt`` file.
         image_dir: Sequence frame directory, as returned by
-            :func:`image_directory`.
+            :func:`image_directory`. Also used to look up ``seqinfo.ini`` as
+            ``image_dir.parent / "seqinfo.ini"``.
         output_file: Final MOTChallenge-format result path. The frame loop
             writes to ``output_file.with_suffix(".txt.partial")`` first and
             only renames it to ``output_file`` on success.
-        config: Dataset configuration used to parse ``detection_file``.
+        config: Dataset configuration used to parse ``detection_file``; its
+            ``frame_rate`` is the fallback when the sequence has no
+            ``seqinfo.ini``.
         device: Forwarded to :func:`create_tracker`.
         enable_isolated_mask_matching: Forwarded to :func:`create_tracker`.
         enable_cmc: Forwarded to :func:`create_tracker`.
@@ -556,10 +651,19 @@ def run_sequence(
     partial_file.unlink(missing_ok=True)
     tracker: McByteTracker | None = None
 
+    frame_rate = _read_sequence_frame_rate(image_dir, config.frame_rate, logger=logger, sequence=sequence)
+    if frame_rate != config.frame_rate:
+        logger.info(
+            "%s | seqinfo.ini frame_rate=%.3g overrides dataset default %.3g",
+            sequence,
+            frame_rate,
+            config.frame_rate,
+        )
+
     try:
         tracker = create_tracker(
             device=device,
-            frame_rate=config.frame_rate,
+            frame_rate=frame_rate,
             enable_isolated_mask_matching=enable_isolated_mask_matching,
             enable_cmc=enable_cmc,
             cmc_method=cmc_method,

--- a/src/trackers/cli/benchmark/mcbyte.py
+++ b/src/trackers/cli/benchmark/mcbyte.py
@@ -450,7 +450,7 @@ def _read_sequence_frame_rate(
     try:
         parser.read(seqinfo_path, encoding="utf-8")
         frame_rate = parser.getfloat("Sequence", "frameRate")
-    except (configparser.Error, ValueError):
+    except (configparser.Error, UnicodeError, ValueError):
         if logger is not None:
             logger.warning(
                 "%s | %s has no usable [Sequence] frameRate; falling back to %.3g",

--- a/src/trackers/cli/track.py
+++ b/src/trackers/cli/track.py
@@ -9,12 +9,13 @@
 
 from __future__ import annotations
 
+import math
 import sys
 import warnings
 from contextlib import nullcontext, suppress
 from dataclasses import dataclass, fields, make_dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, get_type_hints
+from typing import TYPE_CHECKING, Any, cast, get_type_hints
 
 import numpy as np
 import supervision as sv
@@ -369,10 +370,21 @@ def track_command(
     if output.mot_results:
         _validate_output_path(output.mot_results, overwrite=output.overwrite)
 
+    # Classified before the tracker so the source's real FPS (when known) can
+    # seed the tracker's ``frame_rate`` instead of leaving it on the
+    # constructor's hardcoded 30.0 default. `_classify_source` only reads
+    # container metadata (`cv2.VideoCapture(...).get(...)`) and never decodes
+    # a frame, so probing here costs nothing extra; `_run_with_source` reuses
+    # this same `_SourceInfo` rather than reclassifying.
+    source_info = _classify_source(source) if source is not None else None
+
     # Built before the detection model so an unknown tracker ID is rejected
     # without first paying for a model download and load.
     try:
-        tracker_obj = _init_tracker(tracker)
+        tracker_obj = _init_tracker(
+            tracker,
+            detected_frame_rate=source_info.fps if source_info is not None else None,
+        )
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
@@ -390,8 +402,11 @@ def track_command(
     track_id_filter = _resolve_track_id_filter(filters.track_ids)
 
     if source is not None:
+        # source_info was classified above precisely when source is not None,
+        # so this narrows what mypy cannot infer across the two variables.
         return _run_with_source(
             source=source,
+            source_info=cast(_SourceInfo, source_info),
             model=model_obj,
             confidence=detection.confidence,
             detections_data=detections_data,
@@ -459,6 +474,7 @@ def _run_frameless(
 def _run_with_source(
     *,
     source: str,
+    source_info: _SourceInfo,
     model: AnyModel | None,
     confidence: float,
     detections_data: dict | None,
@@ -471,9 +487,14 @@ def _run_with_source(
     display: bool,
     show: ShowOptions,
 ) -> int:
-    """Run tracking with a frame source (video, webcam, images)."""
+    """Run tracking with a frame source (video, webcam, images).
+
+    Args:
+        source_info: Metadata already classified by the caller (``track_command``),
+            which needs it before the tracker is built to seed ``frame_rate``.
+            Reused here instead of calling :func:`_classify_source` a second time.
+    """
     frame_gen = frames_from_source(source)
-    source_info = _classify_source(source)
 
     annotators, label_annotator = _init_annotators(show)
     trace_annotator = (
@@ -704,7 +725,7 @@ def _warn_dropped_tracker_overrides(tracker_id: str, dropped: list[str]) -> None
         )
 
 
-def _init_tracker(params: TrackerOptions | None) -> BaseTracker:  # type: ignore[valid-type]
+def _init_tracker(params: TrackerOptions | None, *, detected_frame_rate: float | None = None) -> BaseTracker:  # type: ignore[valid-type]
     """Create a tracker instance from the registry.
 
     ``params.name`` selects the algorithm; every other field is a parameter
@@ -715,6 +736,15 @@ def _init_tracker(params: TrackerOptions | None) -> BaseTracker:  # type: ignore
 
     Args:
         params: Tracker selection and parameter overrides.
+        detected_frame_rate: Real frame rate read from the source (e.g. via
+            ``cv2.VideoCapture(...).get(cv2.CAP_PROP_FPS)``), used to fill in
+            ``frame_rate`` for trackers that accept it, when the caller did
+            not explicitly override it with ``--tracker.frame_rate``. Every
+            tracker otherwise falls back to the constructor's hardcoded
+            ``30.0`` default regardless of the source's actual rate. Ignored
+            for a tracker whose registry parameters do not include
+            ``frame_rate``, and for ``None``, non-finite, or non-positive
+            values (a corrupt container can report ``inf``/``nan`` FPS).
 
     Returns:
         Initialised tracker instance.
@@ -733,6 +763,14 @@ def _init_tracker(params: TrackerOptions | None) -> BaseTracker:  # type: ignore
     accepted = set(info.parameters)
     kwargs, dropped = _resolve_tracker_kwargs(raw, accepted)
     _warn_dropped_tracker_overrides(tracker_id, dropped)
+    if (
+        "frame_rate" in accepted
+        and "frame_rate" not in kwargs
+        and detected_frame_rate is not None
+        and math.isfinite(detected_frame_rate)
+        and detected_frame_rate > 0
+    ):
+        kwargs["frame_rate"] = detected_frame_rate
     if iou_variant is not None:
         if "iou" in accepted:
             kwargs["iou"] = variant_from_name(iou_variant)

--- a/tests/cli/test_benchmark_mcbyte.py
+++ b/tests/cli/test_benchmark_mcbyte.py
@@ -13,8 +13,10 @@ import re
 from pathlib import Path
 from typing import get_args
 
+import cv2
 import numpy as np
 import pytest
+import supervision as sv
 
 from trackers.cli.__main__ import _CLIParser, _normalise_option
 from trackers.cli._detections import (
@@ -30,6 +32,7 @@ from trackers.cli.benchmark.mcbyte import (
     DatasetConfig,
     DatasetName,
     DatasetPaths,
+    _read_sequence_frame_rate,
     _runtime_error,
     _unknown_datasets_error,
     benchmark_command,
@@ -37,6 +40,7 @@ from trackers.cli.benchmark.mcbyte import (
     prepare_mot17_submission,
     resolve_datasets,
     run_dataset,
+    run_sequence,
     sequence_name,
 )
 
@@ -369,6 +373,207 @@ class TestImageDirectory:
 
         with pytest.raises(ValueError, match="--dataset_roots"):
             image_directory("MOT17-01", config)
+
+
+class TestReadSequenceFrameRate:
+    """``seqinfo.ini``, not the dataset-wide default, should decide a sequence's frame rate.
+
+    Regression coverage for H-FRAME-RATE-NEVER-PROPAGATED: ``DatasetConfig.frame_rate`` is a single 30.0 fallback
+    for every sequence in a dataset, but real sequences run at a different rate (verified locally: every cached
+    SportsMOT-val sequence is 25 fps, every cached DanceTrack-val sequence is 20 fps).
+    """
+
+    def test_missing_seqinfo_falls_back_to_default(self, tmp_path: Path) -> None:
+        """No ``seqinfo.ini`` next to the sequence: the dataset default is used verbatim."""
+        image_dir = tmp_path / "seq" / "img1"
+        image_dir.mkdir(parents=True)
+
+        assert _read_sequence_frame_rate(image_dir, default=30.0) == 30.0
+
+    def test_reads_the_real_frame_rate_from_seqinfo(self, tmp_path: Path) -> None:
+        """A real ``seqinfo.ini`` (SportsMOT-val's own format) overrides the default."""
+        seq_dir = tmp_path / "seq"
+        image_dir = seq_dir / "img1"
+        image_dir.mkdir(parents=True)
+        (seq_dir / "seqinfo.ini").write_text(
+            "[Sequence]\nname=v_0kUtTtmLaJA_c006\nimDir=img1\nframeRate=25\nseqLength=346\n"
+        )
+
+        assert _read_sequence_frame_rate(image_dir, default=30.0) == 25.0
+
+    def test_missing_frame_rate_key_falls_back_to_default(self, tmp_path: Path) -> None:
+        """A ``seqinfo.ini`` present but without ``frameRate`` still falls back."""
+        seq_dir = tmp_path / "seq"
+        image_dir = seq_dir / "img1"
+        image_dir.mkdir(parents=True)
+        (seq_dir / "seqinfo.ini").write_text("[Sequence]\nname=no-frame-rate\n")
+
+        assert _read_sequence_frame_rate(image_dir, default=30.0) == 30.0
+
+    def test_malformed_ini_falls_back_to_default(self, tmp_path: Path) -> None:
+        """Unparsable INI content does not raise; it falls back like a missing file."""
+        seq_dir = tmp_path / "seq"
+        image_dir = seq_dir / "img1"
+        image_dir.mkdir(parents=True)
+        (seq_dir / "seqinfo.ini").write_text("not an ini file at all\n===\n")
+
+        assert _read_sequence_frame_rate(image_dir, default=30.0) == 30.0
+
+    @pytest.mark.parametrize(
+        "frame_rate_value",
+        ["0", "-25", "nan", "inf"],
+    )
+    def test_non_positive_or_non_finite_frame_rate_falls_back(self, tmp_path: Path, frame_rate_value: str) -> None:
+        """A degenerate ``frameRate`` (zero, negative, NaN, inf) is rejected like a missing one."""
+        seq_dir = tmp_path / "seq"
+        image_dir = seq_dir / "img1"
+        image_dir.mkdir(parents=True)
+        (seq_dir / "seqinfo.ini").write_text(f"[Sequence]\nframeRate={frame_rate_value}\n")
+
+        assert _read_sequence_frame_rate(image_dir, default=30.0) == 30.0
+
+    def test_missing_seqinfo_does_not_warn(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """No ``seqinfo.ini`` at all is unremarkable: no warning, unlike a present-but-bad file."""
+        image_dir = tmp_path / "seq" / "img1"
+        image_dir.mkdir(parents=True)
+
+        with caplog.at_level(logging.WARNING, logger="test_mcbyte_seqinfo"):
+            _read_sequence_frame_rate(
+                image_dir, default=30.0, logger=logging.getLogger("test_mcbyte_seqinfo"), sequence="seq"
+            )
+
+        assert caplog.records == []
+
+    def test_malformed_ini_warns_with_logger(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """A ``seqinfo.ini`` present but unparsable warns, distinguishing it from a missing file."""
+        seq_dir = tmp_path / "seq"
+        image_dir = seq_dir / "img1"
+        image_dir.mkdir(parents=True)
+        (seq_dir / "seqinfo.ini").write_text("not an ini file at all\n===\n")
+
+        with caplog.at_level(logging.WARNING, logger="test_mcbyte_seqinfo"):
+            result = _read_sequence_frame_rate(
+                image_dir, default=30.0, logger=logging.getLogger("test_mcbyte_seqinfo"), sequence="seq"
+            )
+
+        assert result == 30.0
+        assert len(caplog.records) == 1
+        assert "seq" in caplog.records[0].message
+        assert "seqinfo.ini" in caplog.records[0].message
+
+    def test_degenerate_frame_rate_warns_with_logger(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """A ``seqinfo.ini`` with a non-finite/non-positive ``frameRate`` warns too."""
+        seq_dir = tmp_path / "seq"
+        image_dir = seq_dir / "img1"
+        image_dir.mkdir(parents=True)
+        (seq_dir / "seqinfo.ini").write_text("[Sequence]\nframeRate=nan\n")
+
+        with caplog.at_level(logging.WARNING, logger="test_mcbyte_seqinfo"):
+            result = _read_sequence_frame_rate(
+                image_dir, default=30.0, logger=logging.getLogger("test_mcbyte_seqinfo"), sequence="seq"
+            )
+
+        assert result == 30.0
+        assert len(caplog.records) == 1
+        assert "nan" in caplog.records[0].message
+
+
+class TestRunSequenceUsesRealFrameRate:
+    """``run_sequence`` must build the tracker with the sequence's real frame rate, not always ``config.frame_rate``.
+
+    ``create_tracker`` is monkeypatched to a stub that only records its ``frame_rate`` kwarg and returns a minimal fake
+    tracker — the real ``McByteTracker`` needs SAM/Cutie, far too heavy for this wiring check. One real 1x1 frame and a
+    one-line detection file are the only filesystem fixtures, matching the sequence layout ``run_sequence`` actually
+    reads (``image_dir`` for frames, ``image_dir.parent / "seqinfo.ini"``).
+    """
+
+    class _FakeTracker:
+        def update(self, detections: sv.Detections, frame: np.ndarray) -> sv.Detections:
+            return sv.Detections.empty()
+
+        def reset(self) -> None:
+            pass
+
+    def _make_sequence(self, tmp_path: Path) -> tuple[Path, Path]:
+        """Write one detection file and one real frame; return (detection_file, image_dir)."""
+        image_dir = tmp_path / "seq" / "img1"
+        image_dir.mkdir(parents=True)
+        cv2.imwrite(str(image_dir / "000001.jpg"), np.zeros((4, 4, 3), dtype=np.uint8))
+        detection_file = tmp_path / "seq.txt"
+        detection_file.write_text("1,10,20,30,40,0.9\n")
+        return detection_file, image_dir
+
+    def test_seqinfo_frame_rate_reaches_create_tracker(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With a ``seqinfo.ini`` present, its ``frameRate`` — not the dataset default — reaches the tracker."""
+        detection_file, image_dir = self._make_sequence(tmp_path)
+        (image_dir.parent / "seqinfo.ini").write_text("[Sequence]\nframeRate=25\n")
+
+        captured: dict[str, float] = {}
+
+        def fake_create_tracker(
+            *, frame_rate: float, **_kwargs: object
+        ) -> TestRunSequenceUsesRealFrameRate._FakeTracker:
+            captured["frame_rate"] = frame_rate
+            return TestRunSequenceUsesRealFrameRate._FakeTracker()
+
+        monkeypatch.setattr("trackers.cli.benchmark.mcbyte.create_tracker", fake_create_tracker)
+
+        config = DatasetConfig(name="sportsmot", detection_format="xyxy", frame_rate=30.0)
+        run_sequence(
+            sequence="seq",
+            detection_file=detection_file,
+            image_dir=image_dir,
+            output_file=tmp_path / "out" / "seq.txt",
+            config=config,
+            device="cpu",
+            enable_isolated_mask_matching=False,
+            enable_cmc=False,
+            cmc_method="sparseOptFlow",
+            cmc_downscale=6,
+            keep_partial_results=False,
+            logger=logging.getLogger("test_mcbyte"),
+        )
+
+        assert captured["frame_rate"] == 25.0
+
+    def test_without_seqinfo_falls_back_to_dataset_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No ``seqinfo.ini``: ``config.frame_rate`` reaches the tracker exactly as before this fix.
+
+        Without the fix — ``create_tracker(frame_rate=config.frame_rate, ...)`` unconditionally — this test would
+        still pass, but :meth:`test_seqinfo_frame_rate_reaches_create_tracker` above would fail (30.0 instead of
+        25.0), which is the actual regression guard.
+        """
+        detection_file, image_dir = self._make_sequence(tmp_path)
+
+        captured: dict[str, float] = {}
+
+        def fake_create_tracker(
+            *, frame_rate: float, **_kwargs: object
+        ) -> TestRunSequenceUsesRealFrameRate._FakeTracker:
+            captured["frame_rate"] = frame_rate
+            return TestRunSequenceUsesRealFrameRate._FakeTracker()
+
+        monkeypatch.setattr("trackers.cli.benchmark.mcbyte.create_tracker", fake_create_tracker)
+
+        config = DatasetConfig(name="sportsmot", detection_format="xyxy", frame_rate=30.0)
+        run_sequence(
+            sequence="seq",
+            detection_file=detection_file,
+            image_dir=image_dir,
+            output_file=tmp_path / "out" / "seq.txt",
+            config=config,
+            device="cpu",
+            enable_isolated_mask_matching=False,
+            enable_cmc=False,
+            cmc_method="sparseOptFlow",
+            cmc_downscale=6,
+            keep_partial_results=False,
+            logger=logging.getLogger("test_mcbyte"),
+        )
+
+        assert captured["frame_rate"] == 30.0
 
 
 class TestPrepareMot17Submission:

--- a/tests/cli/test_track.py
+++ b/tests/cli/test_track.py
@@ -7,14 +7,18 @@
 from __future__ import annotations
 
 from dataclasses import fields
+from pathlib import Path
 from typing import ClassVar
 
+import cv2
 import numpy as np
 import pytest
 import supervision as sv
 
 from trackers.cli.track import (
     _EXCLUDED_TRACKER_PARAMETERS,
+    DetectionOptions,
+    OutputOptions,
     ShowOptions,
     TrackerOptions,
     _abbreviate_parameter_name,
@@ -27,6 +31,7 @@ from trackers.cli.track import (
     _resolve_track_id_filter,
     _resolve_tracker_kwargs,
     _tracker_options_as_dict,
+    track_command,
 )
 from trackers.core.base import BaseTracker
 
@@ -350,3 +355,143 @@ class TestTrackerParameterAbbreviations:
             tracker = _init_tracker(options)
 
         assert not hasattr(tracker, "minimum_mask_coverage")
+
+
+class TestInitTrackerDetectedFrameRate:
+    """``detected_frame_rate`` should seed ``frame_rate`` unless the CLI already overrode it.
+
+    Regression coverage for H-FRAME-RATE-NEVER-PROPAGATED: every tracker's ``frame_rate`` defaults to a hardcoded
+    30.0 (see e.g. ``BaseTracker._compute_maximum_frames_without_update``, ``trackers.utils.motion_models``), and
+    without this parameter ``_init_tracker`` had no way to fill it in from the source's real fps.
+    """
+
+    def test_detected_frame_rate_reaches_the_tracker(self) -> None:
+        """A source fps with no explicit ``--tracker.frame_rate`` override reaches the constructor."""
+        options = TrackerOptions(name="bytetrack")
+
+        tracker = _init_tracker(options, detected_frame_rate=24.0)
+
+        assert tracker._frame_rate == pytest.approx(24.0)
+
+    def test_explicit_override_wins_over_detected_frame_rate(self) -> None:
+        """``--tracker.frame_rate`` set explicitly must not be clobbered by the detected value."""
+        options = TrackerOptions(name="bytetrack", frame_rate=60.0)
+
+        tracker = _init_tracker(options, detected_frame_rate=24.0)
+
+        assert tracker._frame_rate == pytest.approx(60.0)
+
+    def test_no_detected_frame_rate_keeps_the_constructor_default(self) -> None:
+        """``detected_frame_rate=None`` (unknown source fps, e.g. a webcam) changes nothing."""
+        options = TrackerOptions(name="bytetrack")
+
+        tracker = _init_tracker(options, detected_frame_rate=None)
+
+        assert tracker._frame_rate == pytest.approx(30.0)
+
+    @pytest.mark.parametrize("bad_value", [0.0, -24.0, float("nan"), float("inf")])
+    def test_non_positive_or_non_finite_detected_frame_rate_is_ignored(self, bad_value: float) -> None:
+        """A degenerate probed fps (``<= 0``, non-finite, e.g. a corrupt container) falls back to the tracker default.
+
+        Without the ``math.isfinite`` guard, ``inf``/``nan`` pass the old ``> 0`` check (``inf > 0`` is ``True``) and
+        reach the tracker constructor, which raises ``ValueError`` inside
+        ``BaseTracker._compute_maximum_frames_without_update`` instead of falling back cleanly.
+        """
+        options = TrackerOptions(name="bytetrack")
+
+        tracker = _init_tracker(options, detected_frame_rate=bad_value)
+
+        assert tracker._frame_rate == pytest.approx(30.0)
+
+    def test_every_registered_tracker_accepts_frame_rate(self) -> None:
+        """Every tracker in the registry accepts ``frame_rate`` today.
+
+        Backs the ``"frame_rate" in accepted`` guard in ``_init_tracker``: that guard exists so a detected value is
+        silently skipped for a tracker that has no such parameter, but no registered tracker currently exercises that
+        branch — this pins the current registry shape so the guard's dead branch is visible rather than silently
+        unreachable forever.
+        """
+        for tracker_id in BaseTracker._registered_trackers():
+            info = BaseTracker._lookup_tracker(tracker_id)
+            assert info is not None
+            assert "frame_rate" in info.parameters
+
+
+class TestTrackCommandDetectsSourceFrameRate:
+    """``track_command`` must read the source's real fps before building the tracker.
+
+    ``_init_tracker`` used to be called before ``source_info`` (which holds the real fps) even
+    existed in this function's scope — the CLI entry point had no way to reach the fix in
+    ``TestInitTrackerDetectedFrameRate`` above without first reordering ``track_command`` itself.
+    This is the end-to-end wiring check for that reorder: a real (tiny) video written at a
+    non-default fps, replayed through ``--detection.mot_file`` so no detection model is needed.
+    """
+
+    @staticmethod
+    def _write_video(path: Path, fps: float, frame_count: int = 3) -> None:
+        writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (4, 4))
+        try:
+            for _ in range(frame_count):
+                writer.write(np.zeros((4, 4, 3), dtype=np.uint8))
+        finally:
+            writer.release()
+
+    def test_video_fps_reaches_the_tracker(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The video's real (non-30) fps is what the tracker is built with."""
+        video_path = tmp_path / "clip.mp4"
+        self._write_video(video_path, fps=24.0)
+
+        detection_file = tmp_path / "dets.txt"
+        detection_file.write_text("1,1,1,1,2,2,0.9,-1,-1,-1\n2,1,1,1,2,2,0.9,-1,-1,-1\n")
+
+        real_init_tracker = _init_tracker
+        captured: dict[str, float | None] = {}
+
+        def spy_init_tracker(
+            params: TrackerOptions | None,  # type: ignore[valid-type]
+            *,
+            detected_frame_rate: float | None = None,
+        ) -> BaseTracker:
+            captured["detected_frame_rate"] = detected_frame_rate
+            return real_init_tracker(params, detected_frame_rate=detected_frame_rate)
+
+        monkeypatch.setattr("trackers.cli.track._init_tracker", spy_init_tracker)
+
+        exit_code = track_command(
+            source=str(video_path),
+            detection=DetectionOptions(mot_file=detection_file),
+            tracker=TrackerOptions(name="bytetrack"),
+            output=OutputOptions(mot_results=tmp_path / "out.txt"),
+        )
+
+        assert exit_code == 0
+        assert captured["detected_frame_rate"] == pytest.approx(24.0)
+
+    def test_mot_file_only_run_has_no_detected_frame_rate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No video source at all (pure ``--detection.mot_file`` replay): nothing to detect from."""
+        detection_file = tmp_path / "dets.txt"
+        detection_file.write_text("1,1,1,1,2,2,0.9,-1,-1,-1\n2,1,1,1,2,2,0.9,-1,-1,-1\n")
+
+        real_init_tracker = _init_tracker
+        captured: dict[str, float | None] = {}
+
+        def spy_init_tracker(
+            params: TrackerOptions | None,  # type: ignore[valid-type]
+            *,
+            detected_frame_rate: float | None = None,
+        ) -> BaseTracker:
+            captured["detected_frame_rate"] = detected_frame_rate
+            return real_init_tracker(params, detected_frame_rate=detected_frame_rate)
+
+        monkeypatch.setattr("trackers.cli.track._init_tracker", spy_init_tracker)
+
+        exit_code = track_command(
+            detection=DetectionOptions(mot_file=detection_file),
+            tracker=TrackerOptions(name="bytetrack"),
+            output=OutputOptions(mot_results=tmp_path / "out.txt"),
+        )
+
+        assert exit_code == 0
+        assert captured["detected_frame_rate"] is None


### PR DESCRIPTION
None of the three places that build a tracker from a real source pass it the source's actual frame rate. All of them fall back to the constructor default, `frame_rate=30.0`.

- `track_command()` in `src/trackers/cli/track.py` calls `_init_tracker()` before `source_info` exists in that function's scope. `source_info` is what holds the real fps, via `_classify_source()`, so at that point there is nothing to pass yet. It's an ordering problem, not just a missing parameter.
- `_get_video_info()` in `demo/app.py` already reads the fps with `cv2.VideoCapture(...).get(cv2.CAP_PROP_FPS)`, but only uses it to compute the clip duration and throws it away. `track()` then builds `ByteTrackTracker`/`SORTTracker` with no `frame_rate=` at all.
- `run_sequence()` in `src/trackers/cli/benchmark/mcbyte.py` passes `DatasetConfig.frame_rate` (one default shared by every sequence in a dataset) straight into `create_tracker()`. There is no mention of `seqinfo.ini` anywhere in the repo before this PR.

I checked how far off the shared default actually is against real data. The integration tests already cache real MOTChallenge-format sequences locally, and their `seqinfo.ini` files show `frameRate=25` for all 45 cached `SportsMOT-val` sequences, and `frameRate=20` for all 25 cached `DanceTrack-val` sequences. So this is not a couple of outlier sequences. The default is wrong for every sequence checked, in both datasets this benchmark supports.

**Changes**

- `src/trackers/cli/track.py`: reordered `track_command()` to classify the source (metadata only, no frame decode) before building the tracker, and threaded that into `_init_tracker()` through a new `detected_frame_rate: float | None = None` argument.

It only fills `kwargs["frame_rate"]` when three things hold: the selected tracker accepts that argument, there is no explicit `--tracker.frame_rate` override already set, and the detected value is finite and `> 0`. That last check matters, a corrupt container can report `inf`/`nan` through `cv2.CAP_PROP_FPS`, and without the guard that would reach the tracker constructor and crash inside `BaseTracker._compute_maximum_frames_without_update`'s `math.isfinite` check. An explicit override always wins.

For a pure `--detection.mot_file` replay there is no video to read a fps from. `detected_frame_rate` stays `None` and every tracker keeps its own default. That's correct, not a gap.

- `demo/app.py`: `_get_video_info()` now also returns the `fps` it was already reading. It's guarded the same way, rejecting non-finite values and not just non-positive ones, because this value used to be display-only and is now forwarded live into the tracker constructor. `track()` forwards it as `frame_rate=` to `ByteTrackTracker` and `SORTTracker`.
- `src/trackers/cli/benchmark/mcbyte.py`: added `_read_sequence_frame_rate(image_dir, default, *, logger=None, sequence="")`. It reads `image_dir.parent / seqinfo.ini` (the standard MOTChallenge layout) and parses `[Sequence] frameRate` with `configparser`, falling back to the dataset default when the file is missing, unparsable, or the value is not finite/positive.

A missing `seqinfo.ini` stays silent, and that's unremarkable. A *present but broken* one — unparsable content, or a non-finite/non-positive `frameRate` — now logs a warning naming the file, so a dataset shipping bad metadata doesn't silently pass for one with no metadata at all. `run_sequence()` now uses that per-sequence value instead of `config.frame_rate` directly, and logs once per sequence when the two differ.

- `docs/guides/track.md`: updated the `--tracker.frame_rate` reference row. It used to say the default was just the tracker's own default; now it says a readable source FPS is used first, when the flag is left unset.

One sibling I did not touch: `SequenceOptions.frame_rate` in `src/trackers/cli/inspect/mcbyte.py:109` has the same shape, a defaulted fps field. But that tool is a manual debugging entry point. The user already supplies `image_dir`, `det_file`, `start_frame`, `end_frame`, `det_format` by hand for every run, so there is no automatic source detection there for a real value to get discarded from. Left it out of scope on purpose, not something I missed.

A second one I also left alone, for a different reason. `Tuner._build_tracker()` in `src/trackers/tune/tuner.py` builds one tracker per trial with `frame_rate` on the same hardcoded 30.0, then reuses that single instance (`tracker.reset()` only) across every sequence in `self._sequences`.

`frame_rate` is not in any tracker's `search_space`, so nothing here ever sets it from real data either. `images_dir` — where a `seqinfo.ini` would live — is optional, and only required when `enable_cmc=True`.

Closing this one the same way needs an actual design decision. Either rebuild the tracker per sequence with its own detected fps, which changes what "one tracker instance per trial" means in `_objective()`, or accept one fps for a whole trial even when the sequences mix rates. That's not a call I want to make inside a plumbing PR, so I'm leaving it flagged instead of touching it or staying quiet about it.

This PR does not re-run the McByte benchmark or regenerate any of the golden results. That needs SAM/Cutie GPU compute, and it's outside what I wanted to take on here.

Worth flagging clearly though: running `trackers benchmark mcbyte` again after this fix could move the HOTA/MOTA numbers published in `docs/evaluations/results.md` for SportsMOT and DanceTrack. Only the lost-track buffer is affected, the Kalman process noise is not. `BaseTracker._compute_maximum_frames_without_update` scales `lost_track_buffer` by `frame_rate / 30.0` once at tracker construction. So with McByte's default `lost_track_buffer=30`, the missed-frame budget goes from 30 frames (old hardcoded 30fps default) to 25 frames on SportsMOT-val (25fps), and 20 frames on DanceTrack-val (20fps).

The Kalman noise band in `motion_models.py::build_Q` only becomes fps-aware when a `frame_rate` reaches it through `PredictTiming`, the timestamped/dynamic-rate path. `run_sequence()` never passes a timestamp to `update()`, so it stays on the fixed frame-unit fallback regardless of this fix. I have not re-measured the buffer's downstream effect on HOTA/MOTA, I'm just leaving the mechanism and its exact magnitude as a known consequence for whoever runs the benchmark next.

**Validation**

- Full non-integration suite: 1495 passed, 3 skipped, 14 deselected, consistent across repeated runs (baseline, before the adversarial-review fixes below; see caveat under those).
- `pre-commit run --all-files`: all 18 hooks clean (license header, ruff check/format, docformatter, mdformat, codespell, mypy on `src` and `tests`).
- Checked the benchmark regression test actually discriminates: reverted `run_sequence()`'s `frame_rate=frame_rate` back to `frame_rate=config.frame_rate` (the pre-fix behaviour) and reran the new tests. Exactly one failed (`test_seqinfo_frame_rate_reaches_create_tracker`, `assert 30.0 == 25.0`), the other 9 stayed green — expected, since the "no seqinfo" case is unaffected by the bug. Restored the fix, the full suite is green again.
- New tests: `tests/cli/test_track.py::TestInitTrackerDetectedFrameRate` (6 tests, detected value reaches the tracker, explicit override wins, non-positive/non-finite/`None` values are ignored, every registered tracker currently accepts `frame_rate`), `tests/cli/test_track.py::TestTrackCommandDetectsSourceFrameRate` (2 tests, end to end with a real 24fps video written via `cv2.VideoWriter` and round-tripped through `cv2.CAP_PROP_FPS`, and the no-source case), `tests/cli/test_benchmark_mcbyte.py::TestReadSequenceFrameRate` (8 tests, parametrised over `0`, `-25`, `nan`, `inf`, plus 3 covering the new seqinfo-present-but-broken warning), `tests/cli/test_benchmark_mcbyte.py::TestRunSequenceUsesRealFrameRate` (2 tests, `create_tracker` monkeypatched to a stub capturing the `frame_rate` kwarg, the real `McByteTracker` needs SAM/Cutie which is too heavy for a wiring check).
- Adversarial review round (Codex) caught two real gaps and one prose overclaim, all fixed in this same patch:
  1. `_init_tracker` and `demo/app.py::_get_video_info` only rejected `<= 0` fps, not non-finite fps. Since this PR is what makes that value reach the tracker constructor live (it used to be display-only), an `inf`/`nan` from a corrupt container crashed with an unhandled `ValueError` instead of falling back. Added the same `math.isfinite` guard `benchmark/mcbyte.py` already had.
  2. `_read_sequence_frame_rate` fell back identically, and silently, whether `seqinfo.ini` was simply absent or present-but-broken. Added an opt-in `logger`/`sequence` pair so `run_sequence` can warn on the latter case specifically.
  3. The PR body and a docstring overclaimed that this fix also changes McByte's Kalman process noise. It does not: `run_sequence` never passes a timestamp to `update()`, so the tracker stays in fixed-rate mode, only the lost-track buffer scaling is affected.

`tests/cli/test_track.py -m "not integration"` reverified after these fixes: 51 passed. `tests/cli/test_benchmark_mcbyte.py`'s logger-warning behaviour was verified by direct module import (`_read_sequence_frame_rate` called standalone) rather than through pytest, because collecting that test file needs `jsonargparse`, which isn't installed in the environment available for this review round. That's a declared runtime dependency (`pyproject.toml`), not something this PR adds or removes, and none of `benchmark/mcbyte.py`'s other tests were touched by the review-round changes.
