### PR TITLE
perf(kf): avoid bbox decoding during scale-aware noise refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **McByte CMC now defaults to `cmc_downscale=6`** — this aggregate-performance default halves median CMC latency versus factor `2` on the complete 45-clip, 1280x720 SportsMOT validation split and passes the dataset-level mean/median quality criterion. The benchmark used ground-truth detections with masks disabled; 9/45 clips regressed under the previous strict per-clip gate. Pass `cmc_downscale=2` to preserve the previous conservative behavior. Generic `CMCConfig` and `BoTSORTTracker` remain at `2`.
 - **Mask stack moved from `trackers.core.mcbyte.masks` to `trackers.core.masks`** — SAM mask generation, Cutie propagation, and `MaskManager` reference no tracker and are not McByte-specific, so they now live beside the trackers rather than inside one. Import from `trackers.core.masks` instead ([#543](https://github.com/roboflow/trackers/pull/543)).
+- **BoT-SORT / C-BIoU / McByte scale-aware noise refresh avoids full bbox decoding** — the default center-width-height state now reconstructs only the corner pairs needed for width and height while preserving the previous floating-point operation order and output bits.
 
 ### 🔧 Fixed
 

--- a/src/trackers/core/botsort/tracklet.py
+++ b/src/trackers/core/botsort/tracklet.py
@@ -134,13 +134,14 @@ class BoTSORTTracklet(BaseTracklet):
     def _current_wh(self) -> tuple[float, float]:
         """Return the current box width/height, clamped away from zero.
 
-        The ``XCYCWHStateEstimator`` path reconstructs each pair of corners before subtracting them.  Reading the stored
+        The ``XCYCWHStateEstimator`` path reconstructs each pair of corners before subtracting them. Reading the stored
         width and height directly would skip the center-dependent rounding performed by ``state_to_bbox()``. The fast
-        path only applies to the exact base class: a subclass may override ``state_to_bbox()``, and reproducing the
-        arithmetic here instead of calling it would silently skip that override.
+        path applies only when the estimator is exactly ``XCYCWHStateEstimator`` and its state has dtype ``float64``.
+        Subclasses and states with other dtypes fall back to ``state_to_bbox()`` so overridden conversion behavior and
+        the decoder's float64 corner arithmetic is preserved.
         """
-        if type(self.state_estimator) is XCYCWHStateEstimator:
-            state = self.state_estimator.kf.state
+        state = self.state_estimator.kf.state
+        if type(self.state_estimator) is XCYCWHStateEstimator and state.dtype == np.float64:
             x_center = state[0, 0]
             y_center = state[1, 0]
             half_w = state[2, 0] * 0.5

--- a/src/trackers/core/botsort/tracklet.py
+++ b/src/trackers/core/botsort/tracklet.py
@@ -132,7 +132,23 @@ class BoTSORTTracklet(BaseTracklet):
         self.state_estimator.set_kf_covariances(measurement_noise=R, process_noise=Q, state_covariance=state_covariance)
 
     def _current_wh(self) -> tuple[float, float]:
-        """Return the current box width/height, clamped away from zero."""
+        """Return the current box width/height, clamped away from zero.
+
+        The ``XCYCWHStateEstimator`` path reconstructs each pair of corners before subtracting them.  Reading the stored
+        width and height directly would skip the center-dependent rounding performed by ``state_to_bbox()``. The fast
+        path only applies to the exact base class: a subclass may override ``state_to_bbox()``, and reproducing the
+        arithmetic here instead of calling it would silently skip that override.
+        """
+        if type(self.state_estimator) is XCYCWHStateEstimator:
+            state = self.state_estimator.kf.state
+            x_center = state[0, 0]
+            y_center = state[1, 0]
+            half_w = state[2, 0] * 0.5
+            half_h = state[3, 0] * 0.5
+            w = max(float((x_center + half_w) - (x_center - half_w)), 1e-3)
+            h = max(float((y_center + half_h) - (y_center - half_h)), 1e-3)
+            return w, h
+
         bbox = self.state_estimator.state_to_bbox()
         w = max(float(bbox[2] - bbox[0]), 1e-3)
         h = max(float(bbox[3] - bbox[1]), 1e-3)

--- a/src/trackers/core/mcbyte/tracklet.py
+++ b/src/trackers/core/mcbyte/tracklet.py
@@ -132,7 +132,23 @@ class McByteTracklet(BaseTracklet):
         self.state_estimator.set_kf_covariances(measurement_noise=R, process_noise=Q, state_covariance=state_covariance)
 
     def _current_wh(self) -> tuple[float, float]:
-        """Return the current box width/height, clamped away from zero."""
+        """Return the current box width/height, clamped away from zero.
+
+        The ``XCYCWHStateEstimator`` path reconstructs each pair of corners before subtracting them.  Reading the stored
+        width and height directly would skip the center-dependent rounding performed by ``state_to_bbox()``. The fast
+        path only applies to the exact base class: a subclass may override ``state_to_bbox()``, and reproducing the
+        arithmetic here instead of calling it would silently skip that override.
+        """
+        if type(self.state_estimator) is XCYCWHStateEstimator:
+            state = self.state_estimator.kf.state
+            x_center = state[0, 0]
+            y_center = state[1, 0]
+            half_w = state[2, 0] * 0.5
+            half_h = state[3, 0] * 0.5
+            w = max(float((x_center + half_w) - (x_center - half_w)), 1e-3)
+            h = max(float((y_center + half_h) - (y_center - half_h)), 1e-3)
+            return w, h
+
         bbox = self.state_estimator.state_to_bbox()
         w = max(float(bbox[2] - bbox[0]), 1e-3)
         h = max(float(bbox[3] - bbox[1]), 1e-3)

--- a/src/trackers/core/mcbyte/tracklet.py
+++ b/src/trackers/core/mcbyte/tracklet.py
@@ -134,13 +134,14 @@ class McByteTracklet(BaseTracklet):
     def _current_wh(self) -> tuple[float, float]:
         """Return the current box width/height, clamped away from zero.
 
-        The ``XCYCWHStateEstimator`` path reconstructs each pair of corners before subtracting them.  Reading the stored
+        The ``XCYCWHStateEstimator`` path reconstructs each pair of corners before subtracting them. Reading the stored
         width and height directly would skip the center-dependent rounding performed by ``state_to_bbox()``. The fast
-        path only applies to the exact base class: a subclass may override ``state_to_bbox()``, and reproducing the
-        arithmetic here instead of calling it would silently skip that override.
+        path applies only when the estimator is exactly ``XCYCWHStateEstimator`` and its state has dtype ``float64``.
+        Subclasses and states with other dtypes fall back to ``state_to_bbox()`` so overridden conversion behavior and
+        the decoder's float64 corner arithmetic is preserved.
         """
-        if type(self.state_estimator) is XCYCWHStateEstimator:
-            state = self.state_estimator.kf.state
+        state = self.state_estimator.kf.state
+        if type(self.state_estimator) is XCYCWHStateEstimator and state.dtype == np.float64:
             x_center = state[0, 0]
             y_center = state[1, 0]
             half_w = state[2, 0] * 0.5

--- a/tests/core/test_botsort_tracklet.py
+++ b/tests/core/test_botsort_tracklet.py
@@ -94,6 +94,69 @@ class TestBotsortTracklet:
         assert np.all(large_Q > small_Q), "larger box must produce larger process noise diagonal"
 
     @pytest.mark.parametrize("tracklet_cls", [BoTSORTTracklet, McByteTracklet])
+    def test_current_wh_reconstructs_corner_subtraction_without_bbox_decode(
+        self,
+        tracklet_cls: type[BoTSORTTracklet] | type[McByteTracklet],
+    ) -> None:
+        """The default estimator fast path must preserve center-dependent corner rounding without decoding an array."""
+        tracklet = tracklet_cls(np.array([0.0, 0.0, 20.0, 20.0]))
+        tracklet.state_estimator.kf.state[:4, 0] = np.array([1e12, -1e12, 0.1, 0.2])
+        bbox = tracklet.state_estimator.state_to_bbox()
+        expected = np.array(
+            [
+                max(float(bbox[2] - bbox[0]), 1e-3),
+                max(float(bbox[3] - bbox[1]), 1e-3),
+            ]
+        )
+        direct = tracklet.state_estimator.kf.state[2:4, 0]
+        assert not np.array_equal(expected.view(np.uint64), direct.view(np.uint64))
+
+        with patch.object(tracklet.state_estimator, "state_to_bbox", side_effect=AssertionError("decoded bbox")):
+            actual = np.array(tracklet._current_wh())
+
+        np.testing.assert_array_equal(actual.view(np.uint64), expected.view(np.uint64))
+
+    @pytest.mark.parametrize("tracklet_cls", [BoTSORTTracklet, McByteTracklet])
+    @pytest.mark.parametrize("estimator_class", [XYXYStateEstimator, XCYCSRStateEstimator])
+    def test_current_wh_keeps_bbox_decode_for_other_state_representations(
+        self,
+        bbox: np.ndarray,
+        tracklet_cls: type[BoTSORTTracklet] | type[McByteTracklet],
+        estimator_class: type[BaseStateEstimator],
+    ) -> None:
+        """Non-XCYCWH representations retain the state estimator's bbox decoder."""
+        tracklet = tracklet_cls(bbox, state_estimator_class=estimator_class)
+
+        with patch.object(
+            tracklet.state_estimator, "state_to_bbox", wraps=tracklet.state_estimator.state_to_bbox
+        ) as mock_decode:
+            tracklet._current_wh()
+
+        mock_decode.assert_called_once_with()
+
+    @pytest.mark.parametrize("tracklet_cls", [BoTSORTTracklet, McByteTracklet])
+    def test_current_wh_keeps_bbox_decode_for_xcycwh_subclass(
+        self,
+        bbox: np.ndarray,
+        tracklet_cls: type[BoTSORTTracklet] | type[McByteTracklet],
+    ) -> None:
+        """A subclass overriding ``state_to_bbox()`` must not be routed through the exact-class fast path."""
+
+        class CustomXCYCWHStateEstimator(XCYCWHStateEstimator):
+            def state_to_bbox(self) -> np.ndarray:
+                return np.array([3.0, 5.0, 50.0, 76.0])
+
+        tracklet = tracklet_cls(bbox, state_estimator_class=CustomXCYCWHStateEstimator)
+
+        with patch.object(
+            tracklet.state_estimator, "state_to_bbox", wraps=tracklet.state_estimator.state_to_bbox
+        ) as mock_decode:
+            actual = tracklet._current_wh()
+
+        mock_decode.assert_called_once_with()
+        assert actual == (47.0, 71.0)
+
+    @pytest.mark.parametrize("tracklet_cls", [BoTSORTTracklet, McByteTracklet])
     def test_larger_box_has_larger_measurement_noise(
         self,
         tracklet_cls: type[BoTSORTTracklet] | type[McByteTracklet],

--- a/tests/core/test_botsort_tracklet.py
+++ b/tests/core/test_botsort_tracklet.py
@@ -117,6 +117,54 @@ class TestBotsortTracklet:
         np.testing.assert_array_equal(actual.view(np.uint64), expected.view(np.uint64))
 
     @pytest.mark.parametrize("tracklet_cls", [BoTSORTTracklet, McByteTracklet])
+    def test_current_wh_matches_decoder_for_float32_restored_state(
+        self,
+        tracklet_cls: type[BoTSORTTracklet] | type[McByteTracklet],
+    ) -> None:
+        """Restored float32 state must retain the decoder's float64 corner arithmetic."""
+        tracklet = tracklet_cls(np.array([0.0, 0.0, 20.0, 20.0]))
+        restored_state = tracklet.state_estimator.get_state()
+        restored_state["state"] = restored_state["state"].astype(np.float32)
+        restored_state["state"][:4, 0] = np.array([1e12, -1e12, 0.1, 0.2], dtype=np.float32)
+        tracklet.state_estimator.set_state(restored_state)
+        assert tracklet.state_estimator.kf.state.dtype == np.float32
+
+        decoded_bbox = tracklet.state_estimator.state_to_bbox()
+        expected = (
+            max(float(decoded_bbox[2] - decoded_bbox[0]), 1e-3),
+            max(float(decoded_bbox[3] - decoded_bbox[1]), 1e-3),
+        )
+
+        assert tracklet._current_wh() == expected
+
+    @pytest.mark.parametrize("tracklet_cls", [BoTSORTTracklet, McByteTracklet])
+    @pytest.mark.parametrize(
+        ("width", "height"),
+        [
+            pytest.param(0.0, 0.0, id="zero"),
+            pytest.param(-4.0, -6.0, id="negative"),
+        ],
+    )
+    def test_current_wh_clamps_nonpositive_dimensions_to_minimum(
+        self,
+        tracklet_cls: type[BoTSORTTracklet] | type[McByteTracklet],
+        width: float,
+        height: float,
+    ) -> None:
+        """Zero and negative default-estimator dimensions must match the decoder's 1e-3 clamp."""
+        tracklet = tracklet_cls(np.array([0.0, 0.0, 20.0, 20.0]))
+        tracklet.state_estimator.kf.state[:4, 0] = np.array([100.0, -100.0, width, height])
+
+        decoded_bbox = tracklet.state_estimator.state_to_bbox()
+        expected = (
+            max(float(decoded_bbox[2] - decoded_bbox[0]), 1e-3),
+            max(float(decoded_bbox[3] - decoded_bbox[1]), 1e-3),
+        )
+
+        assert expected == (1e-3, 1e-3)
+        assert tracklet._current_wh() == expected
+
+    @pytest.mark.parametrize("tracklet_cls", [BoTSORTTracklet, McByteTracklet])
     @pytest.mark.parametrize("estimator_class", [XYXYStateEstimator, XCYCSRStateEstimator])
     def test_current_wh_keeps_bbox_decode_for_other_state_representations(
         self,
@@ -126,13 +174,19 @@ class TestBotsortTracklet:
     ) -> None:
         """Non-XCYCWH representations retain the state estimator's bbox decoder."""
         tracklet = tracklet_cls(bbox, state_estimator_class=estimator_class)
+        decoded_bbox = tracklet.state_estimator.state_to_bbox()
+        expected = (
+            max(float(decoded_bbox[2] - decoded_bbox[0]), 1e-3),
+            max(float(decoded_bbox[3] - decoded_bbox[1]), 1e-3),
+        )
 
         with patch.object(
             tracklet.state_estimator, "state_to_bbox", wraps=tracklet.state_estimator.state_to_bbox
         ) as mock_decode:
-            tracklet._current_wh()
+            actual = tracklet._current_wh()
 
         mock_decode.assert_called_once_with()
+        assert actual == expected
 
     @pytest.mark.parametrize("tracklet_cls", [BoTSORTTracklet, McByteTracklet])
     def test_current_wh_keeps_bbox_decode_for_xcycwh_subclass(


### PR DESCRIPTION
`BoTSORTTracklet._current_wh()` and `McByteTracklet._current_wh()` decode a full XYXY box during each scale-aware process/measurement-noise refresh, and then only use its width and height.

The default estimator already stores `[x_center, y_center, width, height]`, so reading width and height straight from that looks like the simpler path. It isn't bit-equivalent though: the existing decoder builds both corners first, and with large centers that changes the rounded subtraction result. I checked this on 27,033 Kalman states captured from a DanceTrack replay, and direct reads changed bits in 25,943 of those calls.

So the fix adds a fast path for the default estimator that reconstructs the same two corner pairs and keeps the original operation order, without allocating the XYXY array. The XYXY and XCYCSR estimators keep the existing decoder as a fallback, and C-BIoU also uses the BoT-SORT tracklet, so it goes through the same path.

Regression tests cover BoT-SORT and McByte, check the uint64 output bits, confirm the fast path does not call `state_to_bbox()`, and check that the other two state representations — plus a subclass of the default estimator — still go through their decoder. The fast path is scoped to the exact `XCYCWHStateEstimator` class, not `isinstance`, so a subclass override isn't bypassed. The changelog records the optimisation.

Validation:

- 27,033 real states, 15 repetitions of the final `_current_wh()` method: 1,555.33 ns/call median `[1,544.67, 1,573.07]` to 545.43 `[528.89, 562.81]`, -64.93%. The measured ranges are disjoint.
- Seven alternating fresh-process DanceTrack pairs on the final code, 25 sequences / 25,508 frames / 225,148 boxes per run: BoT-SORT 8,524.33 ms median `[8,299.91, 8,924.06]` to 8,202.17 `[7,808.38, 8,326.87]` (-3.78%); McByte 10,149.26 `[10,116.37, 10,370.00]` to 9,670.04 `[9,593.48, 10,400.23]` (-4.72%). Six of seven pairs were faster for each tracker. Paired deltas were `[-12.46%, +0.32%]` for BoT-SORT and `[-6.88%, +2.47%]` for McByte, so process variance is visible and the exact percentages depend on the machine and workload.
- Output and final Kalman-state hashes matched in each DanceTrack process. Hungarian IoU pairing over 2,059 emitted boxes found minimum IoU 1.0, with zero coordinate-bit or ID mismatches.
- 120,000 plausible cases across both tracklets and three representations, plus 501,250 arbitrary/special float64 calls, had zero bit mismatches.
- `pytest -m "not integration"`: 1,557 passed, 3 skipped, 14 deselected. Seventeen repository pre-commit hooks pass; one shebang hook skips because no matching file is present.
