### PR TITLE
docs(readme): say "object tracking in Python" in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <div align="center">
     <img width="200" src="https://raw.githubusercontent.com/roboflow/trackers/refs/heads/release/stable/docs/assets/logo-trackers-violet.svg" alt="trackers logo">
     <h1>trackers</h1>
-    <p>Plug-and-play multi-object tracking for any detection model.</p>
+    <p>Plug-and-play object tracking in Python, for any detection model.</p>
 
 [![version](https://badge.fury.io/py/trackers.svg)](https://badge.fury.io/py/trackers) [![downloads](https://img.shields.io/pypi/dm/trackers)](https://pypistats.org/packages/trackers) [![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/trackers/blob/release/stable/LICENSE) [![python-version](https://img.shields.io/pypi/pyversions/trackers)](https://badge.fury.io/py/trackers) [![try it](https://img.shields.io/badge/try_it-Hugging%20Face%20Playground-yellow)](https://huggingface.co/spaces/roboflow/trackers) [![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
 
 </div>
 
-`trackers` gives you clean-room, benchmarked implementations of SORT, ByteTrack, OC-SORT, BoT-SORT, C-BIoU, and McByte — so occlusions, fast motion, and moving cameras stop being your problem to solve from scratch. It speaks `supervision.Detections` natively, slotting into any detector you already use — YOLO, DETR, RT-DETR, or anything else — without glue code. One consistent interface, whether you're a researcher comparing algorithms, an engineer shipping a production pipeline, or a hobbyist building something cool. Requires Python ≥ 3.10.
+`trackers` is an object tracking library for Python. It gives you clean-room, benchmarked implementations of SORT, ByteTrack, OC-SORT, BoT-SORT, C-BIoU, and McByte — so occlusions, fast motion, and moving cameras stop being your problem to solve from scratch. It speaks `supervision.Detections` natively, slotting into any detector you already use — YOLO, DETR, RT-DETR, or anything else — without glue code. One consistent interface, whether you're a researcher comparing algorithms, an engineer shipping a production pipeline, or a hobbyist building something cool. Requires Python ≥ 3.10.
 
 ## Why trackers?
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
     <img width="200" src="https://raw.githubusercontent.com/roboflow/trackers/refs/heads/release/stable/docs/assets/logo-trackers-violet.svg" alt="trackers logo">
     <h1>trackers</h1>
-    <p>Plug-and-play object tracking in Python, for any detection model.</p>
+    <p>Plug-and-play object tracking in Python (multi-object) for any detection model.</p>
 
 [![version](https://badge.fury.io/py/trackers.svg)](https://badge.fury.io/py/trackers) [![downloads](https://img.shields.io/pypi/dm/trackers)](https://pypistats.org/packages/trackers) [![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/trackers/blob/release/stable/LICENSE) [![python-version](https://img.shields.io/pypi/pyversions/trackers)](https://badge.fury.io/py/trackers) [![try it](https://img.shields.io/badge/try_it-Hugging%20Face%20Playground-yellow)](https://huggingface.co/spaces/roboflow/trackers) [![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
 


### PR DESCRIPTION
## Problem

We do not rank for "object tracking python". A 12-star repo abandoned since 2023, [ayush-thakur02/object-tracking-opencv](https://github.com/ayush-thakur02/object-tracking-opencv), currently sits second for that query with our 3,717-star maintained library nowhere in sight.

The difference is that it says the words and we do not:

| | that repo | `roboflow/trackers` |
| :-- | :-- | :-- |
| name | `object-tracking-opencv` | `trackers` |
| description | "Object Tracking and Detection using OpenCV in python" | "...leading multi-object tracking algorithms..." |
| topics | object-tracking, opencv, object-detection, yolov4 | no `object-tracking`, no `python`, no `computer-vision` |

In our README, "object tracking" appears twice, "in Python" not at all, and the first mention of Python is buried in "Requires Python >= 3.10" at the end of the intro paragraph.

Google titles a repo page as `GitHub - roboflow/trackers: <description>` and draws the snippet from the README, so neither surface currently carries the phrase.

## Fix

Two edits, +10 words total.

The tagline keeps its length and picks up the phrase:

```diff
-<p>Plug-and-play multi-object tracking for any detection model.</p>
+<p>Plug-and-play object tracking in Python, for any detection model.</p>
```

The intro now opens with a plain definitional sentence before the algorithm list:

```diff
-`trackers` gives you clean-room, benchmarked implementations of SORT, ByteTrack, ...
+`trackers` is an object tracking library for Python. It gives you clean-room, benchmarked implementations of SORT, ByteTrack, ...
```

That first line does double duty: a reader gets "what is this" in one sentence, and it is the passage search engines and LLM answers tend to quote, which currently has to be inferred from a list of algorithm names.

## Next steps

I do not have the permissions to change these, but I strongly suggest we also:

- **Add the topics** `object-tracking`, `python`, `computer-vision`, `kalman-filter` and `re-identification`. We have none of the first three, and they are the highest-volume terms in this space.
- **Update the description**, which is what Google renders as the page title (`GitHub - roboflow/trackers: <description>`):

  ```
  Object tracking in Python. Clean-room implementations of SORT, ByteTrack, OC-SORT, BoT-SORT, C-BIoU and McByte. Apache 2.0, works with any detector.
  ```

Both live in the repo's About panel rather than the git tree, so neither can go in a PR. Both are a two-minute change and I expect either to matter more than this PR does.

## Validation

- `mdformat --check --number --wrap=no README.md` passes.
- No claims changed, no links touched, no benchmark numbers involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

