### PR TITLE
perf(eval): vectorize Identity ID remapping

### DIFF
--- a/src/trackers/eval/identity.py
+++ b/src/trackers/eval/identity.py
@@ -108,9 +108,8 @@ def compute_identity_metrics(
     num_gt_ids = len(unique_gt_ids)
     num_tracker_ids = len(unique_tracker_ids)
 
-    # Create ID mappings for array indexing
-    gt_id_to_idx = {int(id_): idx for idx, id_ in enumerate(unique_gt_ids)}
-    tracker_id_to_idx = {int(id_): idx for idx, id_ in enumerate(unique_tracker_ids)}
+    # `np.unique` sorts the IDs, and every per-frame ID is included in those
+    # arrays, so searchsorted maps all IDs directly to their global indices.
 
     # Variables for global association (ref: identity.py:48-50)
     potential_matches_count = np.zeros((num_gt_ids, num_tracker_ids))
@@ -122,15 +121,15 @@ def compute_identity_metrics(
         if len(gt_ids_t) == 0 or len(tracker_ids_t) == 0:
             # Still count IDs even if no matches possible
             if len(gt_ids_t) > 0:
-                gt_indices = np.array([gt_id_to_idx[int(id_)] for id_ in gt_ids_t])
+                gt_indices = np.searchsorted(unique_gt_ids, gt_ids_t)
                 gt_id_count[gt_indices] += 1
             if len(tracker_ids_t) > 0:
-                tr_indices = np.array([tracker_id_to_idx[int(id_)] for id_ in tracker_ids_t])
+                tr_indices = np.searchsorted(unique_tracker_ids, tracker_ids_t)
                 tracker_id_count[tr_indices] += 1
             continue
 
-        gt_indices = np.array([gt_id_to_idx[int(id_)] for id_ in gt_ids_t])
-        tr_indices = np.array([tracker_id_to_idx[int(id_)] for id_ in tracker_ids_t])
+        gt_indices = np.searchsorted(unique_gt_ids, gt_ids_t)
+        tr_indices = np.searchsorted(unique_tracker_ids, tracker_ids_t)
 
         similarity = similarity_scores[t]
 

--- a/tests/eval/test_identity.py
+++ b/tests/eval/test_identity.py
@@ -163,6 +163,32 @@ class TestComputeIdentityMetrics:
         assert result["IDFP"] == 0
         assert result["IDF1"] == pytest.approx(1.0)
 
+    def test_metrics_invariant_to_id_relabeling(self) -> None:
+        """Identity metrics depend on associations, not integer ID values."""
+        gt_ids = [
+            np.array([0, 1, 2]),
+            np.array([2, 0]),
+            np.array([1, 2]),
+        ]
+        tracker_ids = [
+            np.array([10, 11, 12]),
+            np.array([12, 10]),
+            np.array([11, 12]),
+        ]
+        similarity_scores = [
+            np.array([[0.9, 0.1, 0.0], [0.1, 0.8, 0.1], [0.0, 0.1, 0.7]]),
+            np.array([[0.85, 0.0], [0.0, 0.75]]),
+            np.array([[0.8, 0.1], [0.1, 0.7]]),
+        ]
+        baseline = compute_identity_metrics(gt_ids, tracker_ids, similarity_scores)
+
+        gt_remap = {0: 1007, 1: 1003, 2: 1009}
+        tracker_remap = {10: 5002, 11: 5008, 12: 5001}
+        relabeled_gt = [np.array([gt_remap[id_] for id_ in frame], dtype=np.int32) for frame in gt_ids]
+        relabeled_tracker = [np.array([tracker_remap[id_] for id_ in frame], dtype=np.int64) for frame in tracker_ids]
+
+        assert compute_identity_metrics(relabeled_gt, relabeled_tracker, similarity_scores) == baseline
+
 
 class TestAggregateIdentityMetrics:
     """Multi-sequence aggregation of Identity metrics."""


### PR DESCRIPTION
[`compute_identity_metrics`](https://github.com/roboflow/trackers/blob/35dd78b757d79eee844fc40c4240ed23dd6c273c/src/trackers/eval/identity.py#L103-L133) already gets sorted global ID arrays with `np.unique`, but then it builds two dictionaries and loops over Python four times per frame just to map the IDs back to array indices.

So this replaces those dictionary/list-comprehension remaps with `np.searchsorted`, it's the same mapping HOTA has used since #462 — that PR only touched HOTA, so Identity kept the older path.

## Validation

- Added a regression test that relabels unsorted GT and tracker IDs to non-contiguous `int32`/`int64` values and checks that the metric dictionary is unchanged.
- Compared develop and this patch byte-for-byte over 6,000 seeded random cases: six signed/unsigned integer dtypes, non-contiguous and shuffled IDs, empty frames, strided views, float32/float64 similarities, and five thresholds.
- Regenerated ByteTrack predictions from the repository's MOT17 validation public detections, then evaluated seven sequences and 2,652 frames — Identity results came out bit-identical, and the complete CLEAR/HOTA/Identity result didn't change either.
- `pytest -m 'not integration'`: 1,550 passed, 3 skipped, 14 deselected.
- Evaluation integration tests: 4 passed. Repository pre-commit hooks passed.

## Performance

CPU-only, 13 alternating runs, with garbage collection before each timed run:

| workload | develop median [range] | this patch median [range] | delta |
|---|---:|---:|---:|
| Identity, 7 MOT17 sequences | 22.89 ms [22.58, 23.16] | 17.47 ms [17.32, 17.96] | -23.66% |
| Identity, mean per sequence call | 3269.7 µs | 2496.1 µs | -23.66% |
| Complete CLEAR/HOTA/Identity evaluation | 497.93 ms [490.74, 519.16] | 488.25 ms [484.73, 501.44] | -1.94% |

The complete-evaluation ranges overlap, so I'd call that end-to-end change modest — the isolated Identity ranges don't overlap.
