### PR TITLE
fix(docs): clean up SERP titles, target "object tracking python" on the homepage, unpublish AGENTS.md

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 ---
-title: Changelog — Roboflow Trackers | Trackers
+title: Changelog — Roboflow Trackers
 description: Release history for Roboflow Trackers — added, changed, deprecated, and fixed entries for every version, in Keep a Changelog format.
 ---
 

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,5 +1,5 @@
 ---
-title: Code of Conduct — Roboflow Trackers | Trackers
+title: Code of Conduct — Roboflow Trackers
 description: Community standards for Roboflow Trackers — the Contributor Covenant Code of Conduct, enforcement guidelines, and how to report a violation.
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,5 @@
 ---
-title: Contributing — Roboflow Trackers | Trackers
+title: Contributing — Roboflow Trackers
 description: How to contribute to Roboflow Trackers — branching strategy, running tests, CLA signing, clean room requirements, and docstring conventions.
 ---
 

--- a/docs/evaluations/benchmark-runner.md
+++ b/docs/evaluations/benchmark-runner.md
@@ -1,5 +1,5 @@
 ---
-title: Benchmark Runner — MOT17, SportsMOT, DanceTrack, SoccerNet | Trackers
+title: Benchmark Runner — MOT17, SportsMOT, DanceTrack, SoccerNet
 description: Run a tracker over complete MOT benchmark test sets and write MOTChallenge-format results per sequence with the trackers benchmark command.
 ---
 

--- a/docs/evaluations/evaluate.md
+++ b/docs/evaluations/evaluate.md
@@ -1,5 +1,5 @@
 ---
-title: Evaluate Tracker Performance — HOTA, IDF1, MOTA Metrics | Trackers
+title: Evaluate Tracker Performance — HOTA, IDF1, MOTA Metrics
 description: Measure tracker accuracy with standard MOT metrics — HOTA, IDF1, and MOTA — using Roboflow Trackers built-in evaluation pipeline on MOT benchmark datasets.
 ---
 

--- a/docs/evaluations/methodology.md
+++ b/docs/evaluations/methodology.md
@@ -1,5 +1,5 @@
 ---
-title: Benchmark Methodology | Trackers
+title: Benchmark Methodology
 description: How Trackers' benchmark results are produced — detection sources, tuning procedure, and train/validation/test split usage.
 ---
 

--- a/docs/evaluations/results.md
+++ b/docs/evaluations/results.md
@@ -1,5 +1,5 @@
 ---
-title: Tracker Comparison — MOT Benchmark Results | Trackers
+title: Tracker Comparison — MOT Benchmark Results
 description: Side-by-side MOT benchmark comparison of SORT, ByteTrack, OC-SORT, BoT-SORT, C-BIoU, and McByte on MOT17, DanceTrack, SportsMOT, and SoccerNet — HOTA, IDF1, MOTA with default and tuned parameters.
 ---
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,5 +1,5 @@
 ---
-title: Governance — Roboflow Trackers | Trackers
+title: Governance — Roboflow Trackers
 description: Who reviews and merges changes to Roboflow Trackers, the branching model, release process, and versioning policy.
 ---
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -1,5 +1,5 @@
 ---
-title: CLI Command Reference — trackers track, eval, tune, inspect | Trackers
+title: CLI Command Reference — trackers track, eval, tune, inspect
 description: One-page reference for every trackers CLI command and subcommand, including the full flag tables for trackers inspect and a link to each command's detailed guide.
 ---
 

--- a/docs/guides/dynamic-frame-rate.md
+++ b/docs/guides/dynamic-frame-rate.md
@@ -1,5 +1,5 @@
 ---
-title: Dynamic Frame Rate — Variable-Gap Tracking | Trackers
+title: Dynamic Frame Rate — Variable-Gap Tracking
 description: Track with irregular frame timing by passing timestamps to tracker.update(). Scale Kalman prediction and lost-track pruning to real wall-clock gaps on SORT, ByteTrack, OC-SORT, BoT-SORT, C-BIoU, and McByte.
 ---
 

--- a/docs/guides/inspect.md
+++ b/docs/guides/inspect.md
@@ -1,5 +1,5 @@
 ---
-title: Inspect the Mask Pipeline — SAM, Cutie, MaskManager | Trackers
+title: Inspect the Mask Pipeline — SAM, Cutie, MaskManager
 description: Render what each stage of the mask pipeline produced, frame by frame, with the trackers inspect command.
 ---
 

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -1,5 +1,5 @@
 ---
-title: Install Roboflow Trackers — Python MOT Library | Trackers
+title: Install Roboflow Trackers — Python MOT Library
 description: Install Roboflow Trackers with pip or uv. Add multi-object tracking to any detection pipeline with a single package — supports SORT, ByteTrack, OC-SORT, and BoT-SORT out of the box.
 ---
 

--- a/docs/guides/migration_cli.md
+++ b/docs/guides/migration_cli.md
@@ -1,5 +1,5 @@
 ---
-title: CLI Migration Guide | Trackers
+title: CLI Migration Guide
 description: Migrate Trackers CLI commands from the legacy argparse interface to the jsonargparse CLI.
 ---
 

--- a/docs/guides/track.md
+++ b/docs/guides/track.md
@@ -1,5 +1,5 @@
 ---
-title: Track Objects in Video — Python API & CLI Guide | Trackers
+title: Track Objects in Video — Python API & CLI Guide
 description: Learn how to run multi-object tracking on video with Roboflow Trackers. Combine any detection model with SORT, ByteTrack, OC-SORT, or BoT-SORT to maintain consistent object IDs across frames.
 ---
 

--- a/docs/guides/tune.md
+++ b/docs/guides/tune.md
@@ -1,5 +1,5 @@
 ---
-title: Tune Tracker Hyperparameters — Optuna Guide | Trackers
+title: Tune Tracker Hyperparameters — Optuna Guide
 description: Optimize tracker hyperparameters with the Trackers Tuner class and CLI using Optuna, MOT-format detections, and evaluation metrics like HOTA, MOTA, and IDF1.
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Quickstart — Multi-Object Tracking in Python | Trackers
+title: Quickstart — Multi-Object Tracking in Python
 comments: false
 description: Get started with Roboflow Trackers — install SORT, ByteTrack, OC-SORT, BoT-SORT, C-BIoU, and McByte, run your first tracking pipeline, and evaluate results with HOTA, IDF1, and MOTA metrics.
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Quickstart — Multi-Object Tracking in Python
+title: Object Tracking in Python
 comments: false
 description: Get started with Roboflow Trackers — install SORT, ByteTrack, OC-SORT, BoT-SORT, C-BIoU, and McByte, run your first tracking pipeline, and evaluate results with HOTA, IDF1, and MOTA metrics.
 ---

--- a/docs/trackers/bytetrack.md
+++ b/docs/trackers/bytetrack.md
@@ -1,5 +1,5 @@
 ---
-title: ByteTrack — Multi-Object Tracking Algorithm | Trackers
+title: ByteTrack — Multi-Object Tracking Algorithm
 comments: true
 description: ByteTrack improves multi-object tracking by associating every detection box — including low-confidence ones — to reduce missed tracks and fragmentation while maintaining real-time performance.
 ---

--- a/docs/trackers/cbiou.md
+++ b/docs/trackers/cbiou.md
@@ -1,5 +1,5 @@
 ---
-title: C-BIoU — Cascaded-Buffered IoU Tracker | Trackers
+title: C-BIoU — Cascaded-Buffered IoU Tracker
 comments: true
 description: C-BIoU improves association under fast or irregular motion by matching with Buffered IoU instead of plain IoU, using a ByteTrack-style pipeline.
 ---

--- a/docs/trackers/mcbyte.md
+++ b/docs/trackers/mcbyte.md
@@ -1,5 +1,5 @@
 ---
-title: McByte Tracker — Mask-Conditioned Multi-Object Tracking | Trackers
+title: McByte Tracker — Mask-Conditioned Multi-Object Tracking
 comments: true
 description: McByte extends BoT-SORT-style association with temporally propagated SAM/Cutie segmentation masks as an additional matching cue, without per-video tuning.
 ---

--- a/docs/trackers/ocsort.md
+++ b/docs/trackers/ocsort.md
@@ -1,5 +1,5 @@
 ---
-title: OC-SORT — Observation-Centric SORT Tracker | Trackers
+title: OC-SORT — Observation-Centric SORT Tracker
 comments: true
 description: OC-SORT (Observation-Centric SORT) enhances SORT with three mechanisms for robust tracking under occlusion and non-linear motion, improving identity consistency on crowded scenes.
 ---

--- a/docs/trackers/sort.md
+++ b/docs/trackers/sort.md
@@ -1,5 +1,5 @@
 ---
-title: SORT Tracker — Simple Online and Realtime Tracking | Trackers
+title: SORT Tracker — Simple Online and Realtime Tracking
 comments: true
 description: SORT (Simple Online and Realtime Tracking) uses a Kalman filter and Hungarian algorithm to track objects in real time using only bounding-box geometry — fast, lightweight, and easy to integrate.
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: Trackers
+exclude_docs: |
+  AGENTS.md
 site_url: !ENV [SITE_URL, "https://trackers.roboflow.com/latest/"]
 site_author: Roboflow
 site_description: A unified library for object tracking featuring clean room re-implementations of leading multi-object tracking algorithms.


### PR DESCRIPTION
Follow-up to #582 — on-page fixes for how the docs appear in search results.

## 1. Fix doubled site name in every page title (21 pages)

The `<title>` of a docs page (what browser tabs and Google results show) is assembled from two places:

1. the page's own `title:` in its markdown front-matter, and
2. the site name (`site_name: Trackers` in `mkdocs.yml`), which the mkdocs-material theme **automatically appends** to every page title as `" - Trackers"`.

Our front-matter titles *also* end in a hand-written `| Trackers` suffix. So both suffixes stack, and every page currently renders as:

```html
<title>ByteTrack — Multi-Object Tracking Algorithm | Trackers - Trackers</title>
                                                    └── ours ──┘└─ theme ─┘
```

That doubled "Trackers - Trackers" is what shows in Google results and browser tabs today.

Fix: remove the hand-written `| Trackers` from the front-matter of all 21 pages and let the theme's automatic suffix be the only one:

```html
<title>ByteTrack — Multi-Object Tracking Algorithm - Trackers</title>
```

No theme or config change needed — the theme behavior is the default and stays as is.

## 2. Homepage title targets "object tracking python"

```
before: Quickstart — Multi-Object Tracking in Python - Trackers
after:  Object Tracking in Python - Trackers
```

"Quickstart" matches no search query; the homepage is the natural page for the head term. On-page H1 and content unchanged.

## 3. Unpublish docs/AGENTS.md

It is guidance for AI agents editing the docs (added in #565) and gets built into the public site and sitemap as a side effect of living under `docs/` (mkdocs publishes everything in that folder by default). It is already live at `/develop/AGENTS/` and would ship to `/latest/` with the next release. `exclude_docs` removes it from the build only — the file stays in the repo where agents read it; nothing references it as site content (not nav, not llms.txt).

## Verification

Local `mkdocs build`: titles render with a single suffix, homepage title as above, `AGENTS/` absent from the output tree and sitemap. No Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)