### PR TITLE
fix(docs): emit canonical URLs at /latest/ instead of broken /latest/<version>/

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Trackers
-site_url: !ENV [SITE_URL, "https://trackers.roboflow.com/latest/"]
+site_url: !ENV [SITE_URL, "https://trackers.roboflow.com/"]
 site_author: Roboflow
 site_description: A unified library for object tracking featuring clean room re-implementations of leading multi-object tracking algorithms.
 repo_name: roboflow/trackers
@@ -100,6 +100,8 @@ markdown_extensions:
 
 plugins:
   - search
+  - mike:
+      canonical_version: latest
   - redirects:
       redirect_maps:
         learn/install.md: guides/install.md


### PR DESCRIPTION
## Problem

Every page on trackers.roboflow.com advertises a canonical URL that returns **404**:

```
<link rel="canonical" href="https://trackers.roboflow.com/latest/2.6.0/trackers/bytetrack/">
```

`/latest/` and `/2.6.0/` are **siblings** on gh-pages (`latest` is a mike symlink alias to `2.6.0`), so `/latest/2.6.0/...` has never existed. Checked all 23 URLs in the live sitemap: **0 return 200**. The same broken prefix appears in `og:url`, the JSON-LD `url`/`@id`/`mainEntityOfPage` fields, and every sitemap `<loc>`.

**Consequence:** Google ignores the broken canonical and indexes multiple copies of the docs independently — `/latest/`, `/2.1.0/`, `/develop/`, and the old `roboflow.github.io/trackers` domain all currently appear in search results, splitting ranking signal and sometimes serving users stale 2.1.0 docs.

## Root cause

`site_url` contained the `/latest/` alias, and mike's plugin appends the deployed version to `site_url` at build time (`mkdocs_plugin.py`: `urljoin(site_url, version)`):

```
"https://trackers.roboflow.com/latest/" + "2.6.0" → "https://trackers.roboflow.com/latest/2.6.0/"
```

mike expects `site_url` to be the site **root**; it adds the version segment itself.

## Fix

- `site_url` → site root
- explicit `mike` plugin entry with `canonical_version: latest`, so canonicals are pinned to the `/latest/` alias regardless of which version is being built

Note `site_url` at the bare root **without** `canonical_version` would also be wrong: canonicals would land on `/2.6.0/...`, which `robots.txt` deliberately disallows (numbered version dirs are blocked; `/latest/` is the intended canonical, per the comment in robots.txt).

## Verification

Ran a real `mike deploy --update-aliases 2.6.0 latest` into a scratch branch with this config:

| artifact | before (live) | after (local deploy) |
|---|---|---|
| `rel=canonical` | `/latest/2.6.0/trackers/bytetrack/` → 404 | `/latest/trackers/bytetrack/` → 200 |
| `og:url` | `/latest/2.6.0/...` | `/latest/...` |
| JSON-LD `url` fields | `/latest/2.6.0/...` | `/latest/...` |
| sitemap `<loc>` | 23/23 → 404 | 33/33 resolve within the deployed tree |

The `latest` symlink produced by the local deploy is byte-identical (same blob hash) to the one on live gh-pages, so alias behavior is unchanged.

After this deploys with the next release, the sitemap should be resubmitted in Search Console to speed up re-crawling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)